### PR TITLE
Fix CI: add missing IREE third_party/printf submodule

### DIFF
--- a/plugins/hipdnn-plugin/build_tools/ThePebble.py
+++ b/plugins/hipdnn-plugin/build_tools/ThePebble.py
@@ -87,7 +87,7 @@ THEROCK_DIR = PEBBLE_DIR / "TheRock"
 ROCM_LIBRARIES_REPO = "https://github.com/ROCm/rocm-libraries.git"
 IREE_REPO = "https://github.com/iree-org/iree.git"
 IREE_DIR = PEBBLE_DIR / "iree"
-IREE_SUBMODULES = ["third_party/flatcc", "third_party/benchmark"]
+IREE_SUBMODULES = ["third_party/flatcc", "third_party/benchmark", "third_party/printf"]
 HIPDNN_SRC_DIR = PEBBLE_DIR / "rocm-libraries"
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Add `third_party/printf` to `IREE_SUBMODULES` in `ThePebble.py`
- IREE's runtime `iree/base` now links `printf::printf`, which requires the `third_party/printf` submodule to be fetched

All CI has been broken since #236 bumped IREE to `3.11.0rc20260311`.

Fixes #243

## Test plan

- [x] CI passes on this PR (self-validating — the fix unblocks the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)