### PR TITLE
fix: Quote CXX_CLANG_TIDY property to escalate warnings as errors

### DIFF
--- a/tests/test_buffer.cpp
+++ b/tests/test_buffer.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <iree/runtime/api.h>
 
+#include <cstddef>
 #include <utility>
 #include <vector>
 
@@ -207,7 +208,7 @@ TEST_CASE("Buffer::allocateRaw with various sizes", "[buffer]") {
   REQUIRE(iree_hal_buffer_view_shape_dim(smallBuf, 0) == 1);
 
   // Test larger allocation (1 MB).
-  constexpr size_t oneMB = 1024 * 1024;
+  constexpr size_t oneMB = 1024lu * 1024lu;
   FUSILLI_REQUIRE_ASSIGN(Buffer largeBuf, Buffer::allocateRaw(handle, oneMB));
   REQUIRE(largeBuf != nullptr);
   REQUIRE(iree_hal_buffer_view_shape_dim(largeBuf, 0) == oneMB);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -20,8 +20,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
+
+#include <iree/runtime/api.h>
 
 using namespace fusilli;
 


### PR DESCRIPTION
## Summary
- The `CXX_CLANG_TIDY` property value in `set_target_properties` was unquoted, causing CMake to treat each line as a separate argument
- This silently discarded the `-warnings-as-errors=*` and `--config-file` flags, so clang-tidy warnings were never escalated to build errors
- Quoting the value ensures all flags are correctly passed as a single semicolon-separated list

🤖 Generated with [Claude Code](https://claude.com/claude-code)