### PR TITLE
[WIP] Add CustomOp import in hipdnn-plugin

### DIFF
--- a/plugins/hipdnn-plugin/include/custom_op_opaque_data.h
+++ b/plugins/hipdnn-plugin/include/custom_op_opaque_data.h
@@ -1,0 +1,52 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// Serialization format for the opaque_data payload in CustomOpAttributes.
+// hipDNN treats this payload as opaque bytes; the fusilli plugin interprets it
+// as JSON with the schema below.
+//
+// Both the plugin (deserialization) and integration tests (serialization)
+// include this header.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FUSILLI_PLUGIN_INCLUDE_CUSTOM_OP_OPAQUE_DATA_H
+#define FUSILLI_PLUGIN_INCLUDE_CUSTOM_OP_OPAQUE_DATA_H
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct CustomOpOpaqueData {
+  std::string mlir;
+  uint32_t numOutputs = 0;
+  bool isStatic = false;
+
+  // Serialize to opaque byte vector (for hipDNN side / tests).
+  static std::vector<uint8_t> serialize(const std::string &mlir,
+                                        uint32_t numOutputs, bool isStatic) {
+    nlohmann::json j;
+    j["mlir"] = mlir;
+    j["num_outputs"] = numOutputs;
+    j["is_static"] = isStatic;
+    auto str = j.dump();
+    return {str.begin(), str.end()};
+  }
+
+  // Deserialize from opaque byte vector (for plugin side).
+  static CustomOpOpaqueData deserialize(const uint8_t *data, size_t size) {
+    auto j = nlohmann::json::parse(data, data + size);
+    return {.mlir = j.at("mlir").get<std::string>(),
+            .numOutputs = j.at("num_outputs").get<uint32_t>(),
+            .isStatic = j.value("is_static", false)};
+  }
+};
+
+#endif // FUSILLI_PLUGIN_INCLUDE_CUSTOM_OP_OPAQUE_DATA_H

--- a/plugins/hipdnn-plugin/include/graph_import.h
+++ b/plugins/hipdnn-plugin/include/graph_import.h
@@ -16,12 +16,15 @@
 
 #include <fusilli.h>
 #include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/custom_op_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "custom_op_opaque_data.h"
 
 #include <format>
 #include <memory>
@@ -163,6 +166,10 @@ private:
       FUSILLI_CHECK_ERROR(
           importMatmulAttr(node.attributes_as_MatmulAttributes()));
       break;
+    case hipdnn_data_sdk::data_objects::NodeAttributes::CustomOpAttributes:
+      FUSILLI_CHECK_ERROR(
+          importCustomOpAttr(node.attributes_as_CustomOpAttributes()));
+      break;
     default:
       return fusilli::error(fusilli::ErrorCode::NotImplemented,
                             "Unsupported node type.");
@@ -298,6 +305,50 @@ private:
     // Import node output.
     FUSILLI_CHECK_ERROR(
         importNodeOutput(hipDnnMatmulAttr->c_tensor_uid(), "c", c));
+
+    return fusilli::ok();
+  }
+
+  fusilli::ErrorObject importCustomOpAttr(
+      const hipdnn_data_sdk::data_objects::CustomOpAttributes *hipDnnAttr) {
+    // Only import custom ops targeting this plugin.
+    std::string customOpId = hipDnnAttr->custom_op_id()->str();
+    if (!customOpId.starts_with("fusilli.")) {
+      return fusilli::error(
+          fusilli::ErrorCode::NotImplemented,
+          std::format("Custom op id '{}' does not target the fusilli plugin. "
+                      "Expected 'fusilli.<operation>' prefix.",
+                      customOpId));
+    }
+
+    // Deserialize JSON opaque data.
+    auto opaqueData = CustomOpOpaqueData::deserialize(
+        hipDnnAttr->data()->data(), hipDnnAttr->data()->size());
+
+    // Import input tensors (variable-length).
+    std::vector<std::shared_ptr<fusilli::TensorAttr>> inputs;
+    for (auto uid : *hipDnnAttr->input_tensor_uids()) {
+      FUSILLI_ASSIGN_OR_RETURN(auto tensor, importNodeInput(uid, "custom_in"));
+      inputs.push_back(std::move(tensor));
+    }
+
+    // Build fusilli CustomOpAttr.
+    auto fusilliAttr = fusilli::CustomOpAttr()
+                           .setName(customOpId)
+                           .setMlir(opaqueData.mlir)
+                           .setNumOutputs(opaqueData.numOutputs)
+                           .setIsStatic(opaqueData.isStatic);
+
+    // Create custom op node in fusilli graph.
+    auto outputTensors = fusilliGraph.customOp(inputs, fusilliAttr);
+
+    // Import output tensors.
+    auto *outputUids = hipDnnAttr->output_tensor_uids();
+    for (size_t i = 0; i < outputUids->size(); ++i) {
+      FUSILLI_CHECK_ERROR(importNodeOutput(
+          outputUids->Get(static_cast<flatbuffers::uoffset_t>(i)), "custom_out",
+          outputTensors[i]));
+    }
 
     return fusilli::ok();
   }

