### PR TITLE
[Fusilli][Matmul] Split dtypes for inputs, bias and output

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -128,14 +128,14 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp32 --b_type fp32 --out_type fp32
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type f32 --out_type f32
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp16 --b_type fp16 --out_type fp16
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f16 --b_type f16 --out_type f16
 )
 
 add_fusilli_benchmark(
@@ -150,14 +150,14 @@ add_fusilli_benchmark(
 #   NAME fusilli_benchmark_matmul_mixed
 #   DRIVER fusilli_benchmark_driver
 #   ARGS
-#     --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp32 --b_type bf16 --out_type fp32
+#     --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type bf16 --out_type f32
 # )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16_transA
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp16 --b_type fp16 --out_type fp16 --transA
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f16 --b_type f16 --out_type f16 --transA
 )
 
 add_fusilli_benchmark(
@@ -171,14 +171,14 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_transAB
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp32 --b_type fp32 --out_type fp32 --transA --transB
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type f32 --out_type f32 --transA --transB
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_transAB_bias
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp32 --b_type fp32 --out_type fp32 --bias_type fp32 --transA --transB --bias
+    --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type f32 --out_type f32 --bias_type f32 --transA --transB --bias
 )
 
 # Batched matrix multiplication benchmarks
@@ -186,14 +186,14 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_batched
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp32 --b_type fp32 --out_type fp32
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f32 --b_type f32 --out_type f32
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16_batched
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp16 --b_type fp16 --out_type fp16
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f16 --b_type f16 --out_type f16
 )
 
 add_fusilli_benchmark(
@@ -207,14 +207,14 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_mixed_batched
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp32 --b_type bf16 --out_type fp32
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f32 --b_type bf16 --out_type f32
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16_transA_batched
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp16 --b_type fp16 --out_type fp16 --transA
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f16 --b_type f16 --out_type f16 --transA
 )
 
 add_fusilli_benchmark(
@@ -228,12 +228,12 @@ add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_transAB_batched
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp32 --b_type fp32 --out_type fp32 --transA --transB
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f32 --b_type f32 --out_type f32 --transA --transB
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp32_transAB_batched_bias
   DRIVER fusilli_benchmark_driver
   ARGS
-    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type fp32 --b_type fp32 --out_type fp32 --bias_type fp32 --transA --transB --bias
+    --device 0 --iter 10 matmul -M 64 -N 32 -K 16 -B 10 --a_type f32 --b_type f32 --out_type f32 --bias_type f32 --transA --transB --bias
 )

--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -30,7 +30,7 @@ const auto kIsPositiveInteger =
     CLI::Range(int64_t{1}, std::numeric_limits<int64_t>::max());
 const auto kIsValidConvLayout =
     CLI::IsMember({"NCHW", "NHWC", "NCDHW", "NDHWC"});
-const auto kIsValidDataType = CLI::IsMember({"fp32", "fp16", "bf16"});
+const auto kIsValidDataType = CLI::IsMember({"f32", "f16", "bf16"});
 
 //===---------------------------------------------------------------------===//
 // Option classes for organizing benchmark parameters
@@ -663,22 +663,22 @@ static CLI::App *registerMatmulOptions(CLI::App &mainApp,
       ->check(kIsPositiveInteger);
   matmulApp
       ->add_option("--a_type", matmulOpts.a_type,
-                   "Matrix A data type (fp32, fp16, bf16)")
+                   "Matrix A data type (f32, f16, bf16)")
       ->required()
       ->check(kIsValidDataType);
   matmulApp
       ->add_option("--b_type", matmulOpts.b_type,
-                   "Matrix B data type (fp32, fp16, bf16)")
+                   "Matrix B data type (f32, f16, bf16)")
       ->required()
       ->check(kIsValidDataType);
   matmulApp
       ->add_option("--out_type", matmulOpts.out_type,
-                   "Result data type (fp32, fp16, bf16)")
+                   "Result data type (f32, f16, bf16)")
       ->required()
       ->check(kIsValidDataType);
   matmulApp
       ->add_option("--bias_type", matmulOpts.bias_type,
-                   "Bias data type (fp32, fp16, bf16)")
+                   "Bias data type (f32, f16, bf16)")
       ->check(kIsValidDataType);
 
   // matmulApp CLI Flags:
@@ -768,13 +768,13 @@ static ErrorObject runMatmulBenchmark(const MatmulOptions &matmulOpts,
       ErrorCode::InvalidArgument,
       "bias_type must be specified when --bias flag is set");
 
