### PR TITLE
Verify mixed precision matmul

### DIFF
--- a/include/fusilli/node/matmul_node.h
+++ b/include/fusilli/node/matmul_node.h
@@ -156,15 +156,19 @@ public:
 
     // Check for mixed precision matmuls (inputs with differing element types).
     // Due to torch-mlir MLIR constraints, when element types differ:
-    // - Both LHS and RHS must be 3D (1 batch dim)
+    // - Both LHS and RHS must have rank 3 (single batch dim)
     // - The batch dim must be exactly equal (no broadcast)
-    // This is because we need `torch.matmul` to lower to `torch.bmm` in the
-    // cases of mixed precision.
+    //
+    // PyTorch does not allow differing input element types for any of the
+    // matmul variants. However, torch-mlir breaks conformity with pytorch in
+    // the case of `torch.bmm`. So, we need to be sure that `torch.matmul` will
+    // lower to `torch.bmm` in the cases of mixed precision.
     if (aT->getDataType() != bT->getDataType()) {
       constexpr int64_t kMixedPrecisionRequiredRank = 3;
       FUSILLI_RETURN_ERROR_IF(
           aRank != kMixedPrecisionRequiredRank, ErrorCode::InvalidAttribute,
-          "Mixed precision matmul input tensors A and B must be 3D (1 batch "
+          "Mixed precision matmul is only supported when input tensors A and B "
+          "are of rank 3 (single batch "
           "dim): A and B have rank=" +
               std::to_string(aRank));
       FUSILLI_RETURN_ERROR_IF(

--- a/tests/test_matmul_node.cpp
+++ b/tests/test_matmul_node.cpp
@@ -707,8 +707,8 @@ TEST_CASE("MatmulNode mixed precision constraints", "[matmul_node]") {
     REQUIRE(isError(status));
     REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
     REQUIRE(status.getMessage() ==
-            "Mixed precision matmul input tensors A and B must be 3D (1 batch "
-            "dim): A and B have rank=2");
+            "Mixed precision matmul is only supported when input tensors A and "
+            "B are of rank 3 (single batch dim): A and B have rank=2");
   }
 
   SECTION("Mixed precision 4D matmul (2 batch dims) - fail") {
@@ -735,8 +735,8 @@ TEST_CASE("MatmulNode mixed precision constraints", "[matmul_node]") {
     REQUIRE(isError(status));
     REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
     REQUIRE(status.getMessage() ==
-            "Mixed precision matmul input tensors A and B must be 3D (1 batch "
-            "dim): A and B have rank=4");
+            "Mixed precision matmul is only supported when input tensors A and "
+            "B are of rank 3 (single batch dim): A and B have rank=4");
   }
 
   SECTION("Mixed precision with broadcast batch dim - fail") {


### PR DESCRIPTION
PyTorch does not allow differing input element types for any of the matmul variants. However, torch-mlir breaks conformity with pytorch in the case of `torch.bmm` (see discussion on https://github.com/llvm/torch-mlir/pull/4424). This changes the verifier to only allow mixed precision matmuls when it is known that they will be decomposed from `torch.matmul` to `torch.bmm`. Otherwise, it would result in a compile failure.