### PR TITLE
[Backend] Query GPU SKU name to pass to `--iree-hip-target` to enable GPU specific tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ Alternatively, one may call the logging API directly as needed:
 | `FUSILLI_EXTERNAL_IREE_COMPILE`          | Path to `iree-compile` binary
 | `FUSILLI_EXTERNAL_IREE_COMPILER_LIB`     | Path to the IREE compiler dynamic library
 | `FUSILLI_EXTERNAL_ROCM_AGENT_ENUMERATOR` | Path to `rocm_agent_enumerator` binary
+| `FUSILLI_EXTERNAL_AMD_SMI`               | Path to `amd-smi` binary (used for GPU SKU detection)

--- a/include/fusilli/support/external_tools.h
+++ b/include/fusilli/support/external_tools.h
@@ -28,7 +28,7 @@ inline std::string getIreeCompilePath() {
   }
 
   // Let the shell search for it.
-  return "iree-compile";
+  return std::string("iree-compile");
 }
 
 inline std::string getRocmAgentEnumeratorPath() {
@@ -40,6 +40,17 @@ inline std::string getRocmAgentEnumeratorPath() {
 
   // Let shell search for it.
   return std::string("rocm_agent_enumerator");
+}
+
+inline std::string getAmdSmiPath() {
+  // Check environment variable.
+  const char *envPath = std::getenv("FUSILLI_EXTERNAL_AMD_SMI");
+  if (envPath && envPath[0] != '\0') {
+    return std::string(envPath);
+  }
+
+  // Let shell search for it.
+  return std::string("amd-smi");
 }
 
 inline std::string getIreeCompilerLibPath() {
@@ -56,7 +67,7 @@ inline std::string getIreeCompilerLibPath() {
   }
 
   // Fallback: let the system search for it (may be in LD_LIBRARY_PATH).
-  return "libIREECompiler.so";
+  return std::string("libIREECompiler.so");
 }
 
 } // namespace fusilli

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_fusilli_tests(
   PREFIX
     fusilli_backend_tests
   SRCS
+    test_backend.cpp
     test_buffer.cpp
     test_compile_command.cpp
     test_compile_session.cpp

--- a/tests/test_backend.cpp
+++ b/tests/test_backend.cpp
@@ -1,0 +1,182 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using namespace fusilli;
+
+//===----------------------------------------------------------------------===//
+// Tests for getGpuSkuFromMarketingName
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("getGpuSkuFromMarketingName CDNA GPUs", "[backend][sku]") {
+  SECTION("MI300X variants") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI300X") == "mi300x");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI300X OAM") == "mi300x");
+    REQUIRE(getGpuSkuFromMarketingName("mi300x") == "mi300x");
+  }
+
+  SECTION("MI300A") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI300A") == "mi300a");
+  }
+
+  SECTION("MI325X") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI325X") == "mi325x");
+  }
+
+  SECTION("MI308X") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI308X") == "mi308x");
+  }
+
+  SECTION("CDNA4 - MI350X/MI355X") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI350X") == "mi350x");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI355X") == "mi355x");
+  }
+
+  SECTION("CDNA2 - MI250 series") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI250X") == "mi250x");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI250") == "mi250");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI210") == "mi210");
+  }
+
+  SECTION("CDNA1 - MI100") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI100") == "mi100");
+  }
+}
+
+TEST_CASE("getGpuSkuFromMarketingName RDNA3 Pro GPUs", "[backend][sku]") {
+  SECTION("Radeon PRO W series") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon PRO W7900") == "w7900");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon PRO W7800") == "w7800");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon PRO W7700") == "w7700");
+  }
+
+  SECTION("Radeon PRO V710") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon PRO V710") == "v710");
+  }
+}
+
+TEST_CASE("getGpuSkuFromMarketingName RDNA3 Consumer GPUs", "[backend][sku]") {
+  SECTION("RX 7900 series") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 7900 XTX") ==
+            "rx7900xtx");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 7900 XT") == "rx7900xt");
+  }
+
+  SECTION("RX 7800/7700 series") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 7800 XT") == "rx7800xt");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 7700 XT") == "rx7700xt");
+  }
+}
+
+TEST_CASE("getGpuSkuFromMarketingName RDNA4 GPUs", "[backend][sku]") {
+  SECTION("RX 9000 series") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 9070 XT") == "rx9070xt");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 9070") == "rx9070");
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon RX 9060 XT") == "rx9060xt");
+  }
+
+  SECTION("Radeon AI PRO R9700") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD Radeon AI PRO R9700") == "r9700");
+  }
+}
+
+TEST_CASE("getGpuSkuFromMarketingName case insensitivity", "[backend][sku]") {
+  SECTION("Lowercase input") {
+    REQUIRE(getGpuSkuFromMarketingName("amd instinct mi300x") == "mi300x");
+  }
+
+  SECTION("Uppercase input") {
+    REQUIRE(getGpuSkuFromMarketingName("AMD INSTINCT MI300X") == "mi300x");
+  }
+
+  SECTION("Mixed case input") {
+    REQUIRE(getGpuSkuFromMarketingName("Amd Instinct Mi300x") == "mi300x");
+  }
+}
+
+TEST_CASE("getGpuSkuFromMarketingName unrecognized inputs", "[backend][sku]") {
+  SECTION("Empty string") { REQUIRE(getGpuSkuFromMarketingName("").empty()); }
+
+  SECTION("Unknown GPU") {
+    REQUIRE(getGpuSkuFromMarketingName("NVIDIA GeForce RTX 4090").empty());
+    REQUIRE(getGpuSkuFromMarketingName("Unknown GPU Model").empty());
+  }
+
+  SECTION("Partial match that shouldn't match") {
+    // "MI30" alone shouldn't match MI300X
+    REQUIRE(getGpuSkuFromMarketingName("AMD Instinct MI30").empty());
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Tests for getGpuMarketingNameFromAmdSmi
+//
+// NOTE: These tests require amd-smi to be installed and accessible.
+// They will return empty string if amd-smi is not available.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("getGpuMarketingNameFromAmdSmi returns string or empty",
+          "[backend][amd-smi]") {
+  // This test verifies the function doesn't crash and returns a valid result.
+  // On systems without amd-smi, it should return an empty string.
+  std::string result = getGpuMarketingNameFromAmdSmi();
+
+  // Result should either be empty (no amd-smi) or contain "AMD"
+  if (!result.empty()) {
+    // If we got a result, it should contain AMD in the name
+    REQUIRE(result.find("AMD") != std::string::npos);
+  }
+  // Empty result is also acceptable (amd-smi not available)
+}
+
+//===----------------------------------------------------------------------===//
+// Tests for getIreeHipTargetForAmdgpu
+//
+// NOTE: These tests require either amd-smi or rocm_agent_enumerator
+// to be installed and accessible.
+//===----------------------------------------------------------------------===//
+
+TEST_CASE("getIreeHipTargetForAmdgpu returns valid target or empty",
+          "[backend][hip-target]") {
+  // This test verifies the function doesn't crash and returns a valid result.
+  std::string result = getIreeHipTargetForAmdgpu();
+
+  // Result should either be empty (no tools available) or a valid target
+  if (!result.empty()) {
+    // Valid targets are either:
+    // 1. SKU names (e.g., mi300x, w7900)
+    // 2. Architecture names (e.g., gfx942, gfx1100)
+    bool isSkuName = (result.find("mi") == 0 || result.find("rx") == 0 ||
+                      result.find("w7") == 0 || result.find("v7") == 0 ||
+                      result.find("r9") == 0);
+    bool isArchName = (result.find("gfx") == 0);
+
+    REQUIRE((isSkuName || isArchName));
+  }
+  // Empty result is also acceptable (no tools available)
+}
+
+TEST_CASE("getIreeHipTargetForAmdgpu prefers SKU over architecture",
+          "[backend][hip-target]") {
+  // Get both the marketing name and the final target
+  std::string marketingName = getGpuMarketingNameFromAmdSmi();
+  std::string target = getIreeHipTargetForAmdgpu();
+
+  // If we got a marketing name that maps to a known SKU,
+  // the target should be that SKU, not an architecture
+  if (!marketingName.empty()) {
+    std::string expectedSku = getGpuSkuFromMarketingName(marketingName);
+    if (!expectedSku.empty()) {
+      REQUIRE(target == expectedSku);
+    }
+  }
+  // If marketing name is empty or unrecognized, we can't verify this
+}


### PR DESCRIPTION
Should address #100 when complete. 

## Context

IREE's `--iree-hip-target` flag supports three schemes for specifying the target GPU:

1. **SKU name** (e.g., `mi300x`) - Provides chip-specific details including WGP count, memory bandwidth, and enables SKU-specific tuning specs
2. **Architecture** (e.g., `gfx942`) - Generic architecture-level tuning only
3. **Code name** (e.g., `cdna3`) - Also generic, translated to closest matching architecture

Currently, fusilli uses option 2 (architecture) via `rocm_agent_enumerator`, which returns values like `gfx942`. However, using SKU names (option 1) enables significantly better compiler heuristics and tuning.

As noted in the issue, this can make a substantial performance difference. For example, a forward convolution benchmark showed:
- BOO time: 41 µs
- Fusilli time: 570 µs

The difference was traced to varying lowering config tile sizes due to the target flag difference.

## Solution

This PR adds SKU-based GPU target detection using `amd-smi`, with fallback to architecture-based detection via `rocm_agent_enumerator`.

The implementation:
1. Queries `amd-smi static --gpu 0 --json` to get the GPU's marketing name (e.g., "AMD Instinct MI300X")
2. Maps the marketing name to the corresponding IREE SKU target (e.g., `mi300x`)
3. Falls back to architecture detection if SKU lookup fails

## Changes

### `include/fusilli/support/external_tools.h`
- Added `getAmdSmiPath()` function to locate the `amd-smi` binary, with support for `FUSILLI_EXTERNAL_AMD_SMI` environment variable override

### `include/fusilli/backend/backend.h`
- Added `getGpuSkuFromMarketingName()` - Maps GPU marketing names to IREE SKU targets using pattern matching. Supports:
  - CDNA4: MI355X, MI350X
  - CDNA3: MI325X, MI308X, MI300X, MI300A
  - CDNA2: MI250X, MI250, MI210
  - CDNA1: MI100
  - RDNA3 Pro: W7900, W7800, W7700, V710
  - RDNA3 Consumer: RX 7900 XTX/XT, RX 7800 XT, RX 7700 XT
  - RDNA4: RX 9070 XT, RX 9070, RX 9060 XT, R9700

- Added `getGpuMarketingNameFromAmdSmi()` - Queries `amd-smi` and extracts the `market_name` field from JSON output

- Refactored `getIreeHipTargetForAmdgpu()` to:
  1. First attempt SKU detection via `amd-smi`
  2. Fall back to architecture detection via `rocm_agent_enumerator`

### `README.md`
- Documented new `FUSILLI_EXTERNAL_AMD_SMI` environment variable

## Testing

```bash
# Verify amd-smi returns expected marketing name
amd-smi static --gpu 0 --json | jq '.gpu_data[0].asic.market_name'
# Expected: "AMD Instinct MI300X" (or similar)

# After building, the compiler flags should now show SKU target
# e.g., --iree-hip-target=mi300x instead of --iree-hip-target=gfx942
```

## References

- [IREE GPU-ROCm deployment guide](https://iree.dev/guides/deployment-configurations/gpu-rocm/#choosing-hip-targets)
- [IREE KnownTargets.cpp](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp) - Source of SKU mappings

## Disclaimer
- PR description and code fixes generated with assistance from Claude 4.5 Opus under my supervision.