### PR TITLE
[FusilliPlugin] Use `FUSILLI_ENGINE_ID` as defined in hipDNN

### DIFF
--- a/plugins/hipdnn-plugin/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 
 # Global constants
-set(FUSILLI_PLUGIN_NAME fusilli_plugin)
+set(FUSILLI_PLUGIN_TARGET fusilli_plugin)
 # Relative path from build/install prefix to plugin location.
 # HIPDNN_PLUGIN_ENGINE_SUBDIR is provided by hipdnn_sdk.
 set(FUSILLI_PLUGIN_RELATIVE_PATH "${CMAKE_INSTALL_LIBDIR}/${HIPDNN_PLUGIN_ENGINE_SUBDIR}")
@@ -103,15 +103,12 @@ list(PREPEND FUSILLI_PLUGIN_WARNING_COMPILE_OPTIONS
 include_directories(include)
 
 # Plugin definition
-add_library(${FUSILLI_PLUGIN_NAME} SHARED
+add_library(${FUSILLI_PLUGIN_TARGET} SHARED
   src/fusilli_plugin.cpp
 )
-target_compile_options(${FUSILLI_PLUGIN_NAME} PRIVATE ${FUSILLI_PLUGIN_WARNING_COMPILE_OPTIONS})
-target_link_libraries(${FUSILLI_PLUGIN_NAME} PRIVATE hipdnn_plugin_sdk hipdnn_data_sdk hip::host fusilli::fusilli)
-target_compile_definitions(${FUSILLI_PLUGIN_NAME} PRIVATE
-  FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
-)
-set_target_properties(${FUSILLI_PLUGIN_NAME} PROPERTIES
+target_compile_options(${FUSILLI_PLUGIN_TARGET} PRIVATE ${FUSILLI_PLUGIN_WARNING_COMPILE_OPTIONS})
+target_link_libraries(${FUSILLI_PLUGIN_TARGET} PRIVATE hipdnn_plugin_sdk hipdnn_data_sdk hip::host fusilli::fusilli)
+set_target_properties(${FUSILLI_PLUGIN_TARGET} PROPERTIES
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN ON
@@ -119,11 +116,11 @@ set_target_properties(${FUSILLI_PLUGIN_NAME} PROPERTIES
 )
 # Version script hides all symbol definitions not staring with "hipdnn"
 target_link_options(
-  ${FUSILLI_PLUGIN_NAME} PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/exports.map"
+  ${FUSILLI_PLUGIN_TARGET} PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/exports.map"
 )
 
 # Installation
-install(TARGETS ${FUSILLI_PLUGIN_NAME}
+install(TARGETS ${FUSILLI_PLUGIN_TARGET}
   LIBRARY DESTINATION "${FUSILLI_PLUGIN_RELATIVE_PATH}"
 )
 

--- a/plugins/hipdnn-plugin/src/fusilli_plugin.cpp
+++ b/plugins/hipdnn-plugin/src/fusilli_plugin.cpp
@@ -67,7 +67,7 @@ hipdnnPluginStatus_t hipdnnPluginGetName(const char **name) {
   LOG_API_ENTRY("name_ptr=" << static_cast<void *>(name));
   FUSILLI_PLUGIN_CHECK_NULL(name);
 
-  *name = FUSILLI_PLUGIN_NAME;
+  *name = hipdnn_data_sdk::utilities::FUSILLI_ENGINE_NAME;
 
   LOG_API_SUCCESS_AUTO("pluginName=" << *name);
   return HIPDNN_PLUGIN_STATUS_SUCCESS;
@@ -104,7 +104,8 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback) {
   // No LOG_API_ENTRY as logging won't be wired up yet.
   FUSILLI_PLUGIN_CHECK_NULL(callback);
 
-  hipdnn::logging::initializeCallbackLogging(FUSILLI_PLUGIN_NAME, callback);
+  hipdnn::logging::initializeCallbackLogging(
+      hipdnn_data_sdk::utilities::FUSILLI_ENGINE_NAME, callback);
 
   LOG_API_SUCCESS_AUTO("logging callback initialized");
   return HIPDNN_PLUGIN_STATUS_SUCCESS;

--- a/plugins/hipdnn-plugin/test/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/test/CMakeLists.txt
@@ -24,8 +24,6 @@ add_fusilli_plugin_test(
     hipdnn_data_sdk
     hipdnn_test_sdk
     Threads::Threads
-  COMPILE_DEFS
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 # Graph import tests

--- a/plugins/hipdnn-plugin/test/integration/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/test/integration/CMakeLists.txt
@@ -19,7 +19,7 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
+    FUSILLI_PLUGIN_TARGET="${FUSILLI_PLUGIN_TARGET}"
 )
 
 add_fusilli_plugin_test(
@@ -34,7 +34,6 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 add_fusilli_plugin_test(
@@ -50,7 +49,6 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 add_fusilli_plugin_test(
@@ -65,7 +63,6 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 add_fusilli_plugin_test(
@@ -81,7 +78,6 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 add_fusilli_plugin_test(
@@ -97,7 +93,6 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )
 
 add_fusilli_plugin_test(
@@ -113,5 +108,4 @@ add_fusilli_plugin_test(
     Threads::Threads
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
-    FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
 )

--- a/plugins/hipdnn-plugin/test/integration/plugin_load.cpp
+++ b/plugins/hipdnn-plugin/test/integration/plugin_load.cpp
@@ -76,7 +76,8 @@ TEST(IntegrationTests, PluginLoad) {
   EXPECT_EQ(loadedPlugins.size(), 1);
 
   // Check that fusilli plugin did load.
-  auto expectedPath = pluginPath / std::format("lib{}.so", FUSILLI_PLUGIN_NAME);
+  auto expectedPath =
+      pluginPath / std::format("lib{}.so", FUSILLI_PLUGIN_TARGET);
   EXPECT_TRUE(std::ranges::any_of(
       loadedPlugins, [&expectedPath](const std::string &loadedPluginPath) {
         return std::filesystem::canonical(loadedPluginPath) ==

--- a/plugins/hipdnn-plugin/test/test_fusilli_plugin_api.cpp
+++ b/plugins/hipdnn-plugin/test/test_fusilli_plugin_api.cpp
@@ -138,7 +138,7 @@ TEST(TestFusilliPluginApi, Logging) {
 TEST(TestFusilliPluginApi, GetNameSuccess) {
   const char *name = nullptr;
   EXPECT_EQ(hipdnnPluginGetName(&name), HIPDNN_PLUGIN_STATUS_SUCCESS);
-  EXPECT_STREQ(name, FUSILLI_PLUGIN_NAME);
+  EXPECT_STREQ(name, hipdnn_data_sdk::utilities::FUSILLI_ENGINE_NAME);
 }
 
 TEST(TestFusilliPluginApi, GetNameNullptr) {


### PR DESCRIPTION
[Hipdnn/rfc#0003](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipdnn/docs/rfcs/0003_EngineIdDesign.md) introduced a new way to define engine IDs. This PR updates fusilli to use the name/id pair defined in hipDNN in https://github.com/ROCm/rocm-libraries/pull/4362.