### PR TITLE
[Fusilli Plugin] Use workspace in plugin

### DIFF
--- a/plugins/hipdnn-plugin/src/fusilli_plugin.cpp
+++ b/plugins/hipdnn-plugin/src/fusilli_plugin.cpp
@@ -613,8 +613,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginExecuteOpGraph(
     iree_hal_buffer_view_release(outBufferView);
   }
 
-  FUSILLI_PLUGIN_CHECK_ERROR(
-      executionContext->graph.execute(fusilliHandle, variantPack));
+  FUSILLI_PLUGIN_CHECK_ERROR(executionContext->graph.execute(
+      fusilliHandle, variantPack, /*workspace=*/nullptr));
 
   LOG_API_SUCCESS_AUTO("executed graph");
   return HIPDNN_PLUGIN_STATUS_SUCCESS;


### PR DESCRIPTION
Fixes compilation failure and maintains the current behavior of not supporting user allocated scratch memory.

https://github.com/iree-org/fusilli/blob/1190daa9bc4cdbeee314108ca75dae006310f128/plugins/hipdnn-plugin/src/fusilli_plugin.cpp#L493-L497