### PR TITLE
feat: Add static MLIR support for custom ops

### DIFF
--- a/include/fusilli/attributes/custom_op_attributes.h
+++ b/include/fusilli/attributes/custom_op_attributes.h
@@ -30,6 +30,15 @@ public:
 
   // Sets the MLIR function definition for this custom op.
   //
+  // IMPORTANT: The MLIR function must be written in terms of logical
+  // dimensions, not physical (storage) dimensions. The emitter automatically
+  // inserts permute ops around the custom op call to convert between the
+  // physical layout of graph tensors and the logical layout expected by the
+  // custom function. For example, if a tensor has dim={4,8} with transposed
+  // stride={1,4} (physical layout [8,4]), the emitter permutes it to logical
+  // [4,8] before passing it to the custom function. The custom MLIR should
+  // therefore use [4,8], not [8,4].
+  //
   // The string may contain placeholders that are resolved at emission time
   // by `CustomOpNode::resolveMlirPlaceholders()`:
   //
@@ -37,16 +46,41 @@ public:
   //   {IN0_DTYPE}   — replaced with input 0's MLIR element type (e.g., "f32").
   //   {OUT0_DTYPE}  — replaced with output 0's MLIR element type.
   //
-  // Example:
+  // By default, shapes in the MLIR should use dynamic placeholders [?] so
+  // the function works for any tensor size. If the MLIR uses concrete static
+  // shapes instead (e.g., [4,8]), call `setIsStatic(true)` so the emitter
+  // uses matching static types in the surrounding casts and func.call
+  // signature.
+  //
+  // Example (dynamic):
   //   func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[?],{IN0_DTYPE}>,
   //                                    %arg1: !torch.vtensor<[?],{IN1_DTYPE}>)
   //                                    -> !torch.vtensor<[?],{OUT0_DTYPE}> {
   //     ...
   //   }
   //
+  // Example (static, requires setIsStatic(true)):
+  //   func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[4,8],{IN0_DTYPE}>)
+  //                                    -> !torch.vtensor<[4,8],{OUT0_DTYPE}> {
+  //     ...
+  //   }
+  //
   // If no placeholders are present, the string is emitted verbatim.
   CustomOpAttr &setMlir(const std::string &mlir) {
     mlir_ = mlir;
+    return *this;
+  }
+
+  CustomOpAttr &setNumOutputs(size_t numOutputs) {
+    numOutputs_ = numOutputs;
+    return *this;
+  }
+
+  // When true, the user-provided MLIR already has static shapes baked in.
+  // The emitter will use static types in casts and func.call signatures,
+  // making the casts identity no-ops that the compiler eliminates.
+  CustomOpAttr &setIsStatic(bool isStatic) {
+    isStatic_ = isStatic;
     return *this;
   }
 
@@ -57,15 +91,14 @@ public:
   const std::string &getMlir() const { return mlir_; }
 
   size_t getNumOutputs() const { return numOutputs_; }
-  CustomOpAttr &setNumOutputs(size_t numOutputs) {
-    numOutputs_ = numOutputs;
-    return *this;
-  }
+
+  bool isStatic() const { return isStatic_; }
 
 private:
   std::string name_;
   std::string mlir_;
   size_t numOutputs_ = 0;
+  bool isStatic_ = false;
 };
 
 } // namespace fusilli

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1524,15 +1524,16 @@ inline std::string CustomOpNode::getCallOperandNamesAsm() const {
 }
 
 // Emits CustomOpNode's call operand types in MLIR assembly format.
-// Uses dynamic (all-?) tensor types.
+// Uses dynamic (all-?) tensor types, or static logical types when
+// isStatic() is set.
 inline std::string CustomOpNode::getCallOperandTypesAsm() const {
   std::ostringstream oss;
   interleave(
       inputs.begin(), inputs.end(),
       [&](const std::shared_ptr<TensorAttr> &input) {
         oss << input->getTensorTypeAsm(/*isValueTensor=*/true,
-                                       /*useLogicalDims=*/false,
-                                       /*isDynamic=*/true);
+                                       /*useLogicalDims=*/true,
+                                       /*isDynamic=*/!customOpAttr.isStatic());
       },
       [&] { oss << ", "; });
   return oss.str();
