### PR TITLE
fix: Add direct `#include <utility>` to fix misc-include-cleaner errors

### DIFF
--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using namespace fusilli;

--- a/tests/test_compile_session.cpp
+++ b/tests/test_compile_session.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace fusilli;

--- a/tests/test_custom_op.cpp
+++ b/tests/test_custom_op.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using namespace fusilli;

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -24,7 +24,6 @@
 #include <functional>
 #include <sstream>
 #include <string>
-#include <utility> // IWYU pragma: export
 #include <vector>
 
 // RAII helper to execute cleanup code when going out of scope, even if


### PR DESCRIPTION
## Summary

- Add direct `#include <utility>` to `benchmarks/driver.cpp`, `tests/test_compile_session.cpp`, and `tests/test_custom_op.cpp` to satisfy `misc-include-cleaner` clang-tidy checks for `std::move` and `std::pair`
- Remove the transitive `#include <utility>` IWYU pragma export from `tests/utils.h` since each consumer now includes it directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)