### PR TITLE
[BUILD] Lower required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.24)
 
 # Avoid in-source builds (prevent build artifacts from cluttering the source directory)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/plugins/hipdnn-plugin/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.24)
 
 project(fusilli-plugin
   VERSION 0.1.0


### PR DESCRIPTION
Fusilli's CMake requirement causes issues in TheRock, which builds with an older CMake. This PR lowers the version to the minimum needed for features Fusilli's build actually uses - which (luckily) happens to be low enough for the TheRock.