### PR TITLE
fix: Delay nightly bump schedule to avoid wheel publish race

### DIFF
--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -13,8 +13,8 @@ on:
         type: string
         description: "Branch name override (default: bump-deps/YYYY-MM-DD)"
   schedule:
-    # Weekdays at 10:00 UTC (02:00 PST / 03:00 PDT)
-    - cron: "0 10 * * 1-5"
+    # Weekdays at 12:00 UTC (04:00 PST / 05:00 PDT)
+    - cron: "0 12 * * 1-5"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Moves the nightly bump cron from 10:00 UTC (02:00 PST) to 12:00 UTC (04:00 PST) to avoid racing with IREE's nightly wheel publish
- The [03-04 bump run](https://github.com/iree-org/fusilli/actions/runs/22664864243) failed at 10:14 UTC because the `iree-base-compiler` wheel for `3.11.0rc20260304` wasn't published until ~10:31 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)