### PR TITLE
[Fusilli Plugin] Run previously skipped conv tests

### DIFF
--- a/plugins/hipdnn-plugin/test/integration/convolution/conv_fprop_parameterized_full.cpp
+++ b/plugins/hipdnn-plugin/test/integration/convolution/conv_fprop_parameterized_full.cpp
@@ -170,18 +170,6 @@ TEST_P(ConvFpropParameterizedTest, Correctness) {
 
   const ConvTestCase &tc = GetParam();
 
-  // Skip tests with known bugs (must be before handle creation)
-  bool hasPadding = tc.padding_[0] != 0 || tc.padding_[1] != 0;
-  bool isGrouped = tc.xDims_[1] != tc.wDims_[1];
-  bool isNHWC = tc.layoutName_ == "NHWC";
-
-  if (isNHWC && hasPadding) {
-    GTEST_SKIP() << "NHWC + padding bug (TODO #76)";
-  }
-  if (!isNHWC && isGrouped && hasPadding) {
-    GTEST_SKIP() << "NCHW, grouped conv + padding bug (TODO #72)";
-  }
-
   // Load only the fusilli plugin
   auto pluginPath = std::filesystem::canonical(getCurrentExecutableDirectory() /
                                                FUSILLI_PLUGIN_PATH);


### PR DESCRIPTION
These have been fixed in IREE and no longer produce incorrect results.


Closes: https://github.com/iree-org/fusilli/issues/72
Closes: https://github.com/iree-org/fusilli/issues/76
