### PR TITLE
Minor windows compilation fixes

### DIFF
--- a/include/fusilli/backend/compile_command.h
+++ b/include/fusilli/backend/compile_command.h
@@ -71,7 +71,7 @@ public:
   static CompileCommand build(const Handle &handle, const CacheFile &input,
                               const CacheFile &output,
                               const CacheFile &statistics) {
-    std::vector<std::string> args = {getIreeCompilePath(), input.path};
+    std::vector<std::string> args = {getIreeCompilePath(), input.path.string()};
 
     // Get backend-specific flags.
     auto flags = getBackendFlags(handle.getBackend());
@@ -87,7 +87,7 @@ public:
 
     // Add output specification.
     args.push_back("-o");
-    args.push_back(output.path);
+    args.push_back(output.path.string());
 
     return CompileCommand(std::move(args));
   }

--- a/include/fusilli/support/python_utils.h
+++ b/include/fusilli/support/python_utils.h
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
- std::filesystem::path does not implicitly convert to string on windows
- missing `#include<mutex>`