### PR TITLE
[Build] Hide symbols with version script

### DIFF
--- a/plugins/hipdnn-plugin/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/CMakeLists.txt
@@ -99,14 +99,15 @@ target_compile_definitions(${FUSILLI_PLUGIN_NAME} PRIVATE
   FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
   FUSILLI_PLUGIN_ENGINE_ID=${FUSILLI_PLUGIN_ENGINE_ID}
 )
-target_link_libraries(
-    ${FUSILLI_PLUGIN_NAME} PRIVATE "-Xlinker --exclude-libs=ALL"
-) # Hide symbols from linked static libs
 set_target_properties(${FUSILLI_PLUGIN_NAME} PROPERTIES
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN ON
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${FUSILLI_PLUGIN_RELATIVE_PATH}"
+)
+# Version script hides all symbol definitions not staring with "hipdnn"
+target_link_options(
+  ${FUSILLI_PLUGIN_NAME} PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/exports.map"
 )
 
 # Installation

--- a/plugins/hipdnn-plugin/exports.map
+++ b/plugins/hipdnn-plugin/exports.map
@@ -1,0 +1,8 @@
+/*
+ * Version script for fusilli_plugin
+ * Export only the hipDNN plugin interface symbols
+ */
+{
+	global: hipdnn*;
+	local: *;
+};


### PR DESCRIPTION
This PR hides all symbols in the fusilli plugin that don't begin with `hipdnn`. That should ensure only the symbols that hipDNN requires are exposed. 

This might not be necessary. HipDNN should load the plugin with [RTLD_LOCAL](https://pernos.co/blog/interposition-rtld-local/), which should prevent the symbols being used in a wider scope. But, symbol interposition / ODR violation style bugs are no fun to deal with, and I'm not aware of a major downside of hiding more symbols than necessary.

Before:
```
$ nm -D --defined-only /home/astgeorg/Dev/c++/TheRock/build/iree-libs/fusilli-plugin/build/lib/hipdnn_plugins/engines/libfusilli_plugin.so
...
0000000000056447 V _ZTSSt12format_error
00000000000569bd V _ZTSSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE
00000000000584a4 V _ZTSSt18bad_variant_access
0000000000057f36 V _ZTSSt19_Sp_make_shared_tag
0000000000318848 V _ZTVNSt8__format10_Iter_sinkIcNS_10_Sink_iterIcEEEE
0000000000318878 V _ZTVNSt8__format19_Formatting_scannerINS_10_Sink_iterIcEEcEE
0000000000318830 V _ZTVNSt8__format5_SinkIcEE
00000000003188c0 V _ZTVNSt8__format8_ScannerIcEE
0000000000318818 V _ZTVNSt8__format9_Buf_sinkIcEE
00000000003187c0 V _ZTVNSt8__format9_Seq_sinkINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE
00000000003188f8 V _ZTVSt12format_error
0000000000318a80 V _ZTVSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE
000000000031a7d0 V _ZTVSt18bad_variant_access
0000000000057f50 V _ZZNSt19_Sp_make_shared_tag5_S_tiEvE5__tag
00000000000eebf0 T hipdnnEnginePluginCreate
00000000000f12e0 T hipdnnEnginePluginCreateExecutionContext
00000000000ef030 T hipdnnEnginePluginDestroy
00000000000f0b60 T hipdnnEnginePluginDestroyEngineDetails
00000000000f23e0 T hipdnnEnginePluginDestroyExecutionContext
00000000000f2b00 T hipdnnEnginePluginExecuteOpGraph
00000000000ee870 T hipdnnEnginePluginGetAllEngineIds
00000000000ef7a0 T hipdnnEnginePluginGetApplicableEngineIds
00000000000f0600 T hipdnnEnginePluginGetEngineDetails
00000000000f0f00 T hipdnnEnginePluginGetWorkspaceSize
00000000000f2760 T hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext
00000000000ef360 T hipdnnEnginePluginSetStream
00000000000ee610 T hipdnnPluginGetLastErrorString
00000000000edcf0 T hipdnnPluginGetName
00000000000ee310 T hipdnnPluginGetType
00000000000ee000 T hipdnnPluginGetVersion
00000000000ee640 T hipdnnPluginSetLoggingCallback
```
After:
```
$ nm -D --defined-only /home/astgeorg/Dev/c++/TheRock/build/iree-libs/fusilli-plugin/build/lib/hipdnn_plugins/engines/libfusilli_plugin.so
00000000000dbb50 T hipdnnEnginePluginCreate
00000000000de240 T hipdnnEnginePluginCreateExecutionContext
00000000000dbf90 T hipdnnEnginePluginDestroy
00000000000ddac0 T hipdnnEnginePluginDestroyEngineDetails
00000000000df340 T hipdnnEnginePluginDestroyExecutionContext
00000000000dfa60 T hipdnnEnginePluginExecuteOpGraph
00000000000db7d0 T hipdnnEnginePluginGetAllEngineIds
00000000000dc700 T hipdnnEnginePluginGetApplicableEngineIds
00000000000dd560 T hipdnnEnginePluginGetEngineDetails
00000000000dde60 T hipdnnEnginePluginGetWorkspaceSize
00000000000df6c0 T hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext
00000000000dc2c0 T hipdnnEnginePluginSetStream
00000000000db570 T hipdnnPluginGetLastErrorString
00000000000dac50 T hipdnnPluginGetName
00000000000db270 T hipdnnPluginGetType
00000000000daf60 T hipdnnPluginGetVersion
00000000000db5a0 T hipdnnPluginSetLoggingCallback
```