-  // Parse data type strings
-  DataType aType = FUSILLI_TRY(parseDataTypeString(matmulOpts.a_type));
-  DataType bType = FUSILLI_TRY(parseDataTypeString(matmulOpts.b_type));
-  DataType outType = FUSILLI_TRY(parseDataTypeString(matmulOpts.out_type));
+  // Parse data type strings using direct map lookup
+  DataType aType = kMlirTypeAsmToDataType.at(matmulOpts.a_type);
+  DataType bType = kMlirTypeAsmToDataType.at(matmulOpts.b_type);
+  DataType outType = kMlirTypeAsmToDataType.at(matmulOpts.out_type);
   DataType biasType = DataType::NotSet;
   if (matmulOpts.bias) {
-    biasType = FUSILLI_TRY(parseDataTypeString(matmulOpts.bias_type));
+    biasType = kMlirTypeAsmToDataType.at(matmulOpts.bias_type);
   }
 
   ErrorObject status = benchmarkMatmul(matmulOpts, aType, bType, outType,

--- a/benchmarks/test_commands.txt
+++ b/benchmarks/test_commands.txt
@@ -5,14 +5,14 @@
 --device 0 --iter 10 conv --fp16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
 
 # Test matmul benchmarks
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type fp32 --b_type fp32 --out_type fp32
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 --bias --a_type fp32 --b_type fp32 --out_type fp32 --bias_type fp32
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --a_type fp32 --b_type fp32 --out_type fp32
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --bias --a_type fp32 --b_type fp32 --out_type fp32 --bias_type fp32
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type f32 --out_type f32
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 --bias --a_type f32 --b_type f32 --out_type f32 --bias_type f32
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --a_type f32 --b_type f32 --out_type f32
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --bias --a_type f32 --b_type f32 --out_type f32 --bias_type f32
 --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --transA --a_type bf16 --b_type bf16 --out_type bf16
 --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --transA --bias --a_type bf16 --b_type bf16 --out_type bf16 --bias_type bf16
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --transB --a_type fp16 --b_type fp16 --out_type fp16
---device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --transB --bias --a_type fp16 --b_type fp16 --out_type fp16 --bias_type fp16
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --transB --a_type f16 --b_type f16 --out_type f16
+--device 0 --iter 10 matmul -M 16 -N 32 -K 64 -B 10 --transB --bias --a_type f16 --b_type f16 --out_type f16 --bias_type f16
 
 # Test skipping benchmarks
 [SKIP] --device 0 --iter 10 conv --bf16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2

--- a/include/fusilli/attributes/types.h
+++ b/include/fusilli/attributes/types.h
@@ -69,6 +69,15 @@ static const std::unordered_map<DataType, torch_upstream::ScalarType>
 #undef DEFINE_ENUM
 };
 
+// Map from MLIR type ASM strings to Fusilli types.
+static const std::unordered_map<std::string, DataType> kMlirTypeAsmToDataType =
+    {
+#define DEFINE_ENUM(FUSILLI_TYPE, TORCH_TYPE, MLIR_TYPE)                       \
+  {MLIR_TYPE, DataType::FUSILLI_TYPE},
+        FUSILLI_FORALL_DATA_TYPES(DEFINE_ENUM)
+#undef DEFINE_ENUM
+};
+
 } // namespace fusilli
 
 #endif // FUSILLI_ATTRIBUTES_TYPES_H

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -20,8 +20,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <format>
-#include <string>
 #include <utility> // IWYU pragma: export
 #include <vector>
 
@@ -106,17 +104,6 @@ allocateBufferOfType(Handle &handle, const std::shared_ptr<TensorAttr> &tensor,
   default:
     return error(ErrorCode::InvalidAttribute, "Unsupported DataType");
   }
-}
-
-inline ErrorOr<DataType> parseDataTypeString(const std::string &typeStr) {
-  if (typeStr == "fp32")
-    return DataType::Float;
-  if (typeStr == "fp16")
-    return DataType::Half;
-  if (typeStr == "bf16")
-    return DataType::BFloat16;
-  return error(ErrorCode::InvalidArgument,
-               std::format("Unsupported data type: {}", typeStr));
 }
 
 } // namespace fusilli


### PR DESCRIPTION
Fixes https://github.com/iree-org/fusilli/issues/69.

Also renames `s/cT/outT` and `s/cBuf/outBuf` to disambiguate the use of `C` matrix which in `hipblaslt-bench` parlance is not the output matrix:
<img width="661" height="107" alt="image" src="https://github.com/user-attachments/assets/e7d9f30f-7508-4adc-b489-86660fc7aece" />


Base branch to be updated once #74 lands. 