### PR TITLE
Add iree-flow-enable-pad-handling flag

### DIFF
--- a/include/fusilli/backend/backend.h
+++ b/include/fusilli/backend/backend.h
@@ -83,6 +83,7 @@ static const std::unordered_map<Backend, std::vector<std::string>>
                 std::format("--iree-hip-target=$({} | sed -n '1 p')", getRocmAgentEnumeratorPath()),
                 "--iree-opt-level=O3",
                 "--iree-preprocessing-pass-pipeline=\"builtin.module(util.func(iree-preprocessing-sink-transpose-through-pad))\"",
+                "--iree-flow-enable-pad-handling",
                 "--iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops",
                 "--iree-dispatch-creation-enable-aggressive-reshape-movement",
                 // clang-format on


### PR DESCRIPTION
This tells IREE to not decompose `tensor.pad` ops. This should reduce the dispatch count for certain forward convs after https://github.com/llvm/llvm-project/pull/168888 has been integrated into IREE.