### PR TITLE
Trim benchmark runner test commands

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -249,14 +249,6 @@ add_fusilli_benchmark(
     --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type bf16 --b_type bf16 --out_type bf16
 )
 
-# TODO(llvm/torch-mlir#4422): Uncomment after torch-mlir issue is fixed.
-# add_fusilli_benchmark(
-#   NAME fusilli_benchmark_matmul_mixed
-#   DRIVER fusilli_benchmark_driver
-#   ARGS
-#     --device 0 --iter 10 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type bf16 --out_type f32
-# )
-
 add_fusilli_benchmark(
   NAME fusilli_benchmark_matmul_fp16_transA
   DRIVER fusilli_benchmark_driver

--- a/benchmarks/test_commands.txt
+++ b/benchmarks/test_commands.txt
@@ -1,22 +1,9 @@
-# Test convolution benchmarks
+# Test one benchmark per subcommand (conv, layernorm, matmul)
 --device 0 --iter 2 conv -F 1 -n 16 -c 8 -H 8 -W 8 -k 8 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
---device 0 --iter 2 conv --bf16 -F 1 -n 16 -c 16 --in_d 2 -H 8 -W 8 -k 16 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout NDHWC --out_layout NDHWC --fil_layout NDHWC --spatial_dim 3
---device 0 --iter 2 conv --bf16 -F 2 -n 16 -c 12 -H 8 -W 8 -k 12 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 3 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
---device 0 --iter 2 conv --fp16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
-
-# Test layernorm benchmarks
 --device 0 --iter 2 layernorm -X 2x3x128 -F 1 -t f32 --layout NCH
---device 0 --iter 2 layernorm -X 2x3x128x128 -F 1 --type bf16 --layout NHWC --elementwise_affine -e 0.01
-
-# Test matmul benchmarks
 --device 0 --iter 2 matmul -M 16 -N 32 -K 64 --a_type f32 --b_type f32 --out_type f32
---device 0 --iter 2 matmul -M 16 -N 32 -K 64 -B 10 --bias --a_type f32 --b_type f32 --out_type f32 --bias_type f32
---device 0 --iter 2 matmul -M 16 -N 32 -K 64 --transA --a_type bf16 --b_type bf16 --out_type bf16
---device 0 --iter 2 matmul -M 16 -N 32 -K 64 -B 10 --transB --a_type f16 --b_type f16 --out_type f16
 
 # Test skipping benchmarks
-[SKIP] --device 0 --iter 2 conv --bf16 -F 1 -n 16 -c 384 -H 48 -W 32 -k 384 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 6 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
-[SKIP] --device 0 --iter 2 layernorm --input 2x3x128x128 -F 1 --type f16 --layout NCHW --elementwise_affine
-[SKIP] --device 0 --iter 2 matmul -M 16 -N 32 -K 64
+[SKIP] --device 0 --iter 2 conv -F 1 -n 16 -c 8 -H 8 -W 8 -k 8 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --out_layout NHWC --fil_layout NHWC --spatial_dim 2
 
 # Test empty lines and comments are ignored by the benchmark runner


### PR DESCRIPTION
## Summary
- Reduce `test_commands.txt` to one representative command per subcommand (conv, layernorm, matmul) plus one `[SKIP]` entry. The benchmark runner test validates the Python wrapper and driver infrastructure, not individual kernel correctness — redundant shape/dtype/flag variations added unnecessary JIT compilation overhead (~28 compilations down to ~8). For kernel variant specific benchmark tests, they're to be added via `add_fusilli_benchmark`. 
- Remove stale commented-out TODO benchmark from `CMakeLists.txt` (torch-mlir#4422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)