### PR TITLE
Update IREE_GIT_TAG to version 3.10.0rc20251210

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ message(STATUS "  - Host")
 # Prefer to keep the IREE_GIT_TAG synced with the python-installed IREE version.
 # At a minimum, the compiler from those packages must be compatible with the
 # runtime at this source ref.
-set(IREE_GIT_TAG "iree-3.10.0rc20251201")
+set(IREE_GIT_TAG "iree-3.10.0rc20251210")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Set IREE build flags.


### PR DESCRIPTION
This is for the runtime source build and only gets used when IREE_SOURCE_DIR is not set. But good to keep this in sync with the compiler version which comes from docker.