### PR TITLE
Refactored pointwise samples to minimize duped code and speed up

### DIFF
--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -6,15 +6,12 @@
 
 #include <fusilli.h>
 
-#include "utils.h"
+#include "pointwise_utils.h"
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
 #include <memory>
-#include <string>
-#include <tuple>
-#include <unordered_map>
 #include <vector>
 
 using namespace fusilli;
@@ -50,65 +47,46 @@ TEST_CASE("Pointwise add with transposed operand", "[pointwise][graph]") {
   }
 #endif
 
-  auto buildNewGraph = [&](const Handle &handle) {
-    // Create graph
-    auto graph = std::make_shared<Graph>();
-    graph->setName("pointwise_add_transposed");
-    graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
-
-    // Tensor A: contiguous nxm tensor (row-major)
-    auto aT =
-        graph->tensor(TensorAttr().setName("input_a").setDim({n, m}).setStride(
-            {m, 1})); // Contiguous: stride={2, 1}
-
-    // Tensor B: transposed nxm tensor
-    // Logical dim={n, m}, but stored with transposed strides
-    auto bT = graph->tensor(TensorAttr()
-                                .setName("input_b_transposed")
-                                .setDim({n, m})
-                                .setStride({1, n})); // Transposed
-
-    // Create Pointwise ADD op
-    auto pointwiseAttr = PointwiseAttr()
-                             .setMode(PointwiseAttr::Mode::ADD)
-                             .setName("add_transposed");
-    auto resultT = graph->pointwise(aT, bT, pointwiseAttr);
-
-    resultT->setName("result").setOutput(true);
-
-    // Validate, infer missing properties
-    FUSILLI_REQUIRE_OK(graph->validate());
-
-    // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
-
-    return std::make_tuple(graph, aT, bT, resultT);
-  };
-
   Handle &handle = *handlePtr;
-  // Build graph for the given handle (device), validate and compile it.
-  auto [graph, aT, bT, resultT] = buildNewGraph(handle);
+
+  // Tensor A: contiguous nxm tensor (row-major)
+  TensorAttr aTy =
+      TensorAttr().setName("input_a").setDim({n, m}).setStride({m, 1});
+
+  // Tensor B: transposed nxm tensor
+  // Logical dim={n, m}, but stored with transposed strides
+  TensorAttr bTy = TensorAttr()
+                       .setName("input_b_transposed")
+                       .setDim({n, m})
+                       .setStride({1, n});
+
+  PointwiseBinaryGraphBuilder builder("pointwise_add_transposed",
+                                      DataType::Float, PointwiseAttr::Mode::ADD,
+                                      aTy, bTy);
+  builder.compile(handle);
 
   // Allocate input buffers and initialize with input data
-  auto aBuf = std::make_shared<Buffer>(FUSILLI_REQUIRE_UNWRAP(
-      Buffer::allocate(handle, castToSizeT(aT->getPhysicalDim()), inputData)));
-  auto bBuf = std::make_shared<Buffer>(FUSILLI_REQUIRE_UNWRAP(
-      Buffer::allocate(handle, castToSizeT(bT->getPhysicalDim()), inputData)));
+  auto aBuf = std::make_shared<Buffer>(FUSILLI_REQUIRE_UNWRAP(Buffer::allocate(
+      handle, castToSizeT(builder.getLhsTensor()->getPhysicalDim()),
+      inputData)));
+  auto bBuf = std::make_shared<Buffer>(FUSILLI_REQUIRE_UNWRAP(Buffer::allocate(
+      handle, castToSizeT(builder.getRhsTensor()->getPhysicalDim()),
+      inputData)));
 
   // Allocate output buffer
-  auto resultBuf = FUSILLI_REQUIRE_UNWRAP(
-      allocateBufferOfType(handle, resultT, DataType::Float, 0.0f));
+  auto resultBuf = FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(
+      handle, builder.getOutputTensor(), DataType::Float, 0.0f));
 
   // Create variant pack
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {
-          {aT, aBuf},
-          {bT, bBuf},
-          {resultT, resultBuf},
+          {builder.getLhsTensor(), aBuf},
+          {builder.getRhsTensor(), bBuf},
+          {builder.getOutputTensor(), resultBuf},
       };
 
   // Execute graph
