### PR TITLE
[Build] Require iree-compile to be available for benchmarks as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,11 @@ if(FUSILLI_DEV_PLATFORM_AMDGPU)
   endif()
 endif()
 
-# Both tests and benchmarks depend on libutils
+# Both tests and benchmarks depend on iree-compile, Catch2, and libutils
 if(FUSILLI_BUILD_TESTS OR FUSILLI_BUILD_BENCHMARKS)
+  # Side-load iree-compile program
+  fusilli_find_program(iree-compile INSTALL_INSTRUCTIONS "Please install iree-compile (e.g., pip install iree-base-compiler).")
+
   # Find prebuilt Catch2 library or fetch it if not found
   find_package(Catch2 3 QUIET)
   if(NOT Catch2_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,6 @@ fusilli_find_program(lit INSTALL_INSTRUCTIONS "Please install lit (e.g., pip ins
 # Find iree-opt program
 fusilli_find_program(iree-opt INSTALL_INSTRUCTIONS "Please install iree-opt (e.g., pip install iree-base-compiler).")
 
-# Find iree-compile program
-fusilli_find_program(iree-compile INSTALL_INSTRUCTIONS "Please install iree-compile (e.g., pip install iree-base-compiler).")
-
 # Find FileCheck program
 fusilli_find_program(FileCheck INSTALL_INSTRUCTIONS "Please install FileCheck.")
 


### PR DESCRIPTION
Right now we enable both but if tests is disabled and benchmark isn't, we will see the benchmarks build fine but crash at runtime when `iree-compile` isn't installed.