### PR TITLE
fix: Prevent stale CMake cache values when switching build configs

### DIFF
--- a/build_tools/scripts/build.sh
+++ b/build_tools/scripts/build.sh
@@ -88,6 +88,10 @@ CMAKE_OPTIONS=(
 
 if [[ -n "${IREE_SOURCE_DIR}" ]]; then
   CMAKE_OPTIONS+=("-DIREE_SOURCE_DIR=${IREE_SOURCE_DIR}")
+else
+  # IREE's project() command caches IREE_SOURCE_DIR as a STATIC entry
+  # that persists across reconfigures. Clear it and force an empty value.
+  CMAKE_OPTIONS+=("-UIREE_SOURCE_DIR" "-DIREE_SOURCE_DIR:FILEPATH=")
 fi
 
 case "${CONFIG}" in


### PR DESCRIPTION
## Summary
- Each build config in `build.sh` now explicitly sets all toggle options to `ON` or `OFF`, preventing stale CMake cache values from persisting when switching configs (e.g. `gpu-debug-tidy` → `gpu-debug` no longer leaves clang-tidy enabled)
- When `--iree-source-dir` is not passed, the stale `IREE_SOURCE_DIR` cache entry left by IREE's `project()` command is cleared so the build correctly falls back to FetchContent

🤖 Generated with [Claude Code](https://claude.com/claude-code)