### PR TITLE
Revert "[Backend] Enable default device sharing across handles for multi threaded handle+device creation"

### DIFF
--- a/include/fusilli/backend/backend.h
+++ b/include/fusilli/backend/backend.h
@@ -387,7 +387,8 @@ struct IreeHalBufferViewDeleter {
 // Aliases for IREE runtime types with custom deleters.
 using IreeRuntimeInstanceSharedPtrType =
     std::shared_ptr<iree_runtime_instance_t>;
-using IreeHalDeviceSharedPtrType = std::shared_ptr<iree_hal_device_t>;
+using IreeHalDeviceUniquePtrType =
+    std::unique_ptr<iree_hal_device_t, IreeHalDeviceDeleter>;
 using IreeRuntimeSessionUniquePtrType =
     std::unique_ptr<iree_runtime_session_t, IreeRuntimeSessionDeleter>;
 using IreeHalBufferViewUniquePtrType =

--- a/include/fusilli/backend/handle.h
+++ b/include/fusilli/backend/handle.h
@@ -160,10 +160,7 @@ private:
   // `device_` depends on `backend_` and `instance_`.
   Backend backend_;
   IreeRuntimeInstanceSharedPtrType instance_;
-  // Use shared_ptr to allow sharing devices across handles. For CPU, there's
-  // only one logical device shared by all handles. For GPU, devices with the
-  // same (deviceId, stream) configuration are shared.
-  IreeHalDeviceSharedPtrType device_;
+  IreeHalDeviceUniquePtrType device_;
 };
 
 } // namespace fusilli

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -44,7 +44,6 @@
 #include <iree/runtime/api.h>
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -62,7 +61,7 @@ namespace fusilli {
 // Create static singleton IREE runtime instance shared across handles/threads.
 inline ErrorOr<IreeRuntimeInstanceSharedPtrType>
 Handle::createSharedInstance() {
-  // Mutex for thread-safe initialization of the shared instance.
+  // Mutex for thread-safe initialization of weakInstance.
   static std::mutex instanceMutex;
 
   // Static weak_ptr to the IREE runtime instance ensures that the
@@ -73,7 +72,9 @@ Handle::createSharedInstance() {
   // static variable goes out of scope upon program termination.
   static std::weak_ptr<iree_runtime_instance_t> weakInstance;
 
-  // Serialize access to the weak_ptr check-then-create logic.
+  // If multiple threads simultaneously request a handle, they will
+  // race into `createSharedInstance()` but only one will succeed in
+  // creating the instance, and others will use it.
   std::lock_guard<std::mutex> lock(instanceMutex);
 
   // Try to get the shared_ptr from the weak_ptr (if it exists).
@@ -105,38 +106,15 @@ Handle::createSharedInstance() {
 inline ErrorObject Handle::createCPUDevice() {
   FUSILLI_LOG_LABEL_ENDL("INFO: Creating per-handle IREE HAL device");
 
-  // Mutex for thread-safe access to the shared CPU device.
-  static std::mutex cpuDeviceMutex;
+  iree_hal_device_t *rawDevice = nullptr;
+  FUSILLI_CHECK_ERROR(iree_runtime_instance_try_create_default_device(
+      instance_.get(), iree_make_cstring_view(kHalDriver.at(backend_)),
+      &rawDevice));
 
-  // Static weak_ptr to the CPU device ensures that the device is only
-  // created once and shared across all CPU handles. This is necessary
-  // because IREE's local-task driver typically provides a single default
-  // device. The device is released when the last handle using it goes
-  // out of scope.
-  static std::weak_ptr<iree_hal_device_t> weakCpuDevice;
+  // Wrap the raw device ptr with a unique_ptr and custom deleter
+  // for lifetime management.
+  device_ = IreeHalDeviceUniquePtrType(rawDevice);
 
-  // Serialize access to the weak_ptr check-then-create logic.
-  std::lock_guard<std::mutex> lock(cpuDeviceMutex);
-
-  // Try to get the shared_ptr from the weak_ptr (if it exists).
-  IreeHalDeviceSharedPtrType sharedDevice = weakCpuDevice.lock();
-
-  // If weak_ptr expired, create a new CPU device.
-  if (sharedDevice == nullptr) {
-    FUSILLI_LOG_LABEL_ENDL("INFO: Creating shared CPU device");
-    iree_hal_device_t *rawDevice = nullptr;
-    FUSILLI_CHECK_ERROR(iree_runtime_instance_try_create_default_device(
-        instance_.get(), iree_make_cstring_view(kHalDriver.at(backend_)),
-        &rawDevice));
-
-    // Wrap the raw device ptr with a shared_ptr and custom deleter
-    // for lifetime management.
-    sharedDevice =
-        IreeHalDeviceSharedPtrType(rawDevice, IreeHalDeviceDeleter());
-    weakCpuDevice = sharedDevice;
-  }
-
-  device_ = sharedDevice;
   return ok();
 }
 
@@ -152,36 +130,6 @@ inline ErrorObject Handle::createAMDGPUDevice(int deviceId, uintptr_t stream) {
 // when building Fusilli without AMDGPU support (which disables IREE HAL
 // HIP driver from being built).
 #ifdef FUSILLI_ENABLE_AMDGPU
-  // Mutex for thread-safe access to the GPU device cache.
-  static std::mutex gpuDeviceMutex;
-
-  // Cache key for AMDGPU devices: (deviceId, stream) pair.
-  // Devices with the same configuration are shared across handles.
-  using GpuDeviceKey = std::pair<int, uintptr_t>;
-  static std::map<GpuDeviceKey, std::weak_ptr<iree_hal_device_t>>
-      gpuDeviceCache;
-
-  // Serialize access to the cache check-then-create logic.
-  std::lock_guard<std::mutex> lock(gpuDeviceMutex);
-
-  // Clean up all expired entries while we hold the lock.
-  std::erase_if(gpuDeviceCache, // C++20
-                [](const auto &entry) { return entry.second.expired(); });
-
-  GpuDeviceKey key{deviceId, stream};
-
-  // Try to get an existing device from the cache.
-  if (auto it = gpuDeviceCache.find(key); it != gpuDeviceCache.end()) {
-    // Entry exists and is valid (we just cleaned expired ones).
-    FUSILLI_LOG_LABEL_ENDL("INFO: Reusing cached AMDGPU device");
-    // Lock the weak_ptr to get a shared_ptr and assign to device_.
-    device_ = it->second.lock();
-    return ok();
-  }
-
-  // Create a new device since none exists in cache for this configuration.
-  FUSILLI_LOG_LABEL_ENDL("INFO: Creating new AMDGPU device");
-
   // Device parms.
   iree_hal_hip_device_params_t params;
   setDefaultIreeHalHipDeviceParams(&params);
@@ -201,14 +149,9 @@ inline ErrorObject Handle::createAMDGPUDevice(int deviceId, uintptr_t stream) {
       driver, HIP_DEVICE_ID_TO_IREE_DEVICE_ID(deviceId), /*param_count=*/0,
       /*params=*/nullptr, iree_allocator_system(), &rawDevice));
 
-  // Wrap the raw device ptr with a shared_ptr and custom deleter
+  // Wrap the raw device ptr with a unique_ptr and custom deleter
   // for lifetime management.
-  IreeHalDeviceSharedPtrType sharedDevice(rawDevice, IreeHalDeviceDeleter());
-
-  // Cache the device for future handles with the same configuration.
-  gpuDeviceCache[key] = sharedDevice;
-
-  device_ = sharedDevice;
+  device_ = IreeHalDeviceUniquePtrType(rawDevice);
   return ok();
 #else
   return ErrorObject(ErrorCode::InternalError,


### PR DESCRIPTION
Temporarily reverts  iree-org/fusilli#114 (and soak for a while) to see if it helps with the GPU numerical flakes as this seems suspect and matches with the timeframe when the flakes started.

### Reasoning

Device sharing could be potential source of the GPU numerical flakes, which show characteristics of buffer corruption / read/write isolation issues. 
       
  Before device sharing:                                                                                       
  - Each Handle::create() creates a NEW iree_hal_device_t                                                      
  - Each device is independent                                                                                 
  - When Handle is destroyed → device is destroyed → cleanup happens                                           
                                                                                                               
  After device sharing:                                                                                        
  - First Handle::create() creates device, caches it                                                           
  - Subsequent Handle::create() gets the SAME device from cache                                                
  - Device is only destroyed when ALL handles are gone                                                         
                                                                                                               
  The key difference: device state persists across multiple Handles/Tests.                                     
                                                                                                               
  What state could leak between tests?                                                                         
  1. ~~Async allocation cache~~ - disabled                                                                     
  2. Memory allocations         - since multiple tests share the same device                                  
  3. ~~Compiled modules/sessions~~ - this is per-graph                                                    
              
When two test cases run in parallel (`-j N`)
                                                                                                               
  1. TEST_CASE A: Creates Handle → gets/creates device → creates Graph → compiles → creates session → executes 
  → ends                                                                                                       
  2. TEST_CASE B: Creates Handle → gets SAME device from cache → creates new Graph → compiles → creates new    
  session → executes                                                                                           
                                  
                                                                                                               
The dispatch thread is per-device. With device sharing, the same dispatch thread handles work from multiple  
  tests. But that should still be serialized.        

