### PR TITLE
Revert "[NFC] Add error propagation to ASM emitter boundary methods"

### DIFF
--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -325,7 +325,7 @@ public:
         !isValidated_, ErrorCode::NotValidated,
         "Graph must be validated before emitting MLIR assembly");
     std::ostringstream oss;
-    FUSILLI_CHECK_ERROR(emitAsmSubtree(oss));
+    emitAsmSubtree(oss);
     FUSILLI_LOG_ENDL(oss.str());
     return ok(oss.str());
   }
@@ -597,8 +597,8 @@ private:
   ErrorObject postValidateNode() const override final { return ok(); }
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
-  ErrorOr<std::string> emitNodePostAsm() const override final;
+  std::string emitNodePreAsm() const override final;
+  std::string emitNodePostAsm() const override final;
   std::string getOperandNamesAndTypesAsm() const;
   std::string getResultNamesAndTypesAsm() const;
 

--- a/include/fusilli/node/batchnorm_node.h
+++ b/include/fusilli/node/batchnorm_node.h
@@ -53,7 +53,7 @@ public:
       : NodeCRTP(ctx), batchnormAttr(std::move(attr)) {}
 
   // ASM emitter methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/conv_node.h
+++ b/include/fusilli/node/conv_node.h
@@ -67,7 +67,7 @@ public:
       : NodeCRTP(ctx), convFPropAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
@@ -260,7 +260,7 @@ public:
       : NodeCRTP(ctx), convWGradAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
@@ -433,7 +433,7 @@ public:
       : NodeCRTP(ctx), convDGradAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -39,8 +39,8 @@ public:
       : NodeCRTP(ctx), customOpAttr(std::move(attr)) {}
 
   // ASM emitter methods (definitions in asm_emitter.h).
-  ErrorOr<std::string> emitModuleScopeAsm() const override final;
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitModuleScopeAsm() const override final;
+  std::string emitNodePreAsm() const override final;
 
   // ASM emission helpers (definitions in asm_emitter.h).
   std::string getCallOperandNamesAsm() const;

--- a/include/fusilli/node/layernorm_node.h
+++ b/include/fusilli/node/layernorm_node.h
@@ -43,7 +43,7 @@ public:
       : NodeCRTP(ctx), layernormAttr(std::move(attr)) {}
 
   // ASM emitter methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/matmul_node.h
+++ b/include/fusilli/node/matmul_node.h
@@ -77,7 +77,7 @@ public:
       : NodeCRTP(ctx), matmulAttr(std::move(attr)) {}
 
   // ASM emitter methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/node.h
+++ b/include/fusilli/node/node.h
@@ -67,22 +67,16 @@ protected:
 
   // MLIR assembly emitter helper methods to be provided
   // by each node as needed.
-  virtual ErrorOr<std::string> emitNodePreAsm() const { return std::string(); };
-  virtual ErrorOr<std::string> emitNodePostAsm() const {
-    return std::string();
-  };
-  virtual ErrorOr<std::string> emitModuleScopeAsm() const {
-    return std::string();
-  };
+  virtual std::string emitNodePreAsm() const { return ""; };
+  virtual std::string emitNodePostAsm() const { return ""; };
+  virtual std::string emitModuleScopeAsm() const { return ""; };
 
   // Recursively collect module-scope ASM declarations from this node
   // and all sub-nodes (e.g., custom op function definitions).
