### PR TITLE
[BUILD] Propagate `FUSILLI_ENABLE_AMDGPU` compile definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,12 +178,10 @@ endif()
 # Enable AMD GPU build if requested
 if(FUSILLI_SYSTEMS_AMDGPU)
   # Check for Linux AMD GPU device node - `/dev/kfd`
-  if(EXISTS "/dev/kfd")
-    message(STATUS "AMD GPU detected: Enabling AMD GPU build")
-  else()
+  if(NOT EXISTS "/dev/kfd")
     message(WARNING "No AMD GPU detected (`/dev/kfd` not found) but FUSILLI_SYSTEMS_AMDGPU is set; Only proceed if cross-compiling for AMD GPU systems.")
   endif()
-  add_definitions(-DFUSILLI_ENABLE_AMDGPU)
+  target_compile_definitions(libfusilli INTERFACE FUSILLI_ENABLE_AMDGPU)
 endif()
 
 # Both tests and benchmarks depend on iree-compile, Catch2, and libutils


### PR DESCRIPTION
CMake's `add_definitions` adds compile definitions to targets in the current file - which works locally. `target_compile_definitions` adds the compile definition to all consumers who use the `fusilli` library CMake target (in the build tree, or when using an installed Fusilli). We want the latter. ~Also - in case consumers are cross compiling - we want to add the compile definition regardless of presence or absence of AMDGPU on the build machine.~