### PR TITLE
[Fusilli] Added missed includes in tests to fixed build warnings

### DIFF
--- a/tests/test_buffer.cpp
+++ b/tests/test_buffer.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <iree/runtime/api.h>
 
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -207,7 +208,7 @@ TEST_CASE("Buffer::allocateRaw with various sizes", "[buffer]") {
   REQUIRE(iree_hal_buffer_view_shape_dim(smallBuf, 0) == 1);
 
   // Test larger allocation (1 MB).
-  constexpr size_t oneMB = 1024 * 1024;
+  constexpr size_t oneMB = 1024lu * 1024lu;
   FUSILLI_REQUIRE_ASSIGN(Buffer largeBuf, Buffer::allocateRaw(handle, oneMB));
   REQUIRE(largeBuf != nullptr);
   REQUIRE(iree_hal_buffer_view_shape_dim(largeBuf, 0) == oneMB);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -20,8 +20,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
+
+#include <iree/runtime/api.h>
 
 using namespace fusilli;
 


### PR DESCRIPTION
Fixed warnings below
```
[312/485] Building CXX object tests/CMakeFiles/fusilli_backend_tests_test_buffer.dir/test_buffer.cpp.o
/opt/fusilli/tests/test_buffer.cpp:176:13: warning: no header providing "size_t" is directly included [misc-include-cleaner]
    7 |   constexpr size_t bufferSize = 1024;
      |             ^
/opt/fusilli/tests/test_buffer.cpp:210:28: warning: performing an implicit widening conversion to type 'const size_t' (aka 'const unsigned long') of a multiplication performed in type 'int' [bugprone-implicit-widening-of-multiplication-result]
  210 |   constexpr size_t oneMB = 1024 * 1024;
      |                            ^
/opt/fusilli/tests/test_buffer.cpp:210:28: note: make conversion explicit to silence this warning
   14 |   constexpr size_t oneMB = 1024 * 1024;
      |                            ^~~~~~~~~~~
      |                            static_cast<const size_t>( )
/opt/fusilli/tests/test_buffer.cpp:210:28: note: perform multiplication in a wider type
  210 |   constexpr size_t oneMB = 1024 * 1024;
      |                            ^~~~
      |                            static_cast<long>( )
[330/485] Building CXX object tests/CMakeFiles/fusilli_utils_tests_test_utils.dir/test_utils.cpp.o
/opt/fusilli/tests/test_utils.cpp:336:59: warning: no header providing "std::nullopt" is directly included [misc-include-cleaner]
   23 |                            allocateWorkspace(handle, std::nullopt));
      |                                                           ^
/opt/fusilli/tests/test_utils.cpp:353:5: warning: no header providing "iree_hal_buffer_view_t" is directly included [misc-include-cleaner]
   22 |     iree_hal_buffer_view_t *bufferView = *workspace;
      |     ^
/opt/fusilli/tests/test_utils.cpp:354:13: warning: no header providing "iree_hal_buffer_view_shape_rank" is directly included [misc-include-cleaner]
  354 |     REQUIRE(iree_hal_buffer_view_shape_rank(bufferView) == 1);
      |             ^
/opt/fusilli/tests/test_utils.cpp:355:13: warning: no header providing "iree_hal_buffer_view_shape_dim" is directly included [misc-include-cleaner]
  355 |     REQUIRE(iree_hal_buffer_view_shape_dim(bufferView, 0) == bufferSize);
      |             ^
[485/485] Linking CXX executable bin/benchmarks/fusilli_benchmark_driver
```