-  FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack));
+  builder.execute(handle, variantPack);
 
   // Read output buffer and verify against expected result
   std::vector<float> result;

--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <fusilli.h>
+#include <utils.h>
 
 #include "pointwise_utils.h"
 
@@ -12,6 +13,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 using namespace fusilli;

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <fusilli.h>
+#include <utils.h>
 
 #include "pointwise_utils.h"
 

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -12,7 +12,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <fusilli.h>
+#include <utils.h>
 
 #include "pointwise_utils.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -6,7 +6,7 @@
 
 #include <fusilli.h>
 
-#include "utils.h"
+#include "pointwise_utils.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -16,8 +16,6 @@
 #include <format>
 #include <memory>
 #include <string>
-#include <tuple>
-#include <unordered_map>
 #include <vector>
 
 using namespace fusilli;
@@ -47,68 +45,15 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
       GENERATE(PointwiseAttr::Mode::ADD, PointwiseAttr::Mode::DIV,
                PointwiseAttr::Mode::MUL, PointwiseAttr::Mode::SUB);
 
-  auto execute = [&]<typename T>(const std::shared_ptr<Handle> &handlePtr,
-                                 DataType dt, T x0, T x1) {
-    auto buildNewGraph = [&](const Handle &handle) {
-      // Create graph
-      auto graph = std::make_shared<Graph>();
-      graph->setName(generateName(mode, dt, dims));
-      graph->setIODataType(dt).setComputeDataType(dt);
-
-      // Initialize input tensors
-      auto x0T =
-          graph->tensor(TensorAttr().setName("in0").setDim(dims[0]).setStride(
-              generateStrideFromDim(dims[0],
-                                    getContiguousStrideOrder(dims[0].size()))));
-      auto x1T =
-          graph->tensor(TensorAttr().setName("in1").setDim(dims[1]).setStride(
-              generateStrideFromDim(dims[1],
-                                    getContiguousStrideOrder(dims[1].size()))));
-
-      // Create Pointwise op
-      auto pointwiseAttr = PointwiseAttr().setMode(mode);
-      auto pointwiseResult = graph->pointwise(x0T, x1T, pointwiseAttr);
-
-      pointwiseResult->setName("result").setOutput(true);
-
-      // Validate, infer missing properties
-      FUSILLI_REQUIRE_OK(graph->validate());
-
-      // Compile
-      FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
-
-      return std::make_tuple(graph, x0T, x1T, pointwiseResult);
-    };
-
-    Handle &handle = *handlePtr;
-    // Build graph for the given handle (device), validate and compile it.
-    auto [graph, x0T, x1T, yT] = buildNewGraph(handle);
-
-    // Allocate input buffers.
-    auto x0Buf =
-        FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, x0T, dt, x0));
-    auto x1Buf =
-        FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, x1T, dt, x1));
-
-    // Allocate output buffer.
-    auto yBuf =
-        FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, yT, dt, 0.0f));
-
-    // Create variant pack.
-    const std::unordered_map<std::shared_ptr<TensorAttr>,
-                             std::shared_ptr<Buffer>>
-        variantPack = {
-            {x0T, x0Buf},
-            {x1T, x1Buf},
-            {yT, yBuf},
-        };
-
-    // Execute graph once.
-    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack));
+  auto executeAndVerify = [&]<typename T>(PointwiseBinaryGraphBuilder &builder,
+                                          Handle &handle, DataType dt, T x0,
+                                          T x1) {
+    // Execute and get output buffer (output type same as input type)
+    auto outBuf = builder.execute(handle, dt, x0, x1, dt, T(0));
 
     // Calculate reference value
     T y = 0;
-    switch (mode) {
+    switch (builder.getMode()) {
     case PointwiseAttr::Mode::ADD: {
       y = x0 + x1;
       break;
@@ -126,24 +71,13 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
       break;
     }
     default:
-      FAIL(
-          "Unsupported pointwise mode: " << PointwiseAttr::kModeToStr.at(mode));
+      FAIL("Unsupported pointwise mode: "
+           << PointwiseAttr::kModeToStr.at(builder.getMode()));
     }
 
-    // Read output buffers.
+    // Read output buffers and verify
     std::vector<T> result;
-    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
-    for (auto val : result)
-      REQUIRE(val == y);
-
-    // Execute graph a few times.
-    constexpr size_t numIters = 1;
-    for (size_t i = 0; i < numIters; i++)
-      FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack));
-
-    // Repeat output buffer checks.
-    result.clear();
-    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+    FUSILLI_REQUIRE_OK(outBuf->read(handle, result));
     for (auto val : result)
       REQUIRE(val == y);
   };
