### PR TITLE
Decouple IREE/TheRock version bumps from Docker image rebuilds

### DIFF
--- a/.github/workflows/build-and-test-win.yml
+++ b/.github/workflows/build-and-test-win.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Reading IREE version"
         run: |
           $json = Get-Content version.json | ConvertFrom-Json
-          $ireeGitTag = $json.'iree-version' -replace '^iree-', ''
+          $ireeGitTag = $json.'iree-version'
           echo "IREE_GIT_TAG=$ireeGitTag" >> $env:GITHUB_ENV
       - name: "Installing Python packages"
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,8 @@ endif()
 # Prefer to keep the IREE_GIT_TAG synced with the python-installed IREE version.
 # At a minimum, the compiler from those packages must be compatible with the
 # runtime at this source ref.
-string(JSON IREE_GIT_TAG GET ${VERSION_JSON_STRING} iree-version)
+string(JSON IREE_VERSION GET ${VERSION_JSON_STRING} iree-version)
+set(IREE_GIT_TAG "iree-${IREE_VERSION}")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Set IREE build flags.

--- a/build_tools/docker/exec_docker_ci.sh
+++ b/build_tools/docker/exec_docker_ci.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# Read versions from version.json (single source of truth)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+read -r IREE_GIT_TAG THEROCK_GIT_TAG < <(python3 -c "
+import json; d=json.load(open('${REPO_ROOT}/version.json'))
+print(d['iree-version'], d['therock-version'])")
 
 # ROCm requires accesses to the host's /dev/kfd and /dev/dri/* device nodes, typically
 # owned by the `render` and `video` groups. The groups' GIDs in the container must
@@ -7,6 +15,7 @@
 # adding user to the GIDs of named groups (obtained from `getent group render` or
 # `getent group video`), we simply check the owning GID of the device nodes on the host
 # and pass it to `docker run` with `--group-add=<GID>`.
+DOCKER_RUN_DEVICE_OPTS=""
 for DEV in /dev/kfd /dev/dri/*; do
   # Skip if not a character device
   # /dev/dri/by-path/ symlinks are ignored
@@ -18,7 +27,9 @@ done
 # - current directory to /workspace in the container
 docker run --rm \
            -v "${PWD}":/workspace \
+           -e IREE_GIT_TAG="${IREE_GIT_TAG}" \
+           -e THEROCK_GIT_TAG="${THEROCK_GIT_TAG}" \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:80ef5253f3c4f48b9aee3da47c6b13f1dc5edb4bc804e8fe0f725d278cb5a10c \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:0ae9798cc883c4c2b687d43be5612f9e1333d3cd9af20d47ec20efe8f7921c9b \
            "$@"

--- a/plugins/hipdnn-plugin/build_tools/ThePebble.py
+++ b/plugins/hipdnn-plugin/build_tools/ThePebble.py
@@ -358,7 +358,7 @@ def generate_cmake_user_presets():
         f.write("\n")
 
 
-def provide_iree_tools(iree_git_tag: str):
+def provide_iree_tools(iree_version: str):
     """Pip install iree-base-compiler and symlink IREE tools into dist/.
 
     TheRock builds libIREECompiler.so and installs it to dist/lib/; ThePebble
@@ -369,16 +369,15 @@ def provide_iree_tools(iree_git_tag: str):
     print(f"Creating venv at {venv_dir}...")
     venv.EnvBuilder(with_pip=True, prompt="ThePebble").create(venv_dir)
 
-    pip_version = iree_git_tag.replace("iree-", "")
     pip = venv_dir / "bin" / "pip"
-    print(f"Installing iree-base-compiler=={pip_version}...")
+    print(f"Installing iree-base-compiler=={iree_version}...")
     subprocess.run(
         [
             str(pip),
             "install",
             "--find-links",
             "https://iree.dev/pip-release-links.html",
-            f"iree-base-compiler=={pip_version}",
+            f"iree-base-compiler=={iree_version}",
         ],
         check=True,
     )
@@ -482,12 +481,10 @@ def test_fusilli_plugin():
     # Create iree_tag_for_pip.txt.
     # TheRock/iree-libs/post_hook_fusilliprovider.cmake would create this file
     # when building in TheRock.
-    iree_tag = get_iree_git_tag()
-    # Convert tag like "iree-3.10.0rc20251210" to pip version "3.10.0rc20251210"
-    pip_version = iree_tag.replace("iree-", "")
+    iree_version = get_iree_git_tag()
     iree_tag_file = bin_dir / "fusilli_plugin_test_infra" / "iree_tag_for_pip.txt"
-    iree_tag_file.write_text(pip_version)
-    print(f"Created {iree_tag_file} with version {pip_version}")
+    iree_tag_file.write_text(iree_version)
+    print(f"Created {iree_tag_file} with version {iree_version}")
 
     # Run TheRock's test_fusilliprovider.py
     therock_dir = PEBBLE_DIR / "TheRock"
@@ -552,7 +549,7 @@ def main():
         setup_therock(versions["therock_git_ref"])
         install_hip(versions["hip_run_id"])
         build_hipdnn(versions["hipdnn_git_ref"])
-        setup_iree(get_iree_git_tag())
+        setup_iree(f"iree-{get_iree_git_tag()}")
         build_fusilli()
         generate_cmake_user_presets()
         provide_iree_tools(get_iree_git_tag())

--- a/version.json
+++ b/version.json
@@ -1,4 +1,5 @@
 {
   "package-version": "0.0.1.dev",
-  "iree-version": "iree-3.11.0rc20260217"
+  "iree-version": "3.11.0rc20260217",
+  "therock-version": "7.12.0a20260217"
 }


### PR DESCRIPTION
## Summary

This decouples IREE/TheRock version bumps from Docker image rebuilds. The Docker image only contains system packages; actual IREE and TheRock versions are controlled via `version.json` and forwarded as environment variables at runtime.

Changes:
- Modify `exec_docker_ci.sh` to read versions from `version.json` and forward them as `-e` env vars to the Docker container
- Add `therock-version` to `version.json`, making it the single source of truth for both IREE and TheRock versions

Depends on https://github.com/sjain-stanford/docker/pull/38 (version-aware cache invalidation in entrypoint.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)