--- a/plugins/hipdnn-plugin/test/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_fusilli_plugin_test(
     GTest::gtest_main
     hipdnn_plugin_sdk
     hipdnn_data_sdk
+    hipdnn_frontend
 )
 
 # Integration tests

--- a/plugins/hipdnn-plugin/test/integration/CMakeLists.txt
+++ b/plugins/hipdnn-plugin/test/integration/CMakeLists.txt
@@ -154,3 +154,18 @@ add_fusilli_plugin_test(
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
 )
+
+add_fusilli_plugin_test(
+  NAME fusilli_plugin_simple_custom_op_test
+  SRCS custom_op/simple_custom_op.cpp
+  DEPS
+    GTest::gtest_main
+    hip::host
+    hipdnn_frontend
+    hipdnn_plugin_sdk
+    hipdnn_data_sdk
+    hipdnn_test_sdk
+    Threads::Threads
+  COMPILE_DEFS
+    FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
+)

--- a/plugins/hipdnn-plugin/test/integration/custom_op/simple_custom_op.cpp
+++ b/plugins/hipdnn-plugin/test/integration/custom_op/simple_custom_op.cpp
@@ -1,0 +1,156 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <hipdnn_backend.h>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/attributes/CustomOpAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "custom_op_opaque_data.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+
+// MLIR for element-wise add with dynamic shapes.
+static std::string getCustomAddMlir() {
+  return R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[?],{IN0_DTYPE}>,
+                                   %arg1: !torch.vtensor<[?],{IN1_DTYPE}>)
+                                   -> !torch.vtensor<[?],{OUT0_DTYPE}> {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : !torch.vtensor<[?],{IN0_DTYPE}>,
+          !torch.vtensor<[?],{IN1_DTYPE}>,
+          !torch.int
+        -> !torch.vtensor<[?],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[?],{OUT0_DTYPE}>
+  }
+)";
+}
+
+class CustomOpIntegrationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    ASSERT_EQ(hipInit(0), hipSuccess);
+    ASSERT_EQ(hipSetDevice(0), hipSuccess);
+    ASSERT_EQ(hipStreamCreate(&stream), hipSuccess);
+
+    auto pluginPath = std::filesystem::canonical(
+        getCurrentExecutableDirectory() / FUSILLI_PLUGIN_PATH);
+    const std::array<const char *, 1> paths = {pluginPath.c_str()};
+    ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(),
+                                             HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+              HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnSetStream(handle, stream), HIPDNN_STATUS_SUCCESS);
+  }
+
+  void TearDown() override {
+    ASSERT_EQ(hipStreamDestroy(stream), HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+  }
+
+  hipStream_t stream = nullptr;
+  hipdnnHandle_t handle;
+};
+
+// Test: custom_op element-wise add via MLIR.
+// Graph: in0[4] + in1[4] -> custom_op(add) -> out[4]
+TEST_F(CustomOpIntegrationTest, SimpleCustomAdd) {
+  const int64_t N = 4;
+
+  // UIDs.
+  const int64_t in0UID = 0;
+  const int64_t in1UID = 1;
+  const int64_t outUID = 2;
+
+  // Initialize tensors.
+  PinnedTensor<float> in0Tensor({N});
+  PinnedTensor<float> in1Tensor({N});
+  PinnedTensor<float> outTensor({N});
+  in0Tensor.fillWithValue(3.0f);
+  in1Tensor.fillWithValue(5.0f);
+  outTensor.fillWithValue(-100.0f);
+
+  // Expected: 3.0 + 5.0 = 8.0.
+  PinnedTensor<float> expectedOutput({N});
+  expectedOutput.fillWithValue(8.0f);
+
+  // Create graph.
+  auto graphPtr = std::make_shared<graph::Graph>();
+  graphPtr->set_name("custom_add_test");
+  graphPtr->set_io_data_type(DataType_t::FLOAT)
+      .set_intermediate_data_type(DataType_t::FLOAT)
+      .set_compute_data_type(DataType_t::FLOAT);
+
+  // Create input tensor attributes.
+  auto in0Attr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("in0", DataType_t::FLOAT, in0Tensor));
+  in0Attr->set_uid(in0UID);
+  auto in1Attr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("in1", DataType_t::FLOAT, in1Tensor));
+  in1Attr->set_uid(in1UID);
+
+  // Build JSON opaque data with MLIR add template.
+  auto opaqueData = CustomOpOpaqueData::serialize(
+      getCustomAddMlir(), /*numOutputs=*/1, /*isStatic=*/false);
+
+  // Create custom op attributes.
+  graph::CustomOpAttributes customAttr;
+  customAttr.set_name("my_add")
+      .set_custom_op_id("fusilli.my_add")
+      .set_data(opaqueData);
+
+  // Create custom op node.
+  auto outputs = graphPtr->custom_op({in0Attr, in1Attr}, 1, customAttr);
+  outputs[0]->set_uid(outUID);
+  outputs[0]
+      ->set_dim(outTensor.dims())
+      .set_stride(outTensor.strides())
+      .set_output(true);
+
+  // Build + validate + build plans for graph.
+  auto result = graphPtr->validate();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graphPtr->build_operation_graph(handle);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graphPtr->create_execution_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graphPtr->check_support();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graphPtr->build_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Create variant pack.
+  std::unordered_map<int64_t, void *> variantPack;
+  variantPack[in0UID] = in0Tensor.memory().deviceData();
+  variantPack[in1UID] = in1Tensor.memory().deviceData();
+  variantPack[outUID] = outTensor.memory().deviceData();
+
+  // Execute graph.
+  result = graphPtr->execute(handle, variantPack, nullptr);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+  outTensor.memory().markDeviceModified();
+
+  // Check results.
+  CpuFpReferenceValidation<float> validator(1e-6f, 1e-6f);
+  EXPECT_TRUE(validator.allClose(expectedOutput, outTensor));
+}

