### PR TITLE
[IREE] Bump IREE version to 02/12 nightly

### DIFF
--- a/.github/workflows/build-and-test-win.yml
+++ b/.github/workflows/build-and-test-win.yml
@@ -42,7 +42,7 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install lit filecheck
-          python3 -m pip install --find-links https://iree.dev/pip-release-links.html iree-base-compiler==3.11.0rc20260203
+          python3 -m pip install --find-links https://iree.dev/pip-release-links.html iree-base-compiler==3.11.0rc20260212
 
           echo "${{ github.workspace }}\.venv\Scripts" >> $env:GITHUB_PATH
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ message(STATUS "  - Host")
 # Prefer to keep the IREE_GIT_TAG synced with the python-installed IREE version.
 # At a minimum, the compiler from those packages must be compatible with the
 # runtime at this source ref.
-set(IREE_GIT_TAG "iree-3.11.0rc20260203")
+set(IREE_GIT_TAG "iree-3.11.0rc20260212")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Set IREE build flags.

--- a/plugins/hipdnn-plugin/build_tools/thepebble_config.toml
+++ b/plugins/hipdnn-plugin/build_tools/thepebble_config.toml
@@ -9,4 +9,4 @@ hip_run_id = "19089392286"
 hipdnn_git_ref = "develop"
 
 # IREE git tag
-iree_git_tag = "iree-3.11.0rc20260203"
+iree_git_tag = "iree-3.11.0rc20260212"


### PR DESCRIPTION
## Summary
- Update IREE version references to 3.11.0rc20260212
- Updates in:
  - CMakeLists.txt (IREE_GIT_TAG)
  - Windows CI workflow (iree-base-compiler pip package)
  - hipdnn-plugin config (iree_git_tag)

## Context
This follows PR #156 which updated the docker container digest. This PR completes the version bump by updating all IREE version pins in the Fusilli codebase.

IREE: 3.11.0rc20260203 → 3.11.0rc20260212

## Test plan
- [ ] Verify CI passes with new IREE version
- [ ] Smoke test build and tests locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)