### PR TITLE
Optimize clang-tidy CI and remove redundant CMake defaults

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -40,7 +40,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release
               -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=ON
-              -DFUSILLI_ENABLE_CLANG_TIDY=ON
           - name: cpu_clang18_debug
             runs-on: azure-linux-scale
             cmake-options:
@@ -48,7 +47,6 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
-              -DFUSILLI_SYSTEMS_AMDGPU=OFF
               -DFUSILLI_ENABLE_CLANG_TIDY=ON
           - name: gfx942_clang22_debug
             runs-on: linux-mi325-1gpu-ossci-iree-org
@@ -65,8 +63,6 @@ jobs:
               -DCMAKE_C_COMPILER=gcc-13
               -DCMAKE_CXX_COMPILER=g++-13
               -DFUSILLI_CODE_COVERAGE=ON
-              -DFUSILLI_SYSTEMS_AMDGPU=OFF
-              -DFUSILLI_ENABLE_CLANG_TIDY=ON
 
     steps:
     - name: Checkout fusilli

--- a/.github/workflows/build-and-test-win.yml
+++ b/.github/workflows/build-and-test-win.yml
@@ -61,7 +61,7 @@ jobs:
           refreshenv
       - name: "Building Fusilli"
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR_POWERSHELL}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DFUSILLI_ENABLE_LOGGING=ON -DFUSILLI_SYSTEMS_AMDGPU=OFF
+          cmake -S . -B ${{ env.BUILD_DIR_POWERSHELL}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DFUSILLI_ENABLE_LOGGING=ON
           cmake --build ${{ env.BUILD_DIR_POWERSHELL}} --config Release --target all
       - name: "Running Fusilli tests (libIREECompiler CAPI)"
         run: |

--- a/.github/workflows/flake-test.yml
+++ b/.github/workflows/flake-test.yml
@@ -68,8 +68,6 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
-              -DFUSILLI_SYSTEMS_AMDGPU=OFF
-              -DFUSILLI_ENABLE_CLANG_TIDY=OFF
           - name: gfx942_clang22_debug
             runs-on: linux-mi325-1gpu-ossci-iree-org
             cmake-options:
@@ -78,7 +76,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=ON
-              -DFUSILLI_ENABLE_CLANG_TIDY=OFF
 
     steps:
     - name: Checkout fusilli


### PR DESCRIPTION
## Summary
- Limit clang-tidy to 2 of 4 Linux CI configs (`cpu_clang18_debug` + `gfx942_clang22_debug`) instead of all 4, since results are identical across Debug/Release and the GCC coverage build can't meaningfully use it
- The two remaining configs cover all preprocessor branches: CPU paths and `FUSILLI_ENABLE_AMDGPU`-guarded GPU paths
- Remove explicit `=OFF` values for `FUSILLI_SYSTEMS_AMDGPU` and `FUSILLI_ENABLE_CLANG_TIDY` where they match the CMake defaults, across `build-and-test-linux.yml`, `build-and-test-win.yml`, and `flake-test.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)