### PR TITLE
[Support] Add cross-platform setEnv and unsetEnv utilities

### DIFF
--- a/include/fusilli/support/target_platform.h
+++ b/include/fusilli/support/target_platform.h
@@ -7,6 +7,8 @@
 #ifndef FUSILLI_SUPPORT_TARGET_PLATFORM_H
 #define FUSILLI_SUPPORT_TARGET_PLATFORM_H
 
+#include <cstdlib>
+
 //==============================================================================
 // FUSILLI_PLATFORM_LINUX
 //==============================================================================
@@ -26,5 +28,31 @@
 #if !defined(FUSILLI_PLATFORM_LINUX) && !defined(FUSILLI_PLATFORM_WINDOWS)
 #error Unknown platform.
 #endif // all archs
+
+//==============================================================================
+// Platform-independent environment variable utilities
+//==============================================================================
+
+namespace fusilli {
+
+// Sets an environment variable. Returns 0 on success, non-zero on failure.
+inline int setEnv(const char *name, const char *value) {
+#if defined(FUSILLI_PLATFORM_WINDOWS)
+  return _putenv_s(name, value);
+#else
+  return setenv(name, value, 1);
+#endif
+}
+
+// Unsets an environment variable. Returns 0 on success, non-zero on failure.
+inline int unsetEnv(const char *name) {
+#if defined(FUSILLI_PLATFORM_WINDOWS)
+  return _putenv_s(name, "");
+#else
+  return unsetenv(name);
+#endif
+}
+
+} // namespace fusilli
 
 #endif // FUSILLI_SUPPORT_TARGET_PLATFORM_H

--- a/tests/test_logging.cpp
+++ b/tests/test_logging.cpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <ostream>
 #include <sstream>
-#include <stdlib.h>
 #include <utility>
 
 using namespace fusilli;
@@ -59,11 +58,11 @@ TEST_CASE("ConditionalStreamer conditioned on isLoggingEnabled", "[logging]") {
 // env variable. So subsequent tests that change the env variable (in
 // the same process) will not affect the stream returned by getStream().
 TEST_CASE("getStream stdout mode", "[logging][.]") {
-  setenv("FUSILLI_LOG_FILE", "stdout", 1);
+  setEnv("FUSILLI_LOG_FILE", "stdout");
   std::ostream &stream = getStream();
   REQUIRE(&stream == &std::cout);
 
-  unsetenv("FUSILLI_LOG_FILE");
+  unsetEnv("FUSILLI_LOG_FILE");
 }
 
 // This test is disabled because getStream() statically initializes
@@ -71,11 +70,11 @@ TEST_CASE("getStream stdout mode", "[logging][.]") {
 // env variable. So subsequent tests that change the env variable (in
 // the same process) will not affect the stream returned by getStream().
 TEST_CASE("getStream stderr mode", "[logging][.]") {
-  setenv("FUSILLI_LOG_FILE", "stderr", 1);
+  setEnv("FUSILLI_LOG_FILE", "stderr");
   std::ostream &stream = getStream();
   REQUIRE(&stream == &std::cerr);
 
-  unsetenv("FUSILLI_LOG_FILE");
+  unsetEnv("FUSILLI_LOG_FILE");
 }
 
 // This test is disabled because getStream() statically initializes
@@ -84,7 +83,7 @@ TEST_CASE("getStream stderr mode", "[logging][.]") {
 // the same process) will not affect the stream returned by getStream().
 TEST_CASE("getStream file mode", "[logging][.]") {
   const char *testFile = "/tmp/test_fusilli_log.txt";
-  setenv("FUSILLI_LOG_FILE", testFile, 1);
+  setEnv("FUSILLI_LOG_FILE", testFile);
   std::ostream &stream = getStream();
   REQUIRE(&stream != &std::cout);
   REQUIRE(&stream != &std::cerr);
@@ -93,7 +92,7 @@ TEST_CASE("getStream file mode", "[logging][.]") {
   REQUIRE(dynamic_cast<std::ofstream *>(&stream));
 
   // Cleanup.
-  unsetenv("FUSILLI_LOG_FILE");
+  unsetEnv("FUSILLI_LOG_FILE");
   std::remove(testFile);
 }
 


### PR DESCRIPTION
Add platform-independent environment variable functions to target_platform.h that use _putenv_s on Windows and setenv/unsetenv on Linux. Migrate existing uses in test_logging.cpp to the new utilities.