### PR TITLE
[Docker] Update CI container to 02/12 nightly

### DIFF
--- a/build_tools/docker/exec_docker_ci.sh
+++ b/build_tools/docker/exec_docker_ci.sh
@@ -20,5 +20,5 @@ docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:b3907a379b142fb357015cc5ebd7673005a16079eef0514eb4117b711a452c4d \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:660521226ed3df33160037322d83846c5a06d8c47eacc6671110b54925501331 \
            "$@"


### PR DESCRIPTION
## Summary
- Update docker container digest to use latest IREE and TheRock nightlies
- IREE: 3.11.0rc20260203 → 3.11.0rc20260212
- TheRock: 7.12.0a20260203 → 7.12.0a20260212

## Test plan
- [ ] Verify CI passes with new container
- [ ] Smoke test build and tests locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)