### PR TITLE
[Fusilli][Graph] Added missed checks for non NULL tensors in node builders

### DIFF
--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -649,9 +649,9 @@ Graph::matmul(const std::shared_ptr<TensorAttr> &a,
   // Populate names when not set.
   if (matmulAttr.getName().empty())
     matmulAttr.setName("matmul_" + std::to_string(subNodes_.size()));
-  if (a->getName().empty())
+  if (a && a->getName().empty())
     a->setName(matmulAttr.getName() + "_A");
-  if (b->getName().empty())
+  if (b && b->getName().empty())
     b->setName(matmulAttr.getName() + "_B");
 
   FUSILLI_LOG_LABEL_ENDL("INFO: Adding MatmulNode '" << matmulAttr.getName()


### PR DESCRIPTION
The PR adds checks for non-nullptr tensors in node builders in `graph` when we populate names which are not set. It's needed to avoid segmentation fault when user may (accidentally or not) pass `nullptr` tensors as arguments of builders. 
We shouldn't throw exception here if tensor is `nullptr`, since the class `Node` is responsible for this validation (specially the method `preValidateNode()`, not builders.