@@ -1550,15 +1551,16 @@ inline std::string CustomOpNode::getCallResultNamesAsm() const {
 }
 
 // Emits CustomOpNode's call result types in MLIR assembly format.
-// Uses dynamic (all-?) tensor types.
+// Uses dynamic (all-?) tensor types, or static logical types when
+// isStatic() is set.
 inline std::string CustomOpNode::getCallResultTypesAsm() const {
   std::ostringstream oss;
   interleave(
       outputs.begin(), outputs.end(),
       [&](const std::shared_ptr<TensorAttr> &output) {
         oss << output->getTensorTypeAsm(/*isValueTensor=*/true,
-                                        /*useLogicalDims=*/false,
-                                        /*isDynamic=*/true);
+                                        /*useLogicalDims=*/true,
+                                        /*isDynamic=*/!customOpAttr.isStatic());
       },
       [&] { oss << ", "; });
   return oss.str();
@@ -1578,8 +1580,11 @@ inline std::string CustomOpNode::getStaticToDynamicCastAsm(
     bool isInput, const std::string &operandOverride) const {
   std::string staticType =
       tensor->getTensorTypeAsm(/*isValueTensor=*/true, /*useLogicalDims=*/true);
-  std::string dynamicType = tensor->getTensorTypeAsm(
-      /*isValueTensor=*/true, /*useLogicalDims=*/false, /*isDynamic=*/true);
+  // When isStatic(), isDynamic=false so dynamicType equals staticType,
+  // making the cast an identity no-op.
+  std::string dynamicType =
+      tensor->getTensorTypeAsm(/*isValueTensor=*/true, /*useLogicalDims=*/true,
+                               /*isDynamic=*/!customOpAttr.isStatic());
 
   std::string resultName =
       tensor->getValueNameAsm() + "_" + suffix + (isInput ? "_dyn" : "_perm");

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -85,6 +85,8 @@ add_fusilli_samples(
   PREFIX fusilli_custom_op_samples
   SRCS
     custom_op/custom_op_add.cpp
+    custom_op/custom_op_add_static.cpp
+    custom_op/custom_op_add_static_transposed.cpp
   DEPS
     libfusilli
     libutils

--- a/samples/custom_op/custom_op_add_static.cpp
+++ b/samples/custom_op/custom_op_add_static.cpp
@@ -1,0 +1,116 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+// MLIR template for a custom negate function with static shape [6].
+//
+// Unlike the dynamic variant in custom_op_add.cpp, this template uses a
+// concrete dimension — the caller must set `setIsStatic(true)` so fusilli
+// emits static types in the casts and func.call signature.
+//
+// Placeholders resolved at emission time:
+//   {FUNC_NAME}  — CustomOpAttr name (e.g., "my_neg")
+//   {IN0_DTYPE}  — input 0's MLIR element type (e.g., "f32", "f16")
+//   {OUT0_DTYPE} — output 0's MLIR element type
+static std::string getCustomNegateStaticMlir() {
+  return R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[6],{IN0_DTYPE}>)
+                                    -> !torch.vtensor<[6],{OUT0_DTYPE}> {
+    %0 = torch.aten.neg %arg0 : !torch.vtensor<[6],{IN0_DTYPE}>
+        -> !torch.vtensor<[6],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[6],{OUT0_DTYPE}>
+  }
+)";
+}
+
+// Compose a built-in pointwise add with a static custom negate to compute
+// -(a + b). The custom op MLIR has concrete shape [6] baked in rather than
+// dynamic [?] placeholders.
+TEST_CASE("Custom op static: compose built-in add with static custom negate",
+          "[custom_op][graph]") {
+  auto execute = [&]<typename T>(Handle &handle, DataType dt, T fillVal) {
+    const std::vector<int64_t> dim = {6};
+
+    auto graph = std::make_shared<Graph>();
+    graph->setName(std::format("custom_neg_static_dt{}_n{}",
+                               kDataTypeToMlirTypeAsm.at(dt), dim[0]));
+    graph->setIODataType(dt).setIntermediateDataType(dt);
+
+    auto stride =
+        generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()));
+    auto aT =
+        graph->tensor(TensorAttr().setName("a").setDim(dim).setStride(stride));
+    auto bT =
+        graph->tensor(TensorAttr().setName("b").setDim(dim).setStride(stride));
+
+    // Step 1: Built-in pointwise add.
+    auto pwAttr =
+        PointwiseAttr().setMode(PointwiseAttr::Mode::ADD).setName("pw");
+    auto pwOut = graph->pointwise(aT, bT, pwAttr);
+
+    // Step 2: Custom negate with static MLIR — shapes are baked into the
+    // function definition so we set setIsStatic(true).
+    CustomOpAttr negAttr;
+    negAttr.setName("my_neg")
+        .setMlir(getCustomNegateStaticMlir())
+        .setNumOutputs(1)
+        .setIsStatic(true);
+
+    auto outs = graph->customOp({pwOut}, negAttr);
+
+    // IMPORTANT: Unlike built-in ops, custom op outputs cannot be inferred.
+    // You must manually set dim, stride, and dataType on each output.
+    outs[0]->setDim(dim).setStride(stride).setDataType(dt).setOutput(true);
+
+    FUSILLI_REQUIRE_OK(graph->validate());
+    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto aBuf, allocateBufferOfType(handle, aT, dt, double(fillVal)));
+    FUSILLI_REQUIRE_ASSIGN(
+        auto bBuf, allocateBufferOfType(handle, bT, dt, double(fillVal)));
+    FUSILLI_REQUIRE_ASSIGN(auto outBuf,
+                           allocateBufferOfType(handle, outs[0], dt, 0.0));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    // Verify: -(a + b) where all elements are fillVal → -(2 * fillVal).
+    std::vector<T> result;
+    FUSILLI_REQUIRE_OK(outBuf->read(handle, result));
+
+    T expected = T(-2.0 * double(fillVal));
+    for (const auto &val : result)
+      REQUIRE(val == expected);
+  };
+
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  // Float32
+  execute(handle, DataType::Float, /*fillVal=*/3.0f);
+  // Float16
+  execute(handle, DataType::Half, /*fillVal=*/half(1.5));
+}

