### PR TITLE
Benchmark driver support for batched matmul

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -34,42 +34,42 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nchw_fp32
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
+    --device 0 --iter 10 conv -F 1 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nhwc_fp16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 2 -j 2 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
+    --device 0 --iter 10 conv -F 1 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 2 -j 2 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv3d_ndhwc_bf16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3
+    --device 0 --iter 10 conv -F 1 --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nchw_fp32_bias
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2 --bias
+    --device 0 --iter 10 conv -F 1 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2 --bias
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv3d_ndhwc_bf16_bias
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3 --bias
+    --device 0 --iter 10 conv -F 1 --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3 --bias
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nhwc_fp16_bias
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 1 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2 --bias
+    --device 0 --iter 10 conv -F 1 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2 --bias
 )
 
 # Weight Gradient benchmarks (mode=4)
@@ -77,28 +77,28 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_wgrad_nchw_fp32
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 4 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
+    --device 0 --iter 10 conv -F 4 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_wgrad_nhwc_fp16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 4 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
+    --device 0 --iter 10 conv -F 4 --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_wgrad_nchw_bf16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 4 --bf16 -n 64 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
+    --device 0 --iter 10 conv -F 4 --bf16 -n 64 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_wgrad_nhwc_bf16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 4 --bf16 -n 32 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
+    --device 0 --iter 10 conv -F 4 --bf16 -n 32 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
 )
 
 # Data Gradient benchmarks (mode=2)
@@ -106,21 +106,21 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_dgrad_nchw_fp32
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 2 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
+    --device 0 --iter 10 conv -F 2 -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_dgrad_nhwc_fp16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 2 --fp16 -n 16 -c 3 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
+    --device 0 --iter 10 conv -F 2 --fp16 -n 16 -c 3 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 1 -j 1 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_dgrad_nchw_bf16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 conv -F 2 --bf16 -n 64 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
+    --device 0 --iter 10 conv -F 2 --bf16 -n 64 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
 )
 
 # Matrix multiplication benchmarks
@@ -128,40 +128,83 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul -M 128 -N 128 -K 128
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul --fp16 -M 256 -N 256 -K 256
+    --device 0 --iter 10 matmul --fp16 -M 16 -N 32 -K 64
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_bf16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul --bf16 -M 256 -N 128 -K 64
+    --device 0 --iter 10 matmul --bf16 -M 16 -N 32 -K 64
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16_transA
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul --fp16 -M 128 -N 128 -K 128 --transA
+    --device 0 --iter 10 matmul --fp16 -M 16 -N 32 -K 64 --transA
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_bf16_transB
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul --bf16 -M 128 -N 64 -K 128 --transB
+    --device 0 --iter 10 matmul --bf16 -M 16 -N 32 -K 64 --transB
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_transAB
   DRIVER fusilli_benchmark_driver
   ARGS
-    --iter 10 matmul -M 64 -N 128 -K 64 --transA --transB
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --transA --transB
+)
+
+# Batched matrix multiplication benchmarks
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_fp32_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10
+)
+
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_fp16_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul --fp16 -M 64 -N 32 -K 16 -B 10
+)
+
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_bf16_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul --bf16 -M 64 -N 32 -K 16 -B 10
+)
+
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_fp16_transA_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul --fp16 -M 64 -N 32 -K 16 -B 10 --transA
+)
+
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_bf16_transB_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul --bf16 -M 64 -N 32 -K 16 -B 10 --transB
+)
+
+add_fusilli_benchmark(
+  NAME fusilli_benchmark_matmul_fp32_transAB_batched
+  DRIVER fusilli_benchmark_driver
+  ARGS
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --transA --transB
 )

--- a/benchmarks/test_commands.txt
+++ b/benchmarks/test_commands.txt
@@ -1,14 +1,17 @@
 # Test convolution benchmarks
---iter 10 conv --bf16 -F 1 -n 16 -c 8 -H 8 -W 8 -k 8 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
---iter 10 conv --bf16 -F 1 -n 16 -c 16 --in_d 2 -H 8 -W 8 -k 16 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout NDHWC --out_layout NDHWC --fil_layout NDHWC --spatial_dim 3
---iter 10 conv --bf16 -F 2 -n 16 -c 12 -H 8 -W 8 -k 12 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 3 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
---iter 10 conv --bf16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
+--device 0 --iter 10 conv -F 1 -n 16 -c 8 -H 8 -W 8 -k 8 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
+--device 0 --iter 10 conv --bf16 -F 1 -n 16 -c 16 --in_d 2 -H 8 -W 8 -k 16 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout NDHWC --out_layout NDHWC --fil_layout NDHWC --spatial_dim 3
+--device 0 --iter 10 conv --bf16 -F 2 -n 16 -c 12 -H 8 -W 8 -k 12 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 3 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
+--device 0 --iter 10 conv --fp16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
 
 # Test matmul benchmarks
---iter 10 matmul -M 128 -N 128 -K 128
---iter 10 matmul --bf16 -M 64 -N 64 -K 64 --transA
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10
+--device 0 --iter 10 matmul --bf16 -M 16 -N 32 -K 64 --transA
+--device 0 --iter 10 matmul --fp16 -M 16 -N 32 -K 64 -B 10 --transB
 
 # Test skipping benchmarks
-[SKIP] --iter 10 conv --bf16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
+[SKIP] --device 0 --iter 10 conv --bf16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
+[SKIP] --device 0 --iter 10 matmul -M 16 -N 32 -K 64
 
 # Test empty lines and comments are ignored by the benchmark runner


### PR DESCRIPTION
While Fusilli supports multiple batch dims (inline with cudnn/hipdnn), I'm only adding a single batch dim in the driver to keep it aligned with the usecases we're comparing against with `hipblaslt-bench`: https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/conceptual/hipblaslt-clients.html#hipblaslt-bench

Other minor changes:
- Update M, N, K dims for certain tests
- Add --device flag to benchmark tests