### PR TITLE
Pin hipDNN to specific commit to avoid API breakages

### DIFF
--- a/plugins/hipdnn-plugin/build_tools/thepebble_config.toml
+++ b/plugins/hipdnn-plugin/build_tools/thepebble_config.toml
@@ -6,7 +6,8 @@ therock_git_ref = "main"
 hip_run_id = "19089392286"
 
 # Git ref (commit/tag/branch) for rocm-libraries hipDNN
-hipdnn_git_ref = "develop"
+# TODO: Switch back to develop after fixing API breakages
+hipdnn_git_ref = "0c37fdc37ba545b2ced5211b9f59c2381fc93753"
 
 # IREE git tag
 iree_git_tag = "iree-3.11.0rc20260203"


### PR DESCRIPTION
## Summary
- Temporarily pins `hipdnn_git_ref` to commit `0c37fdc37ba5` instead of the `develop` branch
- Works around upstream API changes in hipDNN that break the build
- Adds TODO comment to switch back to develop after fixing API breakages

## Test plan
- [ ] Verify build completes successfully with the pinned commit
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)