### PR TITLE
[FusilliPlugin] Keep the hipDNN build around in `ThePebble`

### DIFF
--- a/.github/workflows/hipdnn-plugin-build-and-test.yml
+++ b/.github/workflows/hipdnn-plugin-build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3-venv libgtest-dev
+        sudo apt-get install -y python3-venv
 
     - name: Checkout fusilli
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/plugins/hipdnn-plugin/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/CMakeLists.txt
@@ -56,7 +56,19 @@ find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 find_package(hipdnn_frontend CONFIG REQUIRED)
 find_package(hipdnn_test_sdk CONFIG REQUIRED)
 find_package(Fusilli CONFIG REQUIRED)
-find_package(GTest CONFIG REQUIRED)
+# Fetch GTest if system install isn't available
+find_package(GTest CONFIG QUIET)
+if(NOT GTest_FOUND)
+  message(STATUS "GTest not found on system: Fetching from GitHub")
+  FetchContent_Declare(
+    googletest
+    QUIET
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.16.0
+  )
+  FetchContent_MakeAvailable(googletest)
+endif()
+
 
 # Global constants
 set(FUSILLI_PLUGIN_NAME fusilli_plugin)


### PR DESCRIPTION
To find any instances where an installed target depends on things it shouldn't from the build folder `ThePebble`  builds hipDNN in a `tmp` folder that's removed after installation. The `tmp` folder strategy might catch a bug, but not having the build around is pretty annoying - `clangd` and other tools don't work properly without build artifacts.

This PR updates `ThePebble` to keep the hipDNN build around.