### PR TITLE
Bump TheRock to `7.13.0a20260324`

### DIFF
--- a/build_tools/docker/exec_docker_ci.sh
+++ b/build_tools/docker/exec_docker_ci.sh
@@ -31,5 +31,5 @@ docker run --rm \
            -e AMD_ARCH=${AMD_ARCH:-} \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --cap-drop=NET_RAW \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:9ca1e3d757e1a85842b843503a524a7ad094d0b8112dc1ff5268674ea9a6f6c7 \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:896e2ae7b42a0e01e57099a9b6483aa5ca815685f5647979a6030294cd4dfe1a \
            "$@"

--- a/build_tools/scripts/build.sh
+++ b/build_tools/scripts/build.sh
@@ -22,9 +22,9 @@ Configs:
   cpu-debug-tidy    clang-18, Debug, logging, clang-tidy
   cpu-release       clang-18, Release, logging
   gpu-asan          clang-18, Debug, AMDGPU, ASAN + UBSAN
-  gpu-debug         clang-22, Debug, AMDGPU, logging
-  gpu-debug-tidy    clang-22, Debug, AMDGPU, logging, clang-tidy
-  gpu-release       clang-22, Release, AMDGPU, logging
+  gpu-debug         clang-23, Debug, AMDGPU, logging
+  gpu-debug-tidy    clang-23, Debug, AMDGPU, logging, clang-tidy
+  gpu-release       clang-23, Release, AMDGPU, logging
 
 Options:
   --source-dir DIR       Source directory (default: REPO_ROOT)
@@ -162,8 +162,8 @@ case "${CONFIG}" in
     ;;
   gpu-debug)
     CMAKE_OPTIONS+=(
-      -DCMAKE_C_COMPILER=clang-22
-      -DCMAKE_CXX_COMPILER=clang++-22
+      -DCMAKE_C_COMPILER=clang-23
+      -DCMAKE_CXX_COMPILER=clang++-23
       -DCMAKE_BUILD_TYPE=Debug
       -DFUSILLI_SYSTEMS_AMDGPU=ON
       -DFUSILLI_ENABLE_LOGGING=ON
@@ -175,8 +175,8 @@ case "${CONFIG}" in
     ;;
   gpu-debug-tidy)
     CMAKE_OPTIONS+=(
-      -DCMAKE_C_COMPILER=clang-22
-      -DCMAKE_CXX_COMPILER=clang++-22
+      -DCMAKE_C_COMPILER=clang-23
+      -DCMAKE_CXX_COMPILER=clang++-23
       -DCMAKE_BUILD_TYPE=Debug
       -DFUSILLI_SYSTEMS_AMDGPU=ON
       -DFUSILLI_ENABLE_LOGGING=ON
@@ -188,8 +188,8 @@ case "${CONFIG}" in
     ;;
   gpu-release)
     CMAKE_OPTIONS+=(
-      -DCMAKE_C_COMPILER=clang-22
-      -DCMAKE_CXX_COMPILER=clang++-22
+      -DCMAKE_C_COMPILER=clang-23
+      -DCMAKE_CXX_COMPILER=clang++-23
       -DCMAKE_BUILD_TYPE=Release
       -DFUSILLI_SYSTEMS_AMDGPU=ON
       -DFUSILLI_ENABLE_LOGGING=ON

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "package-version": "0.0.1.dev",
   "iree-version": "3.12.0rc20260324",
-  "therock-version": "7.12.0a20260311"
+  "therock-version": "7.13.0a20260324"
 }


### PR DESCRIPTION
## Summary

Bump TheRock to `7.13.0a20260324` and update Docker image for clang-23.

- TheRock 7.13 ships LLVM 23, so `clang-22` → `clang-23` in `build.sh` and the Docker entrypoint
- Updated Docker image SHA to pick up the clang-23 symlinks

## Blocked

GPU CI jobs segfault during process exit with TheRock `>= 7.13.0a20260322`. This is caused by a bug in `libhsa-runtime64.so` where `Runtime::Unload()` calls `dlclose(libhsa-amd-aqlprofile64.so)`, which transitively unmaps HSA's own code mid-execution due to a circular NEEDED dependency.

- **Fix PR**: https://github.com/ROCm/rocm-systems/pull/4442
- **Regressing commit**: `439fb1c774` in rocm-systems
- **Good nightly**: `7.13.0a20260321`
- **Bad nightly**: `7.13.0a20260322`

This PR can land once the fix is picked up in a TheRock nightly, or by pinning to `7.13.0a20260321`.

## Test plan

- [x] CPU CI passes (all configs)
- [x] Windows CI passes
- [ ] GPU CI passes (blocked on upstream fix)