--- a/plugins/hipdnn-plugin/test/test_graph_import.cpp
+++ b/plugins/hipdnn-plugin/test/test_graph_import.cpp
@@ -10,6 +10,11 @@
 #include <fusilli.h>
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/attributes/CustomOpAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+
+#include "custom_op_opaque_data.h"
 
 TEST(TestGraphImport, ConvertHipDnnToFusilli) {
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
@@ -44,4 +49,123 @@ TEST(TestGraphImport, ConvertHipDnnToFusilli) {
   auto invalidResult = hipDnnDataTypeToFusilliDataType(
       static_cast<hipdnn_data_sdk::data_objects::DataType>(42));
   EXPECT_TRUE(isError(invalidResult));
+}
+
+// Build a hipDNN frontend custom op graph and serialize to flatbuffer.
+// The customOpId parameter controls the custom_op_id field.
+static flatbuffers::DetachedBuffer
+buildCustomOpGraph(const std::string &customOpId = "fusilli.my_add") {
+  using namespace hipdnn_frontend;
+
+  graph::Graph graph;
+  graph.set_name("custom_add_import_test")
+      .set_io_data_type(DataType::FLOAT)
+      .set_compute_data_type(DataType::FLOAT)
+      .set_intermediate_data_type(DataType::FLOAT);
+
+  // Input tensors.
+  auto in0 = std::make_shared<graph::TensorAttributes>();
+  in0->set_uid(0)
+      .set_name("in0")
+      .set_data_type(DataType::FLOAT)
+      .set_dim({4})
+      .set_stride({1});
+  auto in1 = std::make_shared<graph::TensorAttributes>();
+  in1->set_uid(1)
+      .set_name("in1")
+      .set_data_type(DataType::FLOAT)
+      .set_dim({4})
+      .set_stride({1});
+
+  // Opaque data: MLIR add + numOutputs=1.
+  std::string mlir = R"(
+  func.func private @{FUNC_NAME}(%arg0: !torch.vtensor<[?],{IN0_DTYPE}>,
+                                   %arg1: !torch.vtensor<[?],{IN1_DTYPE}>)
+                                   -> !torch.vtensor<[?],{OUT0_DTYPE}> {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : !torch.vtensor<[?],{IN0_DTYPE}>,
+          !torch.vtensor<[?],{IN1_DTYPE}>,
+          !torch.int
+        -> !torch.vtensor<[?],{OUT0_DTYPE}>
+    return %0 : !torch.vtensor<[?],{OUT0_DTYPE}>
+  }
+)";
+  auto opaqueData = CustomOpOpaqueData::serialize(mlir, 1, false);
+
+  graph::CustomOpAttributes customAttr;
+  customAttr.set_name("my_add")
+      .set_custom_op_id(customOpId)
+      .set_data(opaqueData);
+
+  auto outputs = graph.custom_op({in0, in1}, 1, customAttr);
+  outputs[0]
+      ->set_uid(2)
+      .set_name("out0")
+      .set_data_type(DataType::FLOAT)
+      .set_dim({4})
+      .set_stride({1})
+      .set_output(true);
+
+  auto result = graph.validate();
+  if (result.is_bad()) {
+    throw std::runtime_error("Graph validation failed: " +
+                             result.get_message());
+  }
+
+  return graph.buildFlatbufferOperationGraph();
+}
+
+TEST(TestGraphImport, ImportCustomOpGraph) {
+  auto flatbufferGraph = buildCustomOpGraph();
+
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = flatbufferGraph.data();
+  opGraph.size = flatbufferGraph.size();
+
+  FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(auto ctx, importGraph(&opGraph));
+
+  // Should have 3 IO tensors tracked: in0 (uid=0), in1 (uid=1), out (uid=2).
+  EXPECT_EQ(ctx.uidToFusilliTensorAttr.size(), 3);
+  ASSERT_TRUE(ctx.uidToFusilliTensorAttr.contains(0));
+  ASSERT_TRUE(ctx.uidToFusilliTensorAttr.contains(1));
+  ASSERT_TRUE(ctx.uidToFusilliTensorAttr.contains(2));
+
+  // Check tensor properties.
+  const std::vector<int64_t> expectedDim = {4};
+  const std::vector<int64_t> expectedStride = {1};
+
+  auto in0 = ctx.uidToFusilliTensorAttr.at(0);
+  EXPECT_EQ(in0->getDim(), expectedDim);
+  EXPECT_EQ(in0->getStride(), expectedStride);
+  EXPECT_EQ(in0->getDataType(), fusilli::DataType::Float);
+  EXPECT_FALSE(in0->isVirtual());
+
+  auto in1 = ctx.uidToFusilliTensorAttr.at(1);
+  EXPECT_EQ(in1->getDim(), expectedDim);
+  EXPECT_EQ(in1->getStride(), expectedStride);
+  EXPECT_EQ(in1->getDataType(), fusilli::DataType::Float);
+  EXPECT_FALSE(in1->isVirtual());
+
+  auto out = ctx.uidToFusilliTensorAttr.at(2);
+  EXPECT_EQ(out->getDim(), expectedDim);
+  EXPECT_EQ(out->getStride(), expectedStride);
+  EXPECT_EQ(out->getDataType(), fusilli::DataType::Float);
+  EXPECT_FALSE(out->isVirtual());
+
+  // Graph properties.
+  EXPECT_EQ(ctx.graph.context.getIODataType(), fusilli::DataType::Float);
+  EXPECT_EQ(ctx.graph.context.getComputeDataType(), fusilli::DataType::Float);
+}
+
+TEST(TestGraphImport, RejectCustomOpWithoutFusilliPrefix) {
+  // Build a graph with a custom_op_id that doesn't start with "fusilli."
+  auto flatbufferGraph = buildCustomOpGraph("other_plugin.my_add");
+
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = flatbufferGraph.data();
+  opGraph.size = flatbufferGraph.size();
+
+  auto result = importGraph(&opGraph);
+  EXPECT_TRUE(isError(result));
 }


### PR DESCRIPTION
**NOTE:** this is a work in progress and is mostly to demonstrate/test custom op support in hipDNN (https://github.com/ROCm/rocm-libraries/pull/5341)

Wire hipDNN's CustomOpAttributes through the fusilli plugin's graph import layer. The plugin deserializes the opaque JSON payload (MLIR template, numOutputs, isStatic) and constructs the corresponding fusilli CustomOpAttr/CustomOpNode.