@@ -161,8 +95,19 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
   }
 #endif
 
+  Handle &handle = *handlePtr;
+
+  auto runTests = [&]<typename T>(DataType dt, T x0, T x1) {
+    std::string name = generateName(mode, dt, dims);
+    TensorAttr lhsTy = getTensorAttr(dt, dims[0]);
+    TensorAttr rhsTy = getTensorAttr(dt, dims[1]);
+    PointwiseBinaryGraphBuilder builder(name, dt, mode, lhsTy, rhsTy);
+    builder.compile(handle);
+    executeAndVerify(builder, handle, dt, x0, x1);
+  };
+
   // int32
-  execute(handlePtr, DataType::Int32, int(-50), int(13));
+  runTests(DataType::Int32, int(-50), int(13));
   // fp16
-  execute(handlePtr, DataType::Half, half(-32.5f16), half(2.f16));
+  runTests(DataType::Half, half(-32.5f16), half(2.f16));
 }

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -6,7 +6,7 @@
 
 #include <fusilli.h>
 
-#include "utils.h"
+#include "pointwise_utils.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -17,9 +17,7 @@
 #include <format>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 using namespace fusilli;
@@ -43,58 +41,14 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       GENERATE(PointwiseAttr::Mode::CEIL, PointwiseAttr::Mode::RELU_FWD,
                PointwiseAttr::Mode::SIGMOID_FWD, PointwiseAttr::Mode::TANH_FWD);
 
-  auto execute = [&]<typename T>(const std::shared_ptr<Handle> &handlePtr,
-                                 DataType dt, T x) {
-    auto buildNewGraph = [&](const Handle &handle) {
-      // Create graph
-      auto graph = std::make_shared<Graph>();
-      graph->setName(generateName(mode, dt, dim));
-      graph->setIODataType(dt).setComputeDataType(dt);
-
-      // Initialize input tensors
-      auto xT = graph->tensor(TensorAttr().setName("in0").setDim(dim).setStride(
-          generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()))));
-
-      // Create Pointwise unary op
-      auto pointwiseAttr = PointwiseAttr().setMode(mode);
-      auto pointwiseResult = graph->pointwise(xT, pointwiseAttr);
-
-      pointwiseResult->setName("result").setOutput(true);
-
-      // Validate, infer missing properties
-      FUSILLI_REQUIRE_OK(graph->validate());
-
-      // Compile
-      FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
-
-      return std::make_tuple(graph, xT, pointwiseResult);
-    };
-
-    Handle &handle = *handlePtr;
-    // Build graph for the given handle (device), validate and compile it.
-    auto [graph, xT, yT] = buildNewGraph(handle);
-
-    // Allocate input buffers.
-    auto xBuf = FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, xT, dt, x));
-
-    // Allocate output buffer.
-    auto yBuf =
-        FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, yT, dt, 0.0f));
-
-    // Create variant pack.
-    const std::unordered_map<std::shared_ptr<TensorAttr>,
-                             std::shared_ptr<Buffer>>
-        variantPack = {
-            {xT, xBuf},
-            {yT, yBuf},
-        };
-
-    // Execute graph once.
-    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack));
+  auto executeAndVerify = [&]<typename T>(PointwiseUnaryGraphBuilder &builder,
+                                          Handle &handle, DataType dt, T x) {
+    // Execute and get output buffer (output type same as input type)
+    auto outBuf = builder.execute(handle, dt, x, dt, T(0));
 
     // Calculate reference value
     T y = 0;
-    switch (mode) {
+    switch (builder.getMode()) {
     case PointwiseAttr::Mode::RELU_FWD: {
       y = std::max(x, T(0));
       break;
@@ -115,13 +69,13 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       break;
     }
     default:
-      FAIL(
-          "Unsupported pointwise mode: " << PointwiseAttr::kModeToStr.at(mode));
+      FAIL("Unsupported pointwise mode: "
+           << PointwiseAttr::kModeToStr.at(builder.getMode()));
     }
 
-    // Read output buffers.
+    // Read output buffers and verify
     std::vector<T> result;
-    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+    FUSILLI_REQUIRE_OK(outBuf->read(handle, result));
 
     auto isClose = [](T lhs, T rhs) -> bool {
       if (std::is_floating_point<T>::value || std::is_same<T, half>::value) {
@@ -134,17 +88,6 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     for (auto val : result) {
       REQUIRE(isClose(val, y));
     }
-
-    // Execute graph a few times.
-    constexpr size_t numIters = 1;
-    for (size_t i = 0; i < numIters; i++)
-      FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack));
-
-    // Repeat output buffer checks.
-    result.clear();
-    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
-    for (auto val : result)
-      REQUIRE(isClose(val, y));
   };
 
   // Parameterize sample by backend and create device-specific handles.
@@ -160,8 +103,18 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
   }
 #endif
 