--- a/samples/custom_op/custom_op_add_static_transposed.cpp
+++ b/samples/custom_op/custom_op_add_static_transposed.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+// MLIR template for a custom negate function with static shape [4,8].
+//
+// Uses logical dimensions — the permute ops in the emitter handle
+// physical-to-logical conversion before the call.
+static std::string getCustomNegateStaticMlir() {
+  return R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[4,8],{IN0_DTYPE}>)
+                                    -> !torch.vtensor<[4,8],{OUT0_DTYPE}> {
+    %0 = torch.aten.neg %arg0 : !torch.vtensor<[4,8],{IN0_DTYPE}>
+        -> !torch.vtensor<[4,8],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[4,8],{OUT0_DTYPE}>
+  }
+)";
+}
+
+// Compose a built-in pointwise add with a static custom negate where one
+// input is transposed. This exercises the physical-to-logical permute path:
+//   a: contiguous dim={4,8} stride={8,1} — physical matches logical
+//   b: transposed  dim={4,8} stride={1,4} — physical layout is [8,4]
+// The permute converts b from physical [8,4] to logical [4,8] before the
+// static func.call which expects [4,8].
+TEST_CASE(
+    "Custom op static transposed: add with transposed input + static negate",
+    "[custom_op][graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName("custom_neg_static_transposed");
+  graph->setIODataType(DataType::Float)
+      .setIntermediateDataType(DataType::Float);
+
+  // Contiguous: dim={4,8}, stride={8,1}.
+  auto aT =
+      graph->tensor(TensorAttr().setName("a").setDim({4, 8}).setStride({8, 1}));
+
+  // Transposed: dim={4,8}, stride={1,4} — physical layout is [8,4].
+  auto bT =
+      graph->tensor(TensorAttr().setName("b").setDim({4, 8}).setStride({1, 4}));
+
+  // Step 1: Built-in pointwise add.
+  auto pwAttr = PointwiseAttr().setMode(PointwiseAttr::Mode::ADD).setName("pw");
+  auto pwOut = graph->pointwise(aT, bT, pwAttr);
+
+  // Step 2: Custom negate with static MLIR using logical shape [4,8].
+  CustomOpAttr negAttr;
+  negAttr.setName("my_neg")
+      .setMlir(getCustomNegateStaticMlir())
+      .setNumOutputs(1)
+      .setIsStatic(true);
+
+  auto outs = graph->customOp({pwOut}, negAttr);
+  outs[0]
+      ->setDim({4, 8})
+      .setStride({8, 1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+  FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+  float fillVal = 3.0f;
+  FUSILLI_REQUIRE_ASSIGN(
+      auto aBuf,
+      allocateBufferOfType(handle, aT, DataType::Float, double(fillVal)));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto bBuf,
+      allocateBufferOfType(handle, bT, DataType::Float, double(fillVal)));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto outBuf, allocateBufferOfType(handle, outs[0], DataType::Float, 0.0));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
+
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+
+  FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+  // Verify: -(a + b) where all elements are 3.0f → -6.0f.
+  std::vector<float> result;
+  FUSILLI_REQUIRE_OK(outBuf->read(handle, result));
+
+  float expected = -2.0f * fillVal;
+  for (const auto &val : result)
+    REQUIRE(val == expected);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,8 +168,11 @@ add_fusilli_lit_tests(
     lit/test_matmul_asm_emitter_broadcast_4D.cpp
     lit/test_matmul_asm_emitter_noncontiguous.cpp
     lit/test_custom_op_asm_emitter.cpp
+    lit/test_custom_op_asm_emitter_static.cpp
+    lit/test_custom_op_asm_emitter_static_transposed.cpp
     lit/test_custom_op_asm_emitter_dup_input.cpp
     lit/test_custom_op_asm_emitter_multi_output.cpp
+    lit/test_custom_op_asm_emitter_multi_output_static.cpp
     lit/test_custom_op_asm_emitter_mixed_dtype.cpp
     lit/test_custom_op_asm_emitter_sdpa.cpp
     lit/test_reduction_asm_emitter_sum.cpp

--- a/tests/lit/test_custom_op_asm_emitter_multi_output_static.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_multi_output_static.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s
+
+// Verifies multi-output custom op ASM emission with setIsStatic(true):
+//   - Module-scope function with static shapes and multiple return types
+//   - %name:N multi-result func.call syntax with static types
+//   - #0 and #1 result indexing in static-to-static (identity) casts
+
+// clang-format off
+//
+// CHECK:       module @module {
+// CHECK:         func.func private @my_split(%arg0: !torch.vtensor<[4],f32>)
+// CHECK:             -> (!torch.vtensor<[4],f32>, !torch.vtensor<[4],f32>) {
+// CHECK:           return %arg0, %arg0 : !torch.vtensor<[4],f32>, !torch.vtensor<[4],f32>
+// CHECK:         }
+// CHECK:         func.func @main(
+// CHECK-SAME:      %{{[^:]*}}: !torch.tensor<[4],f32>
+// CHECK-SAME:      %{{[^:]*}}: !torch.tensor<[4],f32>
+// CHECK-SAME:      %a: !torch.vtensor<[4],f32>
+// CHECK:           %{{.*}} = torch.tensor_static_info_cast %{{.*}} : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           %{{.*}}:2 = func.call @my_split(%{{.*}}) : (!torch.vtensor<[4],f32>) -> (!torch.vtensor<[4],f32>, !torch.vtensor<[4],f32>)
+// CHECK:           %{{.*}} = torch.tensor_static_info_cast %{{.*}}#0 : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           %{{.*}} = torch.tensor_static_info_cast %{{.*}}#1 : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           torch.overwrite.tensor.contents %{{.*}} overwrites %{{.*}}
+// CHECK:           torch.overwrite.tensor.contents %{{.*}} overwrites %{{.*}}
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main() {
+  Graph g;
+  g.setName("custom_op_asm_emitter_multi_output_static")
+      .setIODataType(DataType::Float);
+
+  auto a =
+      g.tensor(TensorAttr().setName("a").setDim({4}).setStride({1}).setDataType(
+          DataType::Float));
+
+  // Static MLIR: shapes are baked in as [4] instead of [?] placeholders.
+  std::string splitMlir = R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[4],{IN0_DTYPE}>)
+      -> (!torch.vtensor<[4],{OUT0_DTYPE}>, !torch.vtensor<[4],{OUT1_DTYPE}>) {
+    return %arg0, %arg0 : !torch.vtensor<[4],{OUT0_DTYPE}>, !torch.vtensor<[4],{OUT1_DTYPE}>
+  }
+)";
+
+  CustomOpAttr splitAttr;
+  splitAttr.setName("my_split")
+      .setMlir(splitMlir)
+      .setNumOutputs(2)
+      .setIsStatic(true);
+
+  auto outs = g.customOp({a}, splitAttr);
+  outs[0]
+      ->setDim({4})
+      .setStride({1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+  outs[1]
+      ->setDim({4})
+      .setStride({1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  auto status = g.validate();
+  if (isError(status)) {
+    std::cerr << "Validation failed: " << status << std::endl;
+    return 1;
+  }
+
+  auto asmOrErr = g.emitAsm();
+  if (isError(asmOrErr)) {
+    std::cerr << "ASM emission failed: " << asmOrErr << std::endl;
+    return 1;
+  }
+
+  auto indentErr = checkMlirIndentation(*asmOrErr);
+  if (isError(indentErr)) {
+    std::cerr << "Indentation check failed: " << indentErr << std::endl;
+    return 1;
+  }
+
+  std::cout << *asmOrErr << std::endl;
+  return 0;
+}

--- a/tests/lit/test_custom_op_asm_emitter_static.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_static.cpp
@@ -1,0 +1,108 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s
+
+// Verifies custom op ASM emission with setIsStatic(true):
+//   - Module-scope function uses static shapes (not dynamic ?)
+//   - Casts are static -> static (identity no-ops)
+//   - func.call uses static types in signature
+
+// clang-format off
+//
+// CHECK:       module @module {
+// CHECK:         func.func private @my_add(%arg0: !torch.vtensor<[4],f32>,
+// CHECK:                                    %arg1: !torch.vtensor<[4],f32>)
+// CHECK:                                    -> !torch.vtensor<[4],f32> {
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+// CHECK:               : !torch.vtensor<[4],f32>, !torch.vtensor<[4],f32>, !torch.int
+// CHECK:               -> !torch.vtensor<[4],f32>
+// CHECK:           return %0 : !torch.vtensor<[4],f32>
+// CHECK:         }
+// CHECK:         func.func @main(
+// CHECK-SAME:      %my_add_OUT_0_: !torch.tensor<[4],f32>
+// CHECK-SAME:      %a: !torch.vtensor<[4],f32>
+// CHECK-SAME:      %b: !torch.vtensor<[4],f32>
+// CHECK:           %a_my_add_i0_perm = torch.aten.permute %a
+// CHECK:           %a_my_add_i0_dyn = torch.tensor_static_info_cast %a_my_add_i0_perm : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           %b_my_add_i1_perm = torch.aten.permute %b
+// CHECK:           %b_my_add_i1_dyn = torch.tensor_static_info_cast %b_my_add_i1_perm : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           %my_add_OUT_0_my_add_dyn = func.call @my_add(%a_my_add_i0_dyn, %b_my_add_i1_dyn) : (!torch.vtensor<[4],f32>, !torch.vtensor<[4],f32>) -> !torch.vtensor<[4],f32>
+// CHECK:           %my_add_OUT_0_my_add_perm = torch.tensor_static_info_cast %my_add_OUT_0_my_add_dyn : !torch.vtensor<[4],f32> to !torch.vtensor<[4],f32>
+// CHECK:           %my_add_OUT_0 = torch.aten.permute %my_add_OUT_0_my_add_perm
+// CHECK:           torch.overwrite.tensor.contents %my_add_OUT_0 overwrites %my_add_OUT_0_
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main() {
+  Graph g;
+  g.setName("custom_op_asm_emitter_static").setIODataType(DataType::Float);
+
+  auto a =
+      g.tensor(TensorAttr().setName("a").setDim({4}).setStride({1}).setDataType(
+          DataType::Float));
+  auto b =
+      g.tensor(TensorAttr().setName("b").setDim({4}).setStride({1}).setDataType(
+          DataType::Float));
+
+  // Static MLIR: shapes are baked in as [4] instead of [?] placeholders.
+  std::string addMlir = R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[4],{IN0_DTYPE}>,
+                                   %arg1: !torch.vtensor<[4],{IN1_DTYPE}>)
+                                   -> !torch.vtensor<[4],{OUT0_DTYPE}> {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : !torch.vtensor<[4],{IN0_DTYPE}>, !torch.vtensor<[4],{IN1_DTYPE}>, !torch.int
+        -> !torch.vtensor<[4],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[4],{OUT0_DTYPE}>
+  }
+)";
+
+  CustomOpAttr addAttr;
+  addAttr.setName("my_add").setMlir(addMlir).setNumOutputs(1).setIsStatic(true);
+
+  auto outs = g.customOp({a, b}, addAttr);
+  outs[0]
+      ->setDim({4})
+      .setStride({1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  auto status = g.validate();
+  if (isError(status)) {
+    std::cerr << "Validation failed: " << status << std::endl;
+    return 1;
+  }
+
+  auto asmOrErr = g.emitAsm();
+  if (isError(asmOrErr)) {
+    std::cerr << "ASM emission failed: " << asmOrErr << std::endl;
+    return 1;
+  }
+
+  auto indentErr = checkMlirIndentation(*asmOrErr);
+  if (isError(indentErr)) {
+    std::cerr << "Indentation check failed: " << indentErr << std::endl;
+    return 1;
+  }
+
+  std::cout << *asmOrErr << std::endl;
+  return 0;
+}

--- a/tests/lit/test_custom_op_asm_emitter_static_transposed.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_static_transposed.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s
+
+// Verifies static custom op ASM emission with transposed inputs:
+//   - Input b has dim={4,8} with stride={1,4} (column-major / transposed),
+//     so physical layout is [8,4] while logical layout is [4,8]
+//   - Permute converts physical [8,4] -> logical [4,8] before the cast
+//   - Static casts and func.call use logical dims [4,8] (not physical [8,4])
+
+// clang-format off
+//
+// CHECK:       module @module {
+// CHECK:         func.func private @my_add(%arg0: !torch.vtensor<[4,8],f32>,
+// CHECK:                                    %arg1: !torch.vtensor<[4,8],f32>)
+// CHECK:                                    -> !torch.vtensor<[4,8],f32> {
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+// CHECK:               : !torch.vtensor<[4,8],f32>, !torch.vtensor<[4,8],f32>, !torch.int
+// CHECK:               -> !torch.vtensor<[4,8],f32>
+// CHECK:           return %0 : !torch.vtensor<[4,8],f32>
+// CHECK:         }
+// CHECK:         func.func @main(%my_add_OUT_0_: !torch.tensor<[4,8],f32>, %a: !torch.vtensor<[4,8],f32>, %b: !torch.vtensor<[8,4],f32>)
+// CHECK:           %a_my_add_i0_perm = torch.aten.permute %a, %permute_IN_0_my_add_i0 : !torch.vtensor<[4,8],f32>, !torch.list<int> -> !torch.vtensor<[4,8],f32>
+// CHECK:           %a_my_add_i0_dyn = torch.tensor_static_info_cast %a_my_add_i0_perm : !torch.vtensor<[4,8],f32> to !torch.vtensor<[4,8],f32>
+// CHECK:           %b_my_add_i1_perm = torch.aten.permute %b, %permute_IN_1_my_add_i1 : !torch.vtensor<[8,4],f32>, !torch.list<int> -> !torch.vtensor<[4,8],f32>
+// CHECK:           %b_my_add_i1_dyn = torch.tensor_static_info_cast %b_my_add_i1_perm : !torch.vtensor<[4,8],f32> to !torch.vtensor<[4,8],f32>
+// CHECK:           %my_add_OUT_0_my_add_dyn = func.call @my_add(%a_my_add_i0_dyn, %b_my_add_i1_dyn) : (!torch.vtensor<[4,8],f32>, !torch.vtensor<[4,8],f32>) -> !torch.vtensor<[4,8],f32>
+// CHECK:           %my_add_OUT_0_my_add_perm = torch.tensor_static_info_cast %my_add_OUT_0_my_add_dyn : !torch.vtensor<[4,8],f32> to !torch.vtensor<[4,8],f32>
+// CHECK:           %my_add_OUT_0 = torch.aten.permute %my_add_OUT_0_my_add_perm, %permute_OUT_0_my_add : !torch.vtensor<[4,8],f32>, !torch.list<int> -> !torch.vtensor<[4,8],f32>
+// CHECK:           torch.overwrite.tensor.contents %my_add_OUT_0 overwrites %my_add_OUT_0_ : !torch.vtensor<[4,8],f32>, !torch.tensor<[4,8],f32>
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main() {
+  Graph g;
+  g.setName("custom_op_asm_emitter_static_transposed")
+      .setIODataType(DataType::Float);
+
+  // Contiguous: dim={4,8}, stride={8,1} — physical matches logical.
+  auto a = g.tensor(
+      TensorAttr().setName("a").setDim({4, 8}).setStride({8, 1}).setDataType(
+          DataType::Float));
+
+  // Transposed: dim={4,8}, stride={1,4} — physical layout is [8,4].
+  auto b = g.tensor(
+      TensorAttr().setName("b").setDim({4, 8}).setStride({1, 4}).setDataType(
+          DataType::Float));
+
+  // Static MLIR with logical shapes [4,8] baked in.
+  std::string addMlir = R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[4,8],{IN0_DTYPE}>,
+                                   %arg1: !torch.vtensor<[4,8],{IN1_DTYPE}>)
+                                   -> !torch.vtensor<[4,8],{OUT0_DTYPE}> {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : !torch.vtensor<[4,8],{IN0_DTYPE}>, !torch.vtensor<[4,8],{IN1_DTYPE}>, !torch.int
+        -> !torch.vtensor<[4,8],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[4,8],{OUT0_DTYPE}>
+  }
+)";
+
+  CustomOpAttr addAttr;
+  addAttr.setName("my_add").setMlir(addMlir).setNumOutputs(1).setIsStatic(true);
+
+  auto outs = g.customOp({a, b}, addAttr);
+  outs[0]
+      ->setDim({4, 8})
+      .setStride({8, 1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  auto status = g.validate();
+  if (isError(status)) {
+    std::cerr << "Validation failed: " << status << std::endl;
+    return 1;
+  }
+
+  auto asmOrErr = g.emitAsm();
+  if (isError(asmOrErr)) {
+    std::cerr << "ASM emission failed: " << asmOrErr << std::endl;
+    return 1;
+  }
+
+  auto indentErr = checkMlirIndentation(*asmOrErr);
+  if (isError(indentErr)) {
+    std::cerr << "Indentation check failed: " << indentErr << std::endl;
+    return 1;
+  }
+
+  std::cout << *asmOrErr << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Adds `setIsStatic(bool)` / `isStatic()` on `CustomOpAttr` so users can declare their MLIR already has static shapes baked in
- When enabled, the emitter uses static types in casts and `func.call` signatures, making the `torch.tensor_static_info_cast` ops identity no-ops that the compiler eliminates
- Adds lit tests for single-output, multi-output, and transposed-input static custom ops, all validated with `iree-opt --verify-roundtrip`
- Adds end-to-end samples for both contiguous and transposed inputs, verifying correctness across f32 and f16

🤖 Generated with [Claude Code](https://claude.com/claude-code)