### PR TITLE
[NFC] Deduplicate ASM transpose emitters

### DIFF
--- a/include/fusilli/node/conv_node.h
+++ b/include/fusilli/node/conv_node.h
@@ -76,9 +76,6 @@ public:
   std::string getStrideOpsAsm() const;
   std::string getPaddingOpsAsm() const;
   std::string getDilationOpsAsm() const;
-  std::string getPermuteXOpsAsm() const;
-  std::string getPermuteWOpsAsm() const;
-  std::string getPermuteYOpsAsm() const;
 
   const std::string &getName() const override final {
     return convFPropAttr.getName();
@@ -272,9 +269,6 @@ public:
   std::string getStrideOpsAsm() const;
   std::string getPaddingOpsAsm() const;
   std::string getDilationOpsAsm() const;
-  std::string getPermuteDYOpsAsm() const;
-  std::string getPermuteXOpsAsm() const;
-  std::string getPermuteDWOpsAsm() const;
   std::string getPermuteEmptyWOpsAsm() const;
 
   const std::string &getName() const override final {
@@ -448,9 +442,6 @@ public:
   std::string getStrideOpsAsm() const;
   std::string getPaddingOpsAsm() const;
   std::string getDilationOpsAsm() const;
-  std::string getPermuteDYOpsAsm() const;
-  std::string getPermuteWOpsAsm() const;
-  std::string getPermuteDXOpsAsm() const;
   std::string getPermuteEmptyXOpsAsm() const;
 
   const std::string &getName() const override final {

--- a/include/fusilli/node/matmul_node.h
+++ b/include/fusilli/node/matmul_node.h
@@ -81,9 +81,6 @@ public:
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
   std::string getResultTypesAsm() const;
-  std::string getPermuteAOpsAsm() const;
-  std::string getPermuteBOpsAsm() const;
-  std::string getPermuteCOpsAsm() const;
 
   const std::string &getName() const override final {
     return matmulAttr.getName();


### PR DESCRIPTION
Removes the `getPermute*OpsAsm` methods for matmul node and all conv nodes. These methods are replaced with a call to the new helper `getPermuteOpsAsm()`.


Pointwise nodes have a slightly different format for the variable names, and to prevent conflicts with https://github.com/iree-org/fusilli/pull/98 they were left unchanged by this commit.