### PR TITLE
Add flake detection workflow to CI

### DIFF
--- a/.github/workflows/flake-test.yml
+++ b/.github/workflows/flake-test.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Generated iterations: ${ITERATIONS}"
 
   flake-test:
-    name: "Flake Test :: ${{ matrix.name }} (iteration ${{ matrix.iteration }})"
+    name: "${{ matrix.name }} - iteration ${{ matrix.iteration }}"
     needs: setup
     runs-on: ${{ matrix.runs-on }}
     defaults:


### PR DESCRIPTION
We recently encountered a GPU stall / segfault related flake that took a while to bisect into. This should help catch such flake issues from being introduced, or at least triaged quicker without needing to bisect. 

I haven't thought of all the trade-offs in making this gate merges but I plan to until we see a good reason not to.