### PR TITLE
[NFC] Add error propagation to ASM emitter boundary methods

### DIFF
--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -306,7 +306,7 @@ public:
         !isValidated_, ErrorCode::NotValidated,
         "Graph must be validated before emitting MLIR assembly");
     std::ostringstream oss;
-    emitAsmSubtree(oss);
+    FUSILLI_CHECK_ERROR(emitAsmSubtree(oss));
     FUSILLI_LOG_ENDL(oss.str());
     return ok(oss.str());
   }
@@ -578,8 +578,8 @@ private:
   ErrorObject postValidateNode() const override final { return ok(); }
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
-  std::string emitNodePostAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePostAsm() const override final;
   std::string getOperandNamesAndTypesAsm() const;
   std::string getResultNamesAndTypesAsm() const;
 

--- a/include/fusilli/node/conv_node.h
+++ b/include/fusilli/node/conv_node.h
@@ -67,7 +67,7 @@ public:
       : NodeCRTP(ctx), convFPropAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
@@ -260,7 +260,7 @@ public:
       : NodeCRTP(ctx), convWGradAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
@@ -433,7 +433,7 @@ public:
       : NodeCRTP(ctx), convDGradAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -39,8 +39,8 @@ public:
       : NodeCRTP(ctx), customOpAttr(std::move(attr)) {}
 
   // ASM emitter methods (definitions in asm_emitter.h).
-  std::string emitModuleScopeAsm() const override final;
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitModuleScopeAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
 
   // ASM emission helpers (definitions in asm_emitter.h).
   std::string

--- a/include/fusilli/node/layernorm_node.h
+++ b/include/fusilli/node/layernorm_node.h
@@ -43,7 +43,7 @@ public:
       : NodeCRTP(ctx), layernormAttr(std::move(attr)) {}
 
   // ASM emitter methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/matmul_node.h
+++ b/include/fusilli/node/matmul_node.h
@@ -77,7 +77,7 @@ public:
       : NodeCRTP(ctx), matmulAttr(std::move(attr)) {}
 
   // ASM emitter methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/node.h
+++ b/include/fusilli/node/node.h
@@ -66,16 +66,22 @@ protected:
 
   // MLIR assembly emitter helper methods to be provided
   // by each node as needed.
-  virtual std::string emitNodePreAsm() const { return ""; };
-  virtual std::string emitNodePostAsm() const { return ""; };
-  virtual std::string emitModuleScopeAsm() const { return ""; };
+  virtual ErrorOr<std::string> emitNodePreAsm() const { return std::string(); };
+  virtual ErrorOr<std::string> emitNodePostAsm() const {
+    return std::string();
+  };
+  virtual ErrorOr<std::string> emitModuleScopeAsm() const {
+    return std::string();
+  };
 
   // Recursively collect module-scope ASM declarations from this node
   // and all sub-nodes (e.g., custom op function definitions).
