### PR TITLE
[Docker] Update CI container to 02/26 nightly

### DIFF
--- a/build_tools/docker/exec_docker_ci.sh
+++ b/build_tools/docker/exec_docker_ci.sh
@@ -20,5 +20,5 @@ docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:80ef5253f3c4f48b9aee3da47c6b13f1dc5edb4bc804e8fe0f725d278cb5a10c \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:3dca8ec1a7105ea618da99625dffac21b9741721fcb545e0601803efe5b607b8 \
            "$@"

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "package-version": "0.0.1.dev",
-  "iree-version": "iree-3.11.0rc20260217"
+  "iree-version": "iree-3.11.0rc20260226"
 }


### PR DESCRIPTION
## Summary
- Update docker container digest to use latest IREE and TheRock nightlies
- IREE: 3.11.0rc20260217 → 3.11.0rc20260226
- TheRock: 7.12.0a20260217 → 7.12.0a20260226

🤖 Generated with [Claude Code](https://claude.com/claude-code)