### PR TITLE
User rocm-sdk targets

### DIFF
--- a/include/fusilli/support/external_tools.h
+++ b/include/fusilli/support/external_tools.h
@@ -45,7 +45,7 @@ inline std::string getRocmAgentEnumeratorPath() {
 #elif defined(FUSILLI_PLATFORM_LINUX)
   return std::string("rocm_agent_enumerator");
 #else
-#error "unkonwn platform"
+#error "unknown platform"
 #endif
 }
 


### PR DESCRIPTION
Windows uses a different tool for identifying available rocm devices for compilation.