### PR TITLE
Make flake tests less resource intensive

### DIFF
--- a/.github/workflows/flake-test.yml
+++ b/.github/workflows/flake-test.yml
@@ -8,7 +8,6 @@ name: Flake test - fusilli
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
We're seeing flake tests become a resource issue (with CPU/memory usage), leading to errors like [these](https://github.com/iree-org/fusilli/actions/runs/20074191037/attempts/1):

```
[gfx942_clang22_debug - iteration 20](https://github.com/iree-org/fusilli/actions/runs/20074191037/job/57584101960)
The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```

This PR 
- reduces the ctest parallelization to 8 threads instead of using the max available threads (via nproc).
- makes the flake tests run post-merge only

