### PR TITLE
[Fusilli,FusilliPlugin] Silence `-Wc2y-extensions` warning around `__COUNTER__` usage

### DIFF
--- a/plugins/hipdnn-plugin/include/utils.h
+++ b/plugins/hipdnn-plugin/include/utils.h
@@ -94,8 +94,10 @@ findDeviceBuffer(int64_t uid, const hipdnnPluginDeviceBuffer_t *deviceBuffers,
   var = std::move(*errorOr);
 
 #define FUSILLI_PLUGIN_ASSIGN_OR_RETURN(varDecl, expr)                         \
+  FUSILLI_DISABLE_COUNTER_WARNING                                              \
   FUSILLI_PLUGIN_ASSIGN_OR_RETURN_IMPL(FUSILLI_ERROR_VAR(_errorOr), varDecl,   \
-                                       expr)
+                                       expr)                                   \
+  FUSILLI_RESTORE_COUNTER_WARNING
 
 template <typename T> fusilli::ErrorObject convertToErrorObject(T &&error) {
   using DecayT = std::decay_t<T>;

--- a/plugins/hipdnn-plugin/test/utils.h
+++ b/plugins/hipdnn-plugin/test/utils.h
@@ -26,8 +26,10 @@
 // variable, or returns the error from the enclosing function if the result is
 // an error.
 #define FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(varDecl, expr)                         \
+  FUSILLI_DISABLE_COUNTER_WARNING                                              \
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN_IMPL(                                        \
       FUSILLI_PLUGIN_ERROR_VAR(_errorOr, __LINE__, __COUNTER__), varDecl,      \
-      expr)
+      expr)                                                                    \
+  FUSILLI_RESTORE_COUNTER_WARNING
 
 #endif // FUSILLI_PLUGIN_TESTS_UTILS_H


### PR DESCRIPTION
Fusilli builds using a very new Clang  and `-Werror` (for example in [`TheRock`](https://github.com/ROCm/TheRock/tree/main/iree-libs)) will fail with `-Wc2y-extensions`. The error is warning about uses of  `__COUNTER__`, which is supported by all major compilers, though technically unstandardized and part of the upcoming C2y standard. The  `__COUNTER__` use isn't a practical problem, so we can add diagnostic push/pop macros around call sites that expand `__COUNTER__` to silence the error.

The other options are for every consumer of fusilli to add `-Wno-c2y-extensions` to their builds, or to just use `__LINE__`. The former is pretty annoying, the latter option would probably be fine though could cause an issue if anyone used multiple `FUSILLI_ASSIGN_OR_RETURN`s on one line (unlikely).

This PR follows the same pattern as https://github.com/google/benchmark/pull/2108.