+  Handle &handle = *handlePtr;
+
+  auto runTests = [&]<typename T>(DataType dt, T x) {
+    std::string name = generateName(mode, dt, dim);
+    TensorAttr inputTy = getTensorAttr(dt, dim);
+    PointwiseUnaryGraphBuilder builder(name, dt, mode, inputTy);
+    builder.compile(handle);
+    executeAndVerify(builder, handle, dt, x);
+  };
+
   // int32
-  execute(handlePtr, DataType::Int32, int(-128));
+  runTests(DataType::Int32, int(-128));
   // fp16
-  execute(handlePtr, DataType::Half, half(3.14));
+  runTests(DataType::Half, half(3.14));
 }

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <fusilli.h>
+#include <utils.h>
 
 #include "pointwise_utils.h"
 
@@ -12,7 +13,6 @@
 #include <catch2/generators/catch_generators.hpp>
 
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>

--- a/samples/pointwise/pointwise_utils.h
+++ b/samples/pointwise/pointwise_utils.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef WORKSPACE_SAMPLES_POINTWISE_UTILS_H
-#define WORKSPACE_SAMPLES_POINTWISE_UTILS_H
+#ifndef WORKSPACE_SAMPLES_POINTWISE_POINTWISE_UTILS_H
+#define WORKSPACE_SAMPLES_POINTWISE_POINTWISE_UTILS_H
 
 // Include test utilities (FUSILLI_REQUIRE_OK, allocateBufferOfType, etc.)
 // Uses angle brackets to search include paths rather than relative directory
@@ -173,4 +173,4 @@ private:
 
 } // namespace fusilli
 
-#endif // WORKSPACE_SAMPLES_POINTWISE_UTILS_H
+#endif // WORKSPACE_SAMPLES_POINTWISE_POINTWISE_UTILS_H

