### PR TITLE
[Docker] Update CI container to 02/17 nightly

### DIFF
--- a/build_tools/docker/exec_docker_ci.sh
+++ b/build_tools/docker/exec_docker_ci.sh
@@ -20,5 +20,5 @@ docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:660521226ed3df33160037322d83846c5a06d8c47eacc6671110b54925501331 \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:80ef5253f3c4f48b9aee3da47c6b13f1dc5edb4bc804e8fe0f725d278cb5a10c \
            "$@"

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "package-version": "0.0.1.dev",
-  "iree-version": "iree-3.11.0rc20260212"
+  "iree-version": "iree-3.11.0rc20260217"
 }


### PR DESCRIPTION
## Summary
- Update docker container digest to use latest IREE and TheRock nightlies
- Update IREE version references across the codebase
- IREE: 3.11.0rc20260212 → 3.11.0rc20260217
- TheRock: 7.12.0a20260212 → 7.12.0a20260217

🤖 Generated with [Claude Code](https://claude.com/claude-code)