### PR TITLE
Fix test cleanup to work even when REQUIRE() fails

### DIFF
--- a/tests/test_cache.cpp
+++ b/tests/test_cache.cpp
@@ -22,7 +22,7 @@ static std::string kGraphName = "test_cache";
 
 TEST_CASE("CacheFile::create remove = true", "[CacheFile]") {
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit([&] {
+  auto cleanup = ScopeExit([&] {
     std::filesystem::remove_all(
         CacheFile::getPath(kGraphName, "a").parent_path());
   });
@@ -96,7 +96,7 @@ TEST_CASE("CacheFile::create remove = true", "[CacheFile]") {
 
 TEST_CASE("CacheFile::create remove = false", "[CacheFile]") {
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit([&] {
+  auto cleanup = ScopeExit([&] {
     std::filesystem::remove_all(
         CacheFile::getPath(kGraphName, "a").parent_path());
   });
@@ -176,7 +176,7 @@ TEST_CASE("CacheFile::open", "[CacheFile]") {
                                                   /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
+  auto cleanup = ScopeExit(
       [&] { std::filesystem::remove_all(cacheFile.path.parent_path()); });
 
   FUSILLI_REQUIRE_OK(cacheFile.write("test data"));
@@ -198,7 +198,7 @@ TEST_CASE("CacheFile directory sanitization", "[CacheFile]") {
                                            /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
+  auto cleanup = ScopeExit(
       [&] { std::filesystem::remove_all(cacheFile.path.parent_path()); });
 
   // Extract the sanitized directory name from the path.

--- a/tests/test_compile_command.cpp
+++ b/tests/test_compile_command.cpp
@@ -35,8 +35,8 @@ TEST_CASE("CompileCommand::build with CPU backend", "[CompileCommand]") {
       CacheFile::create(kGraphName, "statistics.json", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write simple MLIR module to input file.
   REQUIRE(input.write(getSimpleMLIRModule()).isOk());
@@ -115,8 +115,8 @@ TEST_CASE("CompileCommand::build with AMDGPU backend", "[CompileCommand]") {
       CacheFile::create(kGraphName, "statistics.json", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write simple MLIR module to input file.
   REQUIRE(input.write(getSimpleMLIRModule()).isOk());
@@ -173,8 +173,8 @@ TEST_CASE("CompileCommand::toString format", "[CompileCommand]") {
       CacheFile::create(kGraphName, "statistics.json", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
   CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
@@ -215,8 +215,8 @@ TEST_CASE("CompileCommand::writeTo", "[CompileCommand]") {
       CacheFile::create(kGraphName, "command.txt", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
   CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
@@ -247,8 +247,8 @@ TEST_CASE("CompileCommand::getArgs", "[CompileCommand]") {
       CacheFile::create(kGraphName, "statistics.json", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
   CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
@@ -289,8 +289,8 @@ TEST_CASE("CompileCommand round-trip serialization", "[CompileCommand]") {
       CacheFile::create(kGraphName, "command.txt", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build and write command.
   CompileCommand cmd1 =

--- a/tests/test_compile_session.cpp
+++ b/tests/test_compile_session.cpp
@@ -191,8 +191,8 @@ TEST_CASE("CompileSession::compile with valid MLIR",
       CacheFile::create(kGraphName, "output.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write a simple MLIR module to the input file.
   std::string mlirContent = getSimpleMLIRModule();
@@ -230,8 +230,8 @@ TEST_CASE("CompileSession::compile with custom flags",
       CacheFile::create(kGraphName, "output_opt.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write a simple MLIR module to the input file.
   std::string mlirContent = getSimpleMLIRModule();
@@ -264,8 +264,8 @@ TEST_CASE("CompileSession::compile with invalid MLIR",
       CacheFile::create(kGraphName, "invalid.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write invalid MLIR content.
   std::string invalidMLIR = "this is not valid MLIR syntax!";
@@ -295,8 +295,8 @@ TEST_CASE("CompileSession::compile with missing input file",
       CacheFile::create(kGraphName, "missing.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Input file doesn't exist - should fail.
   auto compileResult =
@@ -342,8 +342,8 @@ TEST_CASE("CompileSession::compile with AMDGPU backend",
       CacheFile::create(kGraphName, "output_amdgpu.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write a simple MLIR module to the input file.
   std::string mlirContent = getSimpleMLIRModule();
@@ -437,8 +437,8 @@ TEST_CASE("CompileSession::build with CPU backend", "[CompileSession]") {
       CacheFile::create(kGraphName, "statistics.json", true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
@@ -476,8 +476,8 @@ TEST_CASE("CompileSession::toString format", "[CompileSession]") {
       CacheFile::create(kGraphName, "statistics.json", true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
@@ -504,8 +504,8 @@ TEST_CASE("CompileSession::writeTo", "[CompileSession]") {
                          CacheFile::create(kGraphName, "command.txt", true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
@@ -529,8 +529,8 @@ TEST_CASE("CompileSession::execute with valid MLIR", "[CompileSession]") {
       CacheFile::create(kGraphName, "statistics.json", true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write valid MLIR.
   FUSILLI_REQUIRE_OK(input.write(getSimpleMLIRModule()));
@@ -562,8 +562,8 @@ TEST_CASE("CompileSession::getArgs", "[CompileSession]") {
       CacheFile::create(kGraphName, "statistics.json", true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
@@ -625,8 +625,8 @@ TEST_CASE("CompileSession::compile with tuning spec",
       CacheFile::create(graphName, "output.vmfb", /*remove=*/true));
 
   // Ensure cleanup happens even if REQUIRE() fails.
-  auto cleanup = scope_exit(
-      [&] { std::filesystem::remove_all(input.path.parent_path()); });
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Write a simple MLIR module to the input file.
   std::string mlirContent = R"(


### PR DESCRIPTION
Motivated by the issue pointed by reviewer comments: https://github.com/iree-org/fusilli/pull/184#discussion_r2848459501, this PR add `ScopeExit` RAII helper to `tests/utils.h `that removes cache directories via destructor, ensuring cleanup happens even when tests fail.  Implementation uses std::function<void()> for simplicity.

**Assisted-by:** Claude                                            
                                                                                                                                                                                                 