--- a/samples/pointwise/pointwise_utils.h
+++ b/samples/pointwise/pointwise_utils.h
@@ -1,0 +1,176 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef FUSILLI_SAMPLES_POINTWISE_UTILS_H
+#define FUSILLI_SAMPLES_POINTWISE_UTILS_H
+
+// Include test utilities (FUSILLI_REQUIRE_OK, allocateBufferOfType, etc.)
+// Uses angle brackets to search include paths rather than relative directory
+#include <utils.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace fusilli {
+
+// Helper to create TensorAttr with contiguous strides
+inline TensorAttr getTensorAttr(DataType dt, const std::vector<int64_t> &dims) {
+  return TensorAttr()
+      .setDim(dims)
+      .setStride(
+          generateStrideFromDim(dims, getContiguousStrideOrder(dims.size())))
+      .setDataType(dt);
+}
+
+// Builder for binary pointwise operation graphs.
+// Encapsulates graph creation, tensor setup, compilation, and execution.
+class PointwiseBinaryGraphBuilder {
+public:
+  PointwiseBinaryGraphBuilder(const std::string &name, DataType dt,
+                              PointwiseAttr::Mode mode, const TensorAttr &lhsTy,
+                              const TensorAttr &rhsTy)
+      : mode_(mode) {
+    graph_ = std::make_shared<Graph>();
+    graph_->setName(name);
+    graph_->setIODataType(dt).setComputeDataType(dt);
+
+    lhsT_ = graph_->tensor(lhsTy);
+    rhsT_ = graph_->tensor(rhsTy);
+
+    auto pointwiseAttr = PointwiseAttr().setMode(mode);
+    outputT_ = graph_->pointwise(lhsT_, rhsT_, pointwiseAttr);
+    outputT_->setName("result").setOutput(true);
+
+    FUSILLI_REQUIRE_OK(graph_->validate());
+  }
+
+  // Compile the graph for the given handle
+  void compile(const Handle &handle) {
+    FUSILLI_REQUIRE_OK(graph_->compile(handle, /*remove=*/true));
+  }
+
+  // Execute the graph with input values, returning the output buffer.
+  // InputT is the type for input values, OutputT for initializing output
+  // buffer.
+  template <typename InputT, typename OutputT>
+  std::shared_ptr<Buffer> execute(Handle &handle, DataType inputDt, InputT x0,
+                                  InputT x1, DataType outputDt,
+                                  OutputT outputInit) {
+    auto x0Buf = FUSILLI_REQUIRE_UNWRAP(
+        allocateBufferOfType(handle, lhsT_, inputDt, x0));
+    auto x1Buf = FUSILLI_REQUIRE_UNWRAP(
+        allocateBufferOfType(handle, rhsT_, inputDt, x1));
+    auto outBuf = FUSILLI_REQUIRE_UNWRAP(
+        allocateBufferOfType(handle, outputT_, outputDt, outputInit));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {
+            {lhsT_, x0Buf},
+            {rhsT_, x1Buf},
+            {outputT_, outBuf},
+        };
+
+    FUSILLI_REQUIRE_OK(graph_->execute(handle, variantPack));
+    return outBuf;
+  }
+
+  // Re-execute the graph with an existing variant pack
+  void execute(Handle &handle,
+               const std::unordered_map<std::shared_ptr<TensorAttr>,
+                                        std::shared_ptr<Buffer>> &variantPack) {
+    FUSILLI_REQUIRE_OK(graph_->execute(handle, variantPack));
+  }
+
+  // Accessors
+  std::shared_ptr<Graph> getGraph() const { return graph_; }
+  std::shared_ptr<TensorAttr> getLhsTensor() const { return lhsT_; }
+  std::shared_ptr<TensorAttr> getRhsTensor() const { return rhsT_; }
+  std::shared_ptr<TensorAttr> getOutputTensor() const { return outputT_; }
+  PointwiseAttr::Mode getMode() const { return mode_; }
+
+private:
+  std::shared_ptr<Graph> graph_;
+  std::shared_ptr<TensorAttr> lhsT_;
+  std::shared_ptr<TensorAttr> rhsT_;
+  std::shared_ptr<TensorAttr> outputT_;
+  PointwiseAttr::Mode mode_;
+};
+
+// Builder for unary pointwise operation graphs.
+// Encapsulates graph creation, tensor setup, compilation, and execution.
+class PointwiseUnaryGraphBuilder {
+public:
+  PointwiseUnaryGraphBuilder(const std::string &name, DataType dt,
+                             PointwiseAttr::Mode mode,
+                             const TensorAttr &inputTy)
+      : mode_(mode) {
+    graph_ = std::make_shared<Graph>();
+    graph_->setName(name);
+    graph_->setIODataType(dt).setComputeDataType(dt);
+
+    inputT_ = graph_->tensor(inputTy);
+
+    auto pointwiseAttr = PointwiseAttr().setMode(mode);
+    outputT_ = graph_->pointwise(inputT_, pointwiseAttr);
+    outputT_->setName("result").setOutput(true);
+
+    FUSILLI_REQUIRE_OK(graph_->validate());
+  }
+
+  // Compile the graph for the given handle
+  void compile(const Handle &handle) {
+    FUSILLI_REQUIRE_OK(graph_->compile(handle, /*remove=*/true));
+  }
+
+  // Execute the graph with input value, returning the output buffer.
+  // InputT is the type for input value, OutputT for initializing output buffer.
+  template <typename InputT, typename OutputT>
+  std::shared_ptr<Buffer> execute(Handle &handle, DataType inputDt, InputT x,
+                                  DataType outputDt, OutputT outputInit) {
+    auto xBuf = FUSILLI_REQUIRE_UNWRAP(
+        allocateBufferOfType(handle, inputT_, inputDt, x));
+    auto outBuf = FUSILLI_REQUIRE_UNWRAP(
+        allocateBufferOfType(handle, outputT_, outputDt, outputInit));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {
+            {inputT_, xBuf},
+            {outputT_, outBuf},
+        };
+
+    FUSILLI_REQUIRE_OK(graph_->execute(handle, variantPack));
+    return outBuf;
+  }
+
+  // Re-execute the graph with an existing variant pack
+  void execute(Handle &handle,
+               const std::unordered_map<std::shared_ptr<TensorAttr>,
+                                        std::shared_ptr<Buffer>> &variantPack) {
+    FUSILLI_REQUIRE_OK(graph_->execute(handle, variantPack));
+  }
+
+  // Accessors
+  std::shared_ptr<Graph> getGraph() const { return graph_; }
+  std::shared_ptr<TensorAttr> getInputTensor() const { return inputT_; }
+  std::shared_ptr<TensorAttr> getOutputTensor() const { return outputT_; }
+  PointwiseAttr::Mode getMode() const { return mode_; }
+
+private:
+  std::shared_ptr<Graph> graph_;
+  std::shared_ptr<TensorAttr> inputT_;
+  std::shared_ptr<TensorAttr> outputT_;
+  PointwiseAttr::Mode mode_;
+};
+
+} // namespace fusilli
+
+#endif // FUSILLI_SAMPLES_POINTWISE_UTILS_H

