### PR TITLE
Cleanup pointwise operations for easier merges

### DIFF
--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -42,10 +42,15 @@ TEST_CASE("Pointwise binary compare ops", "[pointwise][graph]") {
       GENERATE(std::vector<int64_t>{2, 16, 64, 64},
                std::vector<int64_t>{1, 16, 1, 1})};
 
-  const auto mode =
-      GENERATE(PointwiseAttr::Mode::CMP_EQ, PointwiseAttr::Mode::CMP_LT,
-               PointwiseAttr::Mode::CMP_LE, PointwiseAttr::Mode::CMP_GT,
-               PointwiseAttr::Mode::CMP_GE, PointwiseAttr::Mode::CMP_NEQ);
+  // clang-format off
+  const auto mode = GENERATE(
+      PointwiseAttr::Mode::CMP_EQ,
+      PointwiseAttr::Mode::CMP_LT,
+      PointwiseAttr::Mode::CMP_LE,
+      PointwiseAttr::Mode::CMP_GT,
+      PointwiseAttr::Mode::CMP_GE,
+      PointwiseAttr::Mode::CMP_NEQ);
+  // clang-format on
 
   auto execute = [&]<typename T>(Handle &handle, DataType dt, T x0, T x1) {
     // Create graph.

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -43,9 +43,13 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
       GENERATE(std::vector<int64_t>{2, 16, 64, 64},
                std::vector<int64_t>{1, 16, 1, 1})};
 
-  const auto mode =
-      GENERATE(PointwiseAttr::Mode::ADD, PointwiseAttr::Mode::DIV,
-               PointwiseAttr::Mode::MUL, PointwiseAttr::Mode::SUB);
+  // clang-format off
+  const auto mode = GENERATE(
+      PointwiseAttr::Mode::ADD,
+      PointwiseAttr::Mode::DIV,
+      PointwiseAttr::Mode::MUL,
+      PointwiseAttr::Mode::SUB);
+  // clang-format on
 
   auto execute = [&]<typename T>(Handle &handle, DataType dt, T x0, T x1) {
     auto buildNewGraph = [&](Handle &handleArg) {

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -39,10 +39,14 @@ static std::string generateName(PointwiseAttr::Mode mode, DataType type,
 TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
   const auto dim = std::vector<int64_t>{2, 16, 64, 64};
 
-  const auto mode =
-      GENERATE(PointwiseAttr::Mode::ABS, PointwiseAttr::Mode::CEIL,
-               PointwiseAttr::Mode::RELU_FWD, PointwiseAttr::Mode::SIGMOID_FWD,
-               PointwiseAttr::Mode::TANH_FWD);
+  // clang-format off
+  const auto mode = GENERATE(
+      PointwiseAttr::Mode::ABS,
+      PointwiseAttr::Mode::CEIL,
+      PointwiseAttr::Mode::RELU_FWD,
+      PointwiseAttr::Mode::SIGMOID_FWD,
+      PointwiseAttr::Mode::TANH_FWD);
+  // clang-format on
 
   auto execute = [&]<typename T>(Handle &handle, DataType dt, T x) {
     auto buildNewGraph = [&](Handle &handleArg) {


### PR DESCRIPTION
Multi-line lists are easier for performing git merges across for op support. Stage with this layout to cleanup the merging process.