-  ErrorObject collectModuleScopeAsm(std::ostringstream &oss) const {
-    FUSILLI_ASSIGN_OR_RETURN(auto moduleScopeAsm, emitModuleScopeAsm());
-    oss << moduleScopeAsm;
+  void collectModuleScopeAsm(std::ostringstream &oss) const {
+    oss << emitModuleScopeAsm();
     for (const auto &subNode : subNodes_)
-      FUSILLI_CHECK_ERROR(subNode->collectModuleScopeAsm(oss));
-    return ok();
+      subNode->collectModuleScopeAsm(oss);
   }
 
   // Recursively validate the node and its sub nodes.
@@ -98,14 +92,11 @@ protected:
   // Recursively emit MLIR assembly for the node and its sub nodes
   // allowing for composite ops to expand into their own regions
   // containing sub ops.
-  ErrorObject emitAsmSubtree(std::ostringstream &oss) {
-    FUSILLI_ASSIGN_OR_RETURN(auto preAsm, emitNodePreAsm());
-    oss << preAsm;
+  void emitAsmSubtree(std::ostringstream &oss) {
+    oss << emitNodePreAsm();
     for (const auto &subNode : subNodes_)
-      FUSILLI_CHECK_ERROR(subNode->emitAsmSubtree(oss));
-    FUSILLI_ASSIGN_OR_RETURN(auto postAsm, emitNodePostAsm());
-    oss << postAsm;
-    return ok();
+      subNode->emitAsmSubtree(oss);
+    oss << emitNodePostAsm();
   }
 
   // Recursively check that names of nodes and their sub nodes

--- a/include/fusilli/node/pointwise_node.h
+++ b/include/fusilli/node/pointwise_node.h
@@ -49,7 +49,7 @@ public:
       : NodeCRTP(ctx), pointwiseAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getPermuteInputOpsAsm(int inputIndex) const;
   std::string getPermuteOut0OpsAsm() const;
   std::string getOperandNamesAsm() const;

--- a/include/fusilli/node/reduction_node.h
+++ b/include/fusilli/node/reduction_node.h
@@ -36,7 +36,7 @@ public:
       : NodeCRTP(ctx), reductionAttr(std::move(attr)) {}
 
   // MLIR assembly emitter helper methods.
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/node/rmsnorm_node.h
+++ b/include/fusilli/node/rmsnorm_node.h
@@ -43,7 +43,7 @@ public:
       : NodeCRTP(ctx), rmsnormAttr(std::move(attr)) {}
 
   // ASM emitter methods (inference mode only).
-  ErrorOr<std::string> emitNodePreAsm() const override final;
+  std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
   std::string getResultNamesAsm() const;

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -427,11 +427,11 @@ inline std::string Graph::getResultNamesAndTypesAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline ErrorOr<std::string> Graph::emitNodePreAsm() const {
+inline std::string Graph::emitNodePreAsm() const {
   // Collect module-scope declarations from sub-nodes
   // (e.g., custom op function definitions).
   std::ostringstream moduleScopeOss;
-  FUSILLI_CHECK_ERROR(collectModuleScopeAsm(moduleScopeOss));
+  collectModuleScopeAsm(moduleScopeOss);
 
   constexpr std::string_view schema = R"(
 module @module {{
@@ -461,7 +461,7 @@ module @module {{
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline ErrorOr<std::string> Graph::emitNodePostAsm() const {
+inline std::string Graph::emitNodePostAsm() const {
   std::ostringstream oss;
   interleave(
       fullGraphOutputsSorted_.begin(), fullGraphOutputsSorted_.end(),
@@ -595,7 +595,7 @@ inline std::string ConvFPropNode::getDilationOpsAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline ErrorOr<std::string> ConvFPropNode::emitNodePreAsm() const {
+inline std::string ConvFPropNode::emitNodePreAsm() const {
   // `torch.aten.convolution` signature from GeneratedTorchOps.td
   // https://github.com/llvm/torch-mlir/blob/main/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
   //
@@ -785,7 +785,7 @@ inline std::string ConvWGradNode::getPermuteEmptyWOpsAsm() const {
   return oss.str() + output;
 }
 
-inline ErrorOr<std::string> ConvWGradNode::emitNodePreAsm() const {
+inline std::string ConvWGradNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     %bias_{0} = torch.constant.none
     %transposed_{0} = torch.constant.bool false
@@ -948,7 +948,7 @@ inline std::string ConvDGradNode::getPermuteEmptyXOpsAsm() const {
   return oss.str() + output;
 }
 
-inline ErrorOr<std::string> ConvDGradNode::emitNodePreAsm() const {
+inline std::string ConvDGradNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     %bias_{0} = torch.constant.none
     %transposed_{0} = torch.constant.bool false
@@ -1162,7 +1162,7 @@ inline std::string BatchNormNode::getMomentumOpsAsm() const {
 // Both inference and training use `torch.aten.native_batch_norm` (three
 // outputs). For inference, training=false and the last two outputs (saved_mean,
 // saved_invstd) are discarded placeholders.
-inline ErrorOr<std::string> BatchNormNode::emitNodePreAsm() const {
+inline std::string BatchNormNode::emitNodePreAsm() const {
   std::string suffix = batchnormAttr.getName();
 
   std::string permuteX = getLayoutConversionOpsAsm(
@@ -1357,7 +1357,7 @@ inline std::string LayerNormNode::getEpsilonOpsAsm() const {
 // for template replacements using `std::format`. When modifying the
 // schema, take extra caution about double bracing the curly brackets
 // (refer to the comments at the top of this file for details).
-inline ErrorOr<std::string> LayerNormNode::emitNodePreAsm() const {
+inline std::string LayerNormNode::emitNodePreAsm() const {
   std::string uniqueSSASuffix = layernormAttr.getName();
   std::string permuteX = getLayoutConversionOpsAsm(
       layernormAttr.getX(), "permute_x", uniqueSSASuffix, /*isInput=*/true);
@@ -1523,10 +1523,9 @@ inline std::string RmsNormNode::getEpsilonOpsAsm() const {
 
 // Emits MLIR assembly for inference-mode RmsNorm. Training mode ASM emission
 // is not yet supported as torch-mlir does not lower the training variant.
-inline ErrorOr<std::string> RmsNormNode::emitNodePreAsm() const {
-  FUSILLI_RETURN_ERROR_IF(
-      isTrainingForwardPhase(), ErrorCode::InternalError,
-      "RmsNorm training mode ASM emission is not yet supported");
+inline std::string RmsNormNode::emitNodePreAsm() const {
+  assert(!isTrainingForwardPhase() &&
+         "RmsNorm training mode ASM emission is not yet supported");
 
   std::string uniqueSSASuffix = rmsnormAttr.getName();
   std::string permuteX = getLayoutConversionOpsAsm(
@@ -1602,7 +1601,7 @@ inline std::string MatmulNode::getResultTypesAsm() const {
                                              /*useLogicalDims=*/true);
 }
 
-inline ErrorOr<std::string> MatmulNode::emitNodePreAsm() const {
+inline std::string MatmulNode::emitNodePreAsm() const {
   constexpr std::string_view schema = R"(
     {0}
     {1}
@@ -1716,7 +1715,7 @@ inline std::string PointwiseNode::getResultNamesAndTypesAsm() const {
     );                                                                         \
   }
 
-inline ErrorOr<std::string> PointwiseNode::emitNodePreAsm() const {
+inline std::string PointwiseNode::emitNodePreAsm() const {
   std::string uniqueSSASuffix = pointwiseAttr.getName();
 
   // Generate permute operations for inputs and output using the standard
@@ -1814,7 +1813,8 @@ inline ErrorOr<std::string> PointwiseNode::emitNodePreAsm() const {
     FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER(SUB, torch.aten.sub.Tensor)
 
   default:
-    return error(ErrorCode::InternalError, "Unsupported pointwise mode");
+    assert(false && "Unsupported pointwise mode");
+    return "";
   }
 }
 
@@ -1857,7 +1857,7 @@ inline std::string ReductionNode::getResultTypesAsm() const {
                                                 /*useLogicalDims=*/true);
 }
 
-inline ErrorOr<std::string> ReductionNode::emitNodePreAsm() const {
+inline std::string ReductionNode::emitNodePreAsm() const {
   const auto &xT = reductionAttr.getX();
   const auto &yT = reductionAttr.getY();
 
@@ -1917,7 +1917,8 @@ inline ErrorOr<std::string> ReductionNode::emitNodePreAsm() const {
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MAX, torch.aten.amax)
   default:
-    return error(ErrorCode::InternalError, "Unsupported reduction mode");
+    assert(false && "Unsupported reduction mode");
+    return "";
   }
 }
 
@@ -1970,7 +1971,7 @@ inline std::string CustomOpNode::resolveMlirPlaceholders() const {
   return mlir;
 }
 
-inline ErrorOr<std::string> CustomOpNode::emitModuleScopeAsm() const {
+inline std::string CustomOpNode::emitModuleScopeAsm() const {
   std::string mlir = resolveMlirPlaceholders();
   if (!mlir.empty() && mlir.back() != '\n')
     mlir += '\n';
@@ -2037,7 +2038,7 @@ inline std::string CustomOpNode::getCallResultTypesAsm() const {
 //   1. Convert inputs physical -> logical (permute + expand if broadcast)
 //   2. func.call to the custom function
 //   3. Convert outputs logical -> physical (permute)
-inline ErrorOr<std::string> CustomOpNode::emitNodePreAsm() const {
+inline std::string CustomOpNode::emitNodePreAsm() const {
   std::ostringstream oss;
   std::string suffix = customOpAttr.getName();
 

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -40,9 +40,7 @@ public:
   using INode::subNodes_;
 
 protected:
-  ErrorOr<std::string> emitModuleScopeAsm() const override {
-    return moduleScopeAsm_;
-  }
+  std::string emitModuleScopeAsm() const override { return moduleScopeAsm_; }
   ErrorObject inferPropertiesNode() override { return ok(); }
 
 private:
@@ -473,7 +471,7 @@ TEST_CASE("collectModuleScopeAsm gathers declarations from nested sub-nodes",
   root->subNodes_.push_back(childB);
 
   std::ostringstream oss;
-  FUSILLI_REQUIRE_OK(root->collectModuleScopeAsm(oss));
+  root->collectModuleScopeAsm(oss);
   std::string result = oss.str();
 
   // All four declarations must be collected in pre-order.


### PR DESCRIPTION
Reverts iree-org/fusilli#262

([context](https://github.com/iree-org/fusilli/pull/262#pullrequestreview-4047264307))

> This breaks the assumption that the asm emitter methods never error (if they do that's a failure on the graph validation logic and needs an update). I'd like to better understand the situation that spawned this and see if there's another way to address the underlying issue (why not use debug builds for dev work)? Can you share the repro / error message and what change triggered it?

> Usually if these asserts are hit (shouldn't in release builds as that code is unreachable) it is highly likely that something is off in a fresh development branch, which ideally uses debug builds. This change is also very non-uniform - doesn't hold to rest of asm emitters, so I push to revert and then revisit if there's a hidden need I'm not seeing rn.