--- a/samples/pointwise/pointwise_utils.h
+++ b/samples/pointwise/pointwise_utils.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef FUSILLI_SAMPLES_POINTWISE_UTILS_H
-#define FUSILLI_SAMPLES_POINTWISE_UTILS_H
+#ifndef WORKSPACE_SAMPLES_POINTWISE_UTILS_H
+#define WORKSPACE_SAMPLES_POINTWISE_UTILS_H
 
 // Include test utilities (FUSILLI_REQUIRE_OK, allocateBufferOfType, etc.)
 // Uses angle brackets to search include paths rather than relative directory
@@ -173,4 +173,4 @@ private:
 
 } // namespace fusilli
 
-#endif // FUSILLI_SAMPLES_POINTWISE_UTILS_H
+#endif // WORKSPACE_SAMPLES_POINTWISE_UTILS_H


### PR DESCRIPTION
  - Introduce PointwiseBinaryGraphBuilder and PointwiseUnaryGraphBuilder classes to encapsulate graph creation, tensor setup, compilation, and execution for pointwise operations
  - Add getTensorAttr() helper function to simplify contiguous tensor creation
  - Refactor all pointwise test files to use the new builder classes, reducing boilerplate and improving readability
  - Remove redundant multi-iteration execution loops from tests (keeping single execution per test case)

  Design Notes

  The new pointwise_utils.h header is intentionally placed in samples/pointwise/ alongside the tests that use it, rather than in a shared location. This keeps the utilities scoped
  to the pointwise operators and avoids exposing implementation details to other sample categories or the broader codebase.