### PR TITLE
FUSILLI_REQUIRE_UNWRAP fixes

### DIFF
--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -94,10 +94,12 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
       xData[i] = static_cast<T>(i % 100 - 50);
     }
 
-    auto xBuf = std::make_shared<Buffer>(FUSILLI_REQUIRE_UNWRAP(
-        Buffer::allocate(handle, castToSizeT(xT->getPhysicalDim()), xData)));
-    auto yBuf =
-        FUSILLI_REQUIRE_UNWRAP(allocateBufferOfType(handle, yT, dt, initValue));
+    FUSILLI_REQUIRE_ASSIGN(
+        Buffer xBufVal,
+        Buffer::allocate(handle, castToSizeT(xT->getPhysicalDim()), xData));
+    auto xBuf = std::make_shared<Buffer>(std::move(xBufVal));
+    FUSILLI_REQUIRE_ASSIGN(auto yBuf,
+                           allocateBufferOfType(handle, yT, dt, initValue));
     const std::unordered_map<std::shared_ptr<TensorAttr>,
                              std::shared_ptr<Buffer>>
         variantPack = {
@@ -159,13 +161,13 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
   // Parameterize sample by backend and create device-specific handles
   std::shared_ptr<Handle> handlePtr;
   SECTION("cpu backend") {
-    handlePtr = std::make_shared<Handle>(
-        FUSILLI_REQUIRE_UNWRAP(Handle::create(Backend::CPU)));
+    FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
+    handlePtr = std::make_shared<Handle>(std::move(handle));
   }
 #ifdef FUSILLI_ENABLE_AMDGPU
   SECTION("amdgpu backend") {
-    handlePtr = std::make_shared<Handle>(
-        FUSILLI_REQUIRE_UNWRAP(Handle::create(Backend::AMDGPU)));
+    FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
+    handlePtr = std::make_shared<Handle>(std::move(handle));
   }
 #endif
 


### PR DESCRIPTION
https://github.com/iree-org/fusilli/pull/107 had clean CI but was on an older base, and in the meantime FUSILLI_REQUIRE_UNWRAP macro changes from https://github.com/iree-org/fusilli/pull/127 had landed. 

It might be a good idea to require branches to be updated before landing:
<img width="779" height="176" alt="image" src="https://github.com/user-attachments/assets/a31fbb52-d907-4806-95bf-cd13b6863e42" />