-  void collectModuleScopeAsm(std::ostringstream &oss) const {
-    oss << emitModuleScopeAsm();
+  ErrorObject collectModuleScopeAsm(std::ostringstream &oss) const {
+    FUSILLI_ASSIGN_OR_RETURN(auto moduleScopeAsm, emitModuleScopeAsm());
+    oss << moduleScopeAsm;
     for (const auto &subNode : subNodes_)
-      subNode->collectModuleScopeAsm(oss);
+      FUSILLI_CHECK_ERROR(subNode->collectModuleScopeAsm(oss));
+    return ok();
   }
 
   // Recursively validate the node and its sub nodes.
@@ -91,11 +97,14 @@ protected:
   // Recursively emit MLIR assembly for the node and its sub nodes
   // allowing for composite ops to expand into their own regions
   // containing sub ops.
-  void emitAsmSubtree(std::ostringstream &oss) {
-    oss << emitNodePreAsm();
+  ErrorObject emitAsmSubtree(std::ostringstream &oss) {
+    FUSILLI_ASSIGN_OR_RETURN(auto preAsm, emitNodePreAsm());
+    oss << preAsm;
     for (const auto &subNode : subNodes_)
-      subNode->emitAsmSubtree(oss);
-    oss << emitNodePostAsm();
+      FUSILLI_CHECK_ERROR(subNode->emitAsmSubtree(oss));
+    FUSILLI_ASSIGN_OR_RETURN(auto postAsm, emitNodePostAsm());
+    oss << postAsm;
+    return ok();
   }
 
   // Recursively check that names of nodes and their sub nodes

--- a/include/fusilli/node/pointwise_node.h
+++ b/include/fusilli/node/pointwise_node.h
@@ -46,7 +46,7 @@ public:
       : NodeCRTP(ctx), pointwiseAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getPermuteInputOpsAsm(int inputIndex) const;
   std::string getPermuteOut0OpsAsm() const;
   std::string getOperandNamesAsm() const;

--- a/include/fusilli/node/reduction_node.h
+++ b/include/fusilli/node/reduction_node.h
@@ -36,7 +36,7 @@ public:
       : NodeCRTP(ctx), reductionAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/rmsnorm_node.h
+++ b/include/fusilli/node/rmsnorm_node.h
@@ -43,7 +43,7 @@ public:
       : NodeCRTP(ctx), rmsnormAttr(std::move(attr)) {}
 
   // ASM emitter methods (inference mode only).
-  std::string emitNodePreAsm() const override final;
+  ErrorOr<std::string> emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -369,11 +369,11 @@ inline std::string Graph::getResultNamesAndTypesAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline std::string Graph::emitNodePreAsm() const {
+inline ErrorOr<std::string> Graph::emitNodePreAsm() const {
   // Collect module-scope declarations from sub-nodes
   // (e.g., custom op function definitions).
   std::ostringstream moduleScopeOss;
-  collectModuleScopeAsm(moduleScopeOss);
+  FUSILLI_CHECK_ERROR(collectModuleScopeAsm(moduleScopeOss));
 
   constexpr std::string_view schema = R"(
 module @module {{
@@ -403,7 +403,7 @@ module @module {{
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline std::string Graph::emitNodePostAsm() const {
+inline ErrorOr<std::string> Graph::emitNodePostAsm() const {
   std::ostringstream oss;
   interleave(
       fullGraphOutputsSorted_.begin(), fullGraphOutputsSorted_.end(),
@@ -537,7 +537,7 @@ inline std::string ConvFPropNode::getDilationOpsAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline std::string ConvFPropNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> ConvFPropNode::emitNodePreAsm() const {
   // `torch.aten.convolution` signature from GeneratedTorchOps.td
   // https://github.com/llvm/torch-mlir/blob/main/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
   //
@@ -727,7 +727,7 @@ inline std::string ConvWGradNode::getPermuteEmptyWOpsAsm() const {
   return oss.str() + output;
 }
 
-inline std::string ConvWGradNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> ConvWGradNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     %bias_{0} = torch.constant.none
     %transposed_{0} = torch.constant.bool false
@@ -890,7 +890,7 @@ inline std::string ConvDGradNode::getPermuteEmptyXOpsAsm() const {
   return oss.str() + output;
 }
 
-inline std::string ConvDGradNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> ConvDGradNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     %bias_{0} = torch.constant.none
     %transposed_{0} = torch.constant.bool false
@@ -1066,7 +1066,7 @@ inline std::string LayerNormNode::getEpsilonOpsAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline std::string LayerNormNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> LayerNormNode::emitNodePreAsm() const {
   std::string uniqueSSASuffix = layernormAttr.getName();
   std::string permuteX = getPermuteOpsAsm(layernormAttr.getX(), "permute_x",
                                           uniqueSSASuffix, /*isInput=*/true);
@@ -1243,9 +1243,10 @@ inline std::string RmsNormNode::getEpsilonOpsAsm() const {
 
 // Emits MLIR assembly for inference-mode RmsNorm. Training mode ASM emission
 // is not yet supported as torch-mlir does not lower the training variant.
-inline std::string RmsNormNode::emitNodePreAsm() const {
-  assert(!isTrainingForwardPhase() &&
-         "RmsNorm training mode ASM emission is not yet supported");
+inline ErrorOr<std::string> RmsNormNode::emitNodePreAsm() const {
+  FUSILLI_RETURN_ERROR_IF(
+      isTrainingForwardPhase(), ErrorCode::InternalError,
+      "RmsNorm training mode ASM emission is not yet supported");
 
   std::string uniqueSSASuffix = rmsnormAttr.getName();
   std::string permuteX = getPermuteOpsAsm(rmsnormAttr.getX(), "permute_x",
@@ -1321,7 +1322,7 @@ inline std::string MatmulNode::getResultTypesAsm() const {
                                              /*useLogicalDims=*/true);
 }
 
-inline std::string MatmulNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> MatmulNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     {0}
     {1}
@@ -1435,7 +1436,7 @@ inline std::string PointwiseNode::getResultNamesAndTypesAsm() const {
     );                                                                         \
   }
 
-inline std::string PointwiseNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> PointwiseNode::emitNodePreAsm() const {
   std::string uniqueSSASuffix = pointwiseAttr.getName();
 
   // Generate permute operations for inputs and output using the standard
@@ -1498,8 +1499,7 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER(SUB, torch.aten.sub.Tensor)
 
   default:
-    assert(false && "Unsupported pointwise mode");
-    return "";
+    return error(ErrorCode::InternalError, "Unsupported pointwise mode");
   }
 }
 
@@ -1542,7 +1542,7 @@ inline std::string ReductionNode::getResultTypesAsm() const {
                                                 /*useLogicalDims=*/true);
 }
 
-inline std::string ReductionNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> ReductionNode::emitNodePreAsm() const {
   const auto &xT = reductionAttr.getX();
   const auto &yT = reductionAttr.getY();
 
@@ -1622,8 +1622,7 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     );
   }
   default:
-    assert(false && "Unsupported reduction mode");
-    return "";
+    return error(ErrorCode::InternalError, "Unsupported reduction mode");
   }
 }
 
@@ -1636,7 +1635,7 @@ inline std::string ReductionNode::emitNodePreAsm() const {
 // Returns the user's MLIR function definition with placeholders resolved
 // for placement at module scope (alongside @main). Ensures a trailing
 // newline so that consecutive definitions don't merge into one line.
-inline std::string CustomOpNode::emitModuleScopeAsm() const {
+inline ErrorOr<std::string> CustomOpNode::emitModuleScopeAsm() const {
   std::string mlir = resolveMlirPlaceholders();
   if (!mlir.empty() && mlir.back() != '\n')
     mlir += '\n';
@@ -1744,7 +1743,7 @@ inline std::string CustomOpNode::getStaticToDynamicCastAsm(
 //   3. func.call to the custom function
 //   4. Cast outputs dynamic -> static logical
 //   5. Permute outputs logical -> physical
-inline std::string CustomOpNode::emitNodePreAsm() const {
+inline ErrorOr<std::string> CustomOpNode::emitNodePreAsm() const {
   std::ostringstream oss;
   std::string suffix = customOpAttr.getName();
 

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -40,7 +40,9 @@ public:
   using INode::subNodes_;
 
 protected:
-  std::string emitModuleScopeAsm() const override { return moduleScopeAsm_; }
+  ErrorOr<std::string> emitModuleScopeAsm() const override {
+    return moduleScopeAsm_;
+  }
   ErrorObject inferPropertiesNode() override { return ok(); }
 
 private:
@@ -471,7 +473,7 @@ TEST_CASE("collectModuleScopeAsm gathers declarations from nested sub-nodes",
   root->subNodes_.push_back(childB);
 
   std::ostringstream oss;
-  root->collectModuleScopeAsm(oss);
+  FUSILLI_REQUIRE_OK(root->collectModuleScopeAsm(oss));
   std::string result = oss.str();
 
   // All four declarations must be collected in pre-order.


### PR DESCRIPTION
Replace assertions with proper ErrorOr<std::string> error propagation at the ASM emitter boundary (emitNodePreAsm, emitNodePostAsm, emitModuleScopeAsm). This allows errors to propagate gracefully back to the user instead of crashing via assert in release builds.

Changes:
- INode virtual methods return ErrorOr<std::string> instead of std::string
- emitAsmSubtree and collectModuleScopeAsm return ErrorObject
- Graph::emitAsm propagates errors from the emitter tree
- Replace assert with FUSILLI_RETURN_ERROR_IF for:
  - RmsNorm training mode (not yet supported)
  - Unsupported pointwise mode
  - Unsupported reduction mode
- Internal helpers (getTensorTypeAsm, getValueNameAsm, etc.) retain asserts as defensive checks since validation guarantees correctness