### PR TITLE
Fix RMSNorm scale and training output tensor shapes

### DIFF
--- a/include/fusilli/node/layernorm_node.h
+++ b/include/fusilli/node/layernorm_node.h
@@ -93,8 +93,11 @@ public:
     // inferPropertiesNode().
     if (sT) {
       if (!sT->getDim().empty()) {
+        // Scale covers all non-batch dims: only batch is set to 1,
+        // no reduction dims collapsed.
         FUSILLI_RETURN_ERROR_IF(
-            sT->getDim() != norm_utils::getScaleBiasDim(xT->getDim()),
+            sT->getDim() !=
+                norm_utils::getScaleBiasDim(xT->getDim(), getBatchDims(), {}),
             ErrorCode::InvalidAttribute,
             "LayerNorm input tensor SCALE must have shape as "
             "tensor X with single batch");
@@ -111,12 +114,14 @@ public:
     }
 
     // Shape and layout checks on bias tensor.
-    // If scale tensor's dims/strides are not set, they will be inferred in
+    // If bias tensor's dims/strides are not set, they will be inferred in
     // inferPropertiesNode().
     if (bT) {
       if (!bT->getDim().empty()) {
+        // Bias covers all non-batch dims, same as scale.
         FUSILLI_RETURN_ERROR_IF(
-            bT->getDim() != norm_utils::getScaleBiasDim(xT->getDim()),
+            bT->getDim() !=
+                norm_utils::getScaleBiasDim(xT->getDim(), getBatchDims(), {}),
             ErrorCode::InvalidAttribute,
             "LayerNorm input tensor BIAS must have shape as "
             "tensor X with single batch");
@@ -168,15 +173,20 @@ public:
     const std::vector<int64_t> &xDim = xT->getDim();
 
     // Infer shape and stride of input SCALE tensor if they're not set.
+    // Scale covers all non-batch dims: only batch set to 1, no reduction
+    // dims collapsed.
     std::shared_ptr<TensorAttr> sT = layernormAttr.getSCALE();
     if (sT) {
-      norm_utils::inferScaleBiasDimAndStride(sT, xDim, xT->getStride());
+      norm_utils::inferScaleBiasDimAndStride(sT, xDim, xT->getStride(),
+                                             getBatchDims(), {});
     }
 
     // Infer shape and stride of input BIAS tensor if they're not set.
+    // Same shape as scale.
     std::shared_ptr<TensorAttr> bT = layernormAttr.getBIAS();
     if (bT) {
-      norm_utils::inferScaleBiasDimAndStride(bT, xDim, xT->getStride());
+      norm_utils::inferScaleBiasDimAndStride(bT, xDim, xT->getStride(),
+                                             getBatchDims(), {});
     }
 
     // Infer shape and stride of output Y tensor.
@@ -185,7 +195,8 @@ public:
 
     if (isTrainingForwardPhase()) {
       const auto &[dim, stride] =
-          norm_utils::getTrainingForwardOutputDimAndStride(xDim);
+          norm_utils::getTrainingForwardOutputDimAndStride(xDim,
+                                                           getReductionDims());
 
       // Infer shape and stride of output MEAN tensor.
       std::shared_ptr<TensorAttr> mT = layernormAttr.getMEAN();
@@ -222,7 +233,8 @@ public:
 
     if (isTrainingForwardPhase()) {
       const auto &[dim, stride] =
-          norm_utils::getTrainingForwardOutputDimAndStride(xDim);
+          norm_utils::getTrainingForwardOutputDimAndStride(xDim,
+                                                           getReductionDims());
 
       std::shared_ptr<TensorAttr> mT = layernormAttr.getMEAN();
       std::shared_ptr<TensorAttr> vT = layernormAttr.getINV_VARIANCE();
@@ -258,8 +270,23 @@ private:
     return layernormAttr.getForwardPhase() == NormFwdPhase::TRAINING;
   }
 
+  static constexpr size_t kBatchDim = 0;
+
+  std::vector<size_t> getBatchDims() const { return {kBatchDim}; }
+
+  // LayerNorm reduces over all non-batch dimensions.
+  std::vector<size_t> getReductionDims() const {
+    size_t rank = layernormAttr.getX()->getDim().size();
+    std::vector<size_t> dims;
+    dims.reserve(rank - 1);
+    for (size_t i = 1; i < rank; ++i)
+      dims.push_back(i);
+    return dims;
+  }
+
   std::vector<int64_t> getNormalizedShape() const {
-    return norm_utils::getNormalizedShape(layernormAttr.getX()->getDim());
+    return norm_utils::getNormalizedShape(layernormAttr.getX()->getDim(),
+                                          getReductionDims());
   }
 };
 

--- a/include/fusilli/node/norm_utils.h
+++ b/include/fusilli/node/norm_utils.h
@@ -21,39 +21,55 @@
 
 namespace fusilli::norm_utils {
 
-// Returns the shape over which normalization is applied:
-// the input tensor's shape excluding the batch dimension,
-// as normalization is computed independently for each sample in the batch.
-inline std::vector<int64_t> getNormalizedShape(const std::vector<int64_t> &xDim,
-                                               size_t batchDim = 0) {
+// Returns the sizes at the given dimension indices. Used to extract the
+// normalized shape from the input tensor. For example, for input
+// [N, C, H, W] with reductionDims = {1, 2, 3} (LayerNorm), returns
+// [C, H, W]. With reductionDims = {2, 3} (RMSNorm), returns [H, W].
+inline std::vector<int64_t>
+getNormalizedShape(const std::vector<int64_t> &xDim,
+                   const std::vector<size_t> &reductionDims) {
   std::vector<int64_t> shape;
-  shape.reserve(xDim.size() - 1);
-  for (size_t i = 0; i < xDim.size(); ++i) {
-    if (i != batchDim)
-      shape.push_back(xDim[i]);
+  shape.reserve(reductionDims.size());
+  for (size_t i : reductionDims) {
+    shape.push_back(xDim[i]);
   }
   return shape;
 }
 
-// Returns [1, ..., B, ..., 1] dim and unit strides for training forward outputs
-// (e.g. MEAN, INV_VARIANCE, INV_RMS), where only the batch dimension is
-// preserved from xDim.
+// Returns dim and unit strides for training forward outputs (e.g. MEAN,
+// INV_VARIANCE, INV_RMS), where the reduction dimensions are collapsed to 1
+// and all other dimensions are preserved from xDim. For example, for input
+// [N, C, H, W] with reductionDims = {1, 2, 3} (LayerNorm), returns
+// [N, 1, 1, 1]. With reductionDims = {2, 3} (RMSNorm), returns [N, C, 1, 1].
 inline std::pair<std::vector<int64_t>, std::vector<int64_t>>
 getTrainingForwardOutputDimAndStride(const std::vector<int64_t> &xDim,
-                                     size_t batchDim = 0) {
-  std::vector<int64_t> dim(xDim.size(), 1);
-  dim[batchDim] = xDim[batchDim];
+                                     const std::vector<size_t> &reductionDims) {
+  std::vector<int64_t> dim = xDim;
+  for (size_t i : reductionDims) {
+    dim[i] = 1;
+  }
   std::vector<int64_t> stride =
       generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()));
   return {dim, stride};
 }
 
-// Returns the expected shape for scale (and bias) tensors:
-// input X tensor's dims with single batch.
-inline std::vector<int64_t> getScaleBiasDim(const std::vector<int64_t> &xDim,
-                                            size_t batchDim = 0) {
-  auto dim = xDim;
-  dim[batchDim] = 1;
+// Returns the expected shape for scale (and bias) tensors. The result has
+// the same rank as xDim, with dimensions at positions in batchDims and
+// reductionDims set to 1, and all other dimensions preserved from xDim.
+// The caller decides which dims to collapse:
+//   - LayerNorm:  getScaleBiasDim(xDim, {0}, {})      -> [1, C, H, W]
+//   - RMSNorm:    getScaleBiasDim(xDim, {0}, {2, 3})  -> [1, C, 1, 1]
+inline std::vector<int64_t>
+getScaleBiasDim(const std::vector<int64_t> &xDim,
+                const std::vector<size_t> &batchDims,
+                const std::vector<size_t> &reductionDims) {
+  std::vector<int64_t> dim = xDim;
+  for (size_t i : batchDims) {
+    dim[i] = 1;
+  }
+  for (size_t i : reductionDims) {
+    dim[i] = 1;
+  }
   return dim;
 }
 
@@ -88,13 +104,15 @@ inline void inferDimAndStride(std::shared_ptr<TensorAttr> &tensor,
   inferStride(tensor, stride);
 }
 
-// Infers dim and stride of a scale/bias tensor.
-// Stride depends on the tensor's dim (which may be just-inferred), so dim
-// must be set before computing stride.
-inline void inferScaleBiasDimAndStride(std::shared_ptr<TensorAttr> &tensor,
-                                       const std::vector<int64_t> &xDim,
-                                       const std::vector<int64_t> &xStride) {
-  inferDim(tensor, getScaleBiasDim(xDim));
+// Infers dim and stride of a scale/bias tensor. See getScaleBiasDim for
+// the meaning of batchDims and reductionDims. Stride depends on the
+// tensor's dim (which may be just-inferred), so dim must be set before
+// computing stride.
+inline void inferScaleBiasDimAndStride(
+    std::shared_ptr<TensorAttr> &tensor, const std::vector<int64_t> &xDim,
+    const std::vector<int64_t> &xStride, const std::vector<size_t> &batchDims,
+    const std::vector<size_t> &reductionDims) {
+  inferDim(tensor, getScaleBiasDim(xDim, batchDims, reductionDims));
   inferStride(tensor, getScaleBiasStride(tensor->getDim(), xStride));
 }
 

--- a/include/fusilli/node/rmsnorm_node.h
+++ b/include/fusilli/node/rmsnorm_node.h
@@ -91,11 +91,14 @@ public:
     // inferPropertiesNode().
     if (sT) {
       if (!sT->getDim().empty()) {
-        FUSILLI_RETURN_ERROR_IF(sT->getDim() !=
-                                    norm_utils::getScaleBiasDim(xT->getDim()),
-                                ErrorCode::InvalidAttribute,
-                                "RmsNorm input tensor SCALE must have shape as "
-                                "tensor X with single batch");
+        // Scale is per-channel: batch and spatial dims are set to 1.
+        FUSILLI_RETURN_ERROR_IF(
+            sT->getDim() != norm_utils::getScaleBiasDim(xT->getDim(),
+                                                        getBatchDims(),
+                                                        getReductionDims()),
+            ErrorCode::InvalidAttribute,
+            "RmsNorm input tensor SCALE must have per-channel shape "
+            "[1, C, 1, ..., 1]");
       }
 
       if (!sT->getStride().empty()) {
@@ -140,9 +143,11 @@ public:
     const std::vector<int64_t> &xDim = xT->getDim();
 
     // Infer shape and stride of input SCALE tensor if they're not set.
+    // Scale is per-channel: batch and spatial dims are set to 1.
     std::shared_ptr<TensorAttr> sT = rmsnormAttr.getSCALE();
     if (sT) {
-      norm_utils::inferScaleBiasDimAndStride(sT, xDim, xT->getStride());
+      norm_utils::inferScaleBiasDimAndStride(
+          sT, xDim, xT->getStride(), getBatchDims(), getReductionDims());
     }
 
     // Infer shape and stride of output Y tensor.
@@ -150,8 +155,11 @@ public:
     norm_utils::inferDimAndStride(yT, xDim, xT->getStride());
 
     if (isTrainingForwardPhase()) {
+      // INV_RMS shape is [N, 1, 1, ..., 1]: all non-batch dims set to 1
+      // (cuDNN/ONNX keepdim convention).
       const auto &[dim, stride] =
-          norm_utils::getTrainingForwardOutputDimAndStride(xDim);
+          norm_utils::getTrainingForwardOutputDimAndStride(
+              xDim, getAllNonBatchDims());
 
       // Infer shape and stride of output INV_RMS tensor.
       std::shared_ptr<TensorAttr> rT = rmsnormAttr.getINV_RMS();
@@ -183,17 +191,19 @@ public:
                                 "defined by its stride");
 
     if (isTrainingForwardPhase()) {
+      // INV_RMS shape is [N, 1, 1, ..., 1]: all non-batch dims set to 1.
       const auto &[dim, stride] =
-          norm_utils::getTrainingForwardOutputDimAndStride(xDim);
+          norm_utils::getTrainingForwardOutputDimAndStride(
+              xDim, getAllNonBatchDims());
 
       std::shared_ptr<TensorAttr> rT = rmsnormAttr.getINV_RMS();
 
       // Shape check for output INV_RMS tensor
       FUSILLI_RETURN_ERROR_IF(
           dim != rT->getDim(), ErrorCode::InvalidAttribute,
-          "RmsNorm output INV_RMS tensor must have shape [B, 1, ..., 1] with "
-          "rank equal to input X tensor's rank, and batch dimension equal "
-          "to input X tensor's batch dimension");
+          "RmsNorm output INV_RMS tensor must have shape [N, 1, ..., 1] "
+          "with rank equal to input X tensor's rank, and all non-batch "
+          "dimensions set to 1");
       // Stride check for output INV_RMS tensor
       FUSILLI_RETURN_ERROR_IF(
           stride != rT->getStride(), ErrorCode::InvalidAttribute,
@@ -213,8 +223,35 @@ private:
     return rmsnormAttr.getForwardPhase() == NormFwdPhase::TRAINING;
   }
 
+  static constexpr size_t kBatchDim = 0;
+  static constexpr size_t kChannelDim = 1;
+
+  std::vector<size_t> getBatchDims() const { return {kBatchDim}; }
+
+  // RMSNorm reduces over spatial dimensions (all dims except batch and
+  // channel).
+  std::vector<size_t> getReductionDims() const {
+    size_t rank = rmsnormAttr.getX()->getDim().size();
+    std::vector<size_t> dims;
+    for (size_t i = 2; i < rank; ++i)
+      dims.push_back(i);
+    return dims;
+  }
+
+  // All non-batch dimensions (channel + spatial). Used for training
+  // forward outputs (INV_RMS) which have shape [N, 1, 1, ..., 1] per
+  // cuDNN/ONNX keepdim convention.
+  std::vector<size_t> getAllNonBatchDims() const {
+    size_t rank = rmsnormAttr.getX()->getDim().size();
+    std::vector<size_t> dims;
+    for (size_t i = 1; i < rank; ++i)
+      dims.push_back(i);
+    return dims;
+  }
+
   std::vector<int64_t> getNormalizedShape() const {
-    return norm_utils::getNormalizedShape(rmsnormAttr.getX()->getDim());
+    return norm_utils::getNormalizedShape(rmsnormAttr.getX()->getDim(),
+                                          getReductionDims());
   }
 };
 

--- a/tests/lit/test_rmsnorm_infer_asm_emitter_nchw.cpp
+++ b/tests/lit/test_rmsnorm_infer_asm_emitter_nchw.cpp
@@ -14,10 +14,9 @@
 // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,128,64,32],f32>, %arg0_x: !torch.vtensor<[16,128,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
 // Graph-level scalar constant emission for epsilon:
 // TORCH-CHECK:       %rmsnorm_infer_EPSILON = torch.vtensor.literal(dense<0x3727C5AC> : tensor<1xf32>) : !torch.vtensor<[1],f32>
-// TORCH-CHECK:       %normalized_shape_val_0_rmsnorm_infer = torch.constant.int 128
-// TORCH-CHECK:       %normalized_shape_val_1_rmsnorm_infer = torch.constant.int 64
-// TORCH-CHECK:       %normalized_shape_val_2_rmsnorm_infer = torch.constant.int 32
-// TORCH-CHECK:       %normalized_shape_rmsnorm_infer = torch.prim.ListConstruct %normalized_shape_val_0_rmsnorm_infer, %normalized_shape_val_1_rmsnorm_infer, %normalized_shape_val_2_rmsnorm_infer : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %normalized_shape_val_0_rmsnorm_infer = torch.constant.int 64
+// TORCH-CHECK:       %normalized_shape_val_1_rmsnorm_infer = torch.constant.int 32
+// TORCH-CHECK:       %normalized_shape_rmsnorm_infer = torch.prim.ListConstruct %normalized_shape_val_0_rmsnorm_infer, %normalized_shape_val_1_rmsnorm_infer : (!torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %eps_rmsnorm_infer = torch.aten.item %rmsnorm_infer_EPSILON : !torch.vtensor<[1],f32> -> !torch.float
 // TORCH-CHECK:       %permute_x_val_0_rmsnorm_infer = torch.constant.int 0
 // TORCH-CHECK:       %permute_x_val_1_rmsnorm_infer = torch.constant.int 1

--- a/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc.cpp
+++ b/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc.cpp
@@ -11,13 +11,12 @@
 // clang-format off
 //
 // TORCH-CHECK:   module @module {
-// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,128],f32>, %arg0_scale: !torch.vtensor<[1,64,32,128],f32>, %arg0_x: !torch.vtensor<[16,64,32,128],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,128],f32>, %arg0_scale: !torch.vtensor<[1,128,1,1],f32>, %arg0_x: !torch.vtensor<[16,64,32,128],f32>) attributes {torch.assume_strict_symbolic_shapes} {
 // Graph-level scalar constant emission for epsilon:
 // TORCH-CHECK:       %rmsnorm_infer_EPSILON = torch.vtensor.literal(dense<0x3727C5AC> : tensor<1xf32>) : !torch.vtensor<[1],f32>
-// TORCH-CHECK:       %normalized_shape_val_0_rmsnorm_infer = torch.constant.int 128
-// TORCH-CHECK:       %normalized_shape_val_1_rmsnorm_infer = torch.constant.int 64
-// TORCH-CHECK:       %normalized_shape_val_2_rmsnorm_infer = torch.constant.int 32
-// TORCH-CHECK:       %normalized_shape_rmsnorm_infer = torch.prim.ListConstruct %normalized_shape_val_0_rmsnorm_infer, %normalized_shape_val_1_rmsnorm_infer, %normalized_shape_val_2_rmsnorm_infer : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %normalized_shape_val_0_rmsnorm_infer = torch.constant.int 64
+// TORCH-CHECK:       %normalized_shape_val_1_rmsnorm_infer = torch.constant.int 32
+// TORCH-CHECK:       %normalized_shape_rmsnorm_infer = torch.prim.ListConstruct %normalized_shape_val_0_rmsnorm_infer, %normalized_shape_val_1_rmsnorm_infer : (!torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %eps_rmsnorm_infer = torch.aten.item %rmsnorm_infer_EPSILON : !torch.vtensor<[1],f32> -> !torch.float
 // TORCH-CHECK:       %permute_x_val_0_rmsnorm_infer = torch.constant.int 0
 // TORCH-CHECK:       %permute_x_val_1_rmsnorm_infer = torch.constant.int 3
@@ -26,12 +25,12 @@
 // TORCH-CHECK:       %permute_x_rmsnorm_infer = torch.prim.ListConstruct %permute_x_val_0_rmsnorm_infer, %permute_x_val_1_rmsnorm_infer, %permute_x_val_2_rmsnorm_infer, %permute_x_val_3_rmsnorm_infer : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %arg0_x_rmsnorm_infer_perm = torch.aten.permute %arg0_x, %permute_x_rmsnorm_infer : !torch.vtensor<[16,64,32,128],f32>, !torch.list<int> -> !torch.vtensor<[16,128,64,32],f32>
 // TORCH-CHECK:       %permute_scale_val_0_rmsnorm_infer = torch.constant.int 0
-// TORCH-CHECK:       %permute_scale_val_1_rmsnorm_infer = torch.constant.int 3
-// TORCH-CHECK:       %permute_scale_val_2_rmsnorm_infer = torch.constant.int 1
-// TORCH-CHECK:       %permute_scale_val_3_rmsnorm_infer = torch.constant.int 2
+// TORCH-CHECK:       %permute_scale_val_1_rmsnorm_infer = torch.constant.int 1
+// TORCH-CHECK:       %permute_scale_val_2_rmsnorm_infer = torch.constant.int 2
+// TORCH-CHECK:       %permute_scale_val_3_rmsnorm_infer = torch.constant.int 3
 // TORCH-CHECK:       %permute_scale_rmsnorm_infer = torch.prim.ListConstruct %permute_scale_val_0_rmsnorm_infer, %permute_scale_val_1_rmsnorm_infer, %permute_scale_val_2_rmsnorm_infer, %permute_scale_val_3_rmsnorm_infer : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %arg0_scale_rmsnorm_infer_perm = torch.aten.permute %arg0_scale, %permute_scale_rmsnorm_infer : !torch.vtensor<[1,64,32,128],f32>, !torch.list<int> -> !torch.vtensor<[1,128,64,32],f32>
-// TORCH-CHECK:       %result_rmsnorm_infer_perm = torch.aten.rms_norm %arg0_x_rmsnorm_infer_perm, %normalized_shape_rmsnorm_infer, %arg0_scale_rmsnorm_infer_perm, %eps_rmsnorm_infer : !torch.vtensor<[16,128,64,32],f32>, !torch.list<int>, !torch.vtensor<[1,128,64,32],f32>, !torch.float -> !torch.vtensor<[16,128,64,32],f32>
+// TORCH-CHECK:       %arg0_scale_rmsnorm_infer_perm = torch.aten.permute %arg0_scale, %permute_scale_rmsnorm_infer : !torch.vtensor<[1,128,1,1],f32>, !torch.list<int> -> !torch.vtensor<[1,128,1,1],f32>
+// TORCH-CHECK:       %result_rmsnorm_infer_perm = torch.aten.rms_norm %arg0_x_rmsnorm_infer_perm, %normalized_shape_rmsnorm_infer, %arg0_scale_rmsnorm_infer_perm, %eps_rmsnorm_infer : !torch.vtensor<[16,128,64,32],f32>, !torch.list<int>, !torch.vtensor<[1,128,1,1],f32>, !torch.float -> !torch.vtensor<[16,128,64,32],f32>
 // TORCH-CHECK:       %permute_y_val_0_rmsnorm_infer = torch.constant.int 0
 // TORCH-CHECK:       %permute_y_val_1_rmsnorm_infer = torch.constant.int 2
 // TORCH-CHECK:       %permute_y_val_2_rmsnorm_infer = torch.constant.int 3

--- a/tests/test_rmsnorm_node.cpp
+++ b/tests/test_rmsnorm_node.cpp
@@ -103,6 +103,7 @@ TEST_CASE("RmsNormNode preValidateNode detects missing attributes",
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
         TensorAttr().setDim({2, 3}).setStride({3, 1})));
+    // For 2D input [N, C], scale is [1, C] (channel-only).
     attr.setSCALE(std::make_shared<TensorAttr>(
         TensorAttr().setDim({1, 3}).setStride({3, 1})));
     attr.setY(std::make_shared<TensorAttr>(
@@ -165,6 +166,7 @@ TEST_CASE("RmsNormNode preValidateNode detects missing attributes",
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
         TensorAttr().setDim({2, 3}).setStride({3, 1})));
+    // For 2D input [N, C], scale is [1, C] (channel-only).
     attr.setSCALE(std::make_shared<TensorAttr>(
         TensorAttr().setDim({1, 3}).setStride({3, 1})));
     attr.setY(std::make_shared<TensorAttr>(
@@ -184,24 +186,25 @@ TEST_CASE(
   RmsnormAttr attr;
   attr.setForwardPhase(NormFwdPhase::TRAINING);
 
-  int64_t n = 2, c = 5;
+  int64_t n = 2, c = 5, h = 3, w = 4;
 
   attr.setX(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c}).setStride({c, 1})));
+      TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
   attr.setY(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c}).setStride({c, 1})));
+      TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+  // INV_RMS has all non-batch dims reduced: [N, 1, 1, 1].
   attr.setINV_RMS(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, 1}).setStride({1, 1})));
+      TensorAttr().setDim({n, 1, 1, 1}).setStride({1, 1, 1, 1})));
 
   RmsNormNode node(std::move(attr), ctx);
   FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 
   auto yT = node.rmsnormAttr.getY();
   auto rT = node.rmsnormAttr.getINV_RMS();
-  REQUIRE(yT->getDim() == std::vector<int64_t>{n, c});
-  REQUIRE(yT->getStride() == std::vector<int64_t>{c, 1});
-  REQUIRE(rT->getDim() == std::vector<int64_t>{n, 1});
-  REQUIRE(rT->getStride() == std::vector<int64_t>{1, 1});
+  REQUIRE(yT->getDim() == std::vector<int64_t>{n, c, h, w});
+  REQUIRE(yT->getStride() == std::vector<int64_t>{c * h * w, h * w, w, 1});
+  REQUIRE(rT->getDim() == std::vector<int64_t>{n, 1, 1, 1});
+  REQUIRE(rT->getStride() == std::vector<int64_t>{1, 1, 1, 1});
 }
 
 TEST_CASE(
@@ -211,10 +214,10 @@ TEST_CASE(
   RmsnormAttr attr;
   attr.setForwardPhase(NormFwdPhase::TRAINING);
 
-  int64_t n = 2, c = 5;
+  int64_t n = 2, c = 5, h = 3, w = 4;
 
   attr.setX(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c}).setStride({c, 1})));
+      TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
   attr.setY(std::make_shared<TensorAttr>());
   attr.setINV_RMS(std::make_shared<TensorAttr>());
 
@@ -223,10 +226,10 @@ TEST_CASE(
 
   auto yT = node.rmsnormAttr.getY();
   auto rT = node.rmsnormAttr.getINV_RMS();
-  REQUIRE(yT->getDim() == std::vector<int64_t>{n, c});
-  REQUIRE(yT->getStride() == std::vector<int64_t>{c, 1});
-  REQUIRE(rT->getDim() == std::vector<int64_t>{n, 1});
-  REQUIRE(rT->getStride() == std::vector<int64_t>{1, 1});
+  REQUIRE(yT->getDim() == std::vector<int64_t>{n, c, h, w});
+  REQUIRE(yT->getStride() == std::vector<int64_t>{c * h * w, h * w, w, 1});
+  REQUIRE(rT->getDim() == std::vector<int64_t>{n, 1, 1, 1});
+  REQUIRE(rT->getStride() == std::vector<int64_t>{1, 1, 1, 1});
 }
 
 TEST_CASE("RmsNormNode inferPropertiesNode when SCALE tensor is unspecified",
@@ -236,11 +239,11 @@ TEST_CASE("RmsNormNode inferPropertiesNode when SCALE tensor is unspecified",
   attr.setForwardPhase(NormFwdPhase::INFERENCE)
       .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
 
-  int64_t n = 2, c = 5, d = 10;
+  int64_t n = 2, c = 5, h = 3, w = 4;
 
-  SECTION("SCALE shape and strides are unspecified") {
+  SECTION("SCALE shape and strides are unspecified (NCHW)") {
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setSCALE(std::make_shared<TensorAttr>(TensorAttr()));
     attr.setY(std::make_shared<TensorAttr>());
     RmsNormNode node(std::move(attr), ctx);
@@ -248,15 +251,17 @@ TEST_CASE("RmsNormNode inferPropertiesNode when SCALE tensor is unspecified",
     FUSILLI_REQUIRE_OK(node.preValidateNode());
     FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 
+    // RMSNorm scale is per-channel: [1, C, 1, 1].
     auto sT = node.rmsnormAttr.getSCALE();
-    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, d});
-    REQUIRE(sT->getStride() == std::vector<int64_t>{c * d, d, 1});
+    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, 1, 1});
+    REQUIRE(sT->getStride() == std::vector<int64_t>{c, 1, 1, 1});
   }
 
-  SECTION("SCALE shape and strides are partially specified") {
+  SECTION("SCALE shape and strides are partially specified (NHWC)") {
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, 1, c})));
-    attr.setSCALE(std::make_shared<TensorAttr>(TensorAttr().setDim({1, c, d})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, 1, c * w, c})));
+    attr.setSCALE(
+        std::make_shared<TensorAttr>(TensorAttr().setDim({1, c, 1, 1})));
     attr.setY(std::make_shared<TensorAttr>());
     RmsNormNode node(std::move(attr), ctx);
 
@@ -264,15 +269,17 @@ TEST_CASE("RmsNormNode inferPropertiesNode when SCALE tensor is unspecified",
     FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 
     auto sT = node.rmsnormAttr.getSCALE();
-    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, d});
-    REQUIRE(sT->getStride() == std::vector<int64_t>{c * d, 1, c});
+    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, 1, 1});
+    // Stride preserves channels-last format from X; dims 0, 2, 3 are
+    // size 1 so their stride values don't affect memory layout.
+    REQUIRE(sT->getStride() == std::vector<int64_t>{c, 1, c, c});
   }
 
   SECTION("SCALE shape and strides are set") {
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, 1, c})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, 1, c * w, c})));
     attr.setSCALE(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({1, c, d}).setStride({c * d, 1, c})));
+        TensorAttr().setDim({1, c, 1, 1}).setStride({c, 1, 1, 1})));
     attr.setY(std::make_shared<TensorAttr>());
     RmsNormNode node(std::move(attr), ctx);
 
@@ -280,8 +287,8 @@ TEST_CASE("RmsNormNode inferPropertiesNode when SCALE tensor is unspecified",
     FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 
     auto sT = node.rmsnormAttr.getSCALE();
-    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, d});
-    REQUIRE(sT->getStride() == std::vector<int64_t>{c * d, 1, c});
+    REQUIRE(sT->getDim() == std::vector<int64_t>{1, c, 1, 1});
+    REQUIRE(sT->getStride() == std::vector<int64_t>{c, 1, 1, 1});
   }
 }
 
@@ -289,15 +296,15 @@ TEST_CASE("RmsNormNode shape checks on SCALE tensor", "[rmsnorm_node]") {
   Context ctx;
   RmsnormAttr attr;
 
-  int64_t n = 2, c = 3, d = 4;
+  int64_t n = 2, c = 3, h = 4, w = 5;
 
-  SECTION("Incorrect SCALE shape") {
+  SECTION("Incorrect SCALE shape - matches X (non-unit batch)") {
     attr.setForwardPhase(NormFwdPhase::INFERENCE)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setSCALE(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setY(std::make_shared<TensorAttr>());
     RmsNormNode node(std::move(attr), ctx);
 
@@ -305,8 +312,27 @@ TEST_CASE("RmsNormNode shape checks on SCALE tensor", "[rmsnorm_node]") {
     REQUIRE(isError(status));
     REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
     REQUIRE(status.getMessage() ==
-            "RmsNorm input tensor SCALE must have shape as "
-            "tensor X with single batch");
+            "RmsNorm input tensor SCALE must have per-channel shape "
+            "[1, C, 1, ..., 1]");
+  }
+
+  SECTION("Incorrect SCALE shape - non-unit spatial dims") {
+    attr.setForwardPhase(NormFwdPhase::INFERENCE)
+        .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
+    attr.setX(std::make_shared<TensorAttr>(
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    // [1, C, H, W] is wrong for RMSNorm; should be [1, C, 1, 1].
+    attr.setSCALE(std::make_shared<TensorAttr>(
+        TensorAttr().setDim({1, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    attr.setY(std::make_shared<TensorAttr>());
+    RmsNormNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "RmsNorm input tensor SCALE must have per-channel shape "
+            "[1, C, 1, ..., 1]");
   }
 }
 
@@ -315,15 +341,17 @@ TEST_CASE("RmsNormNode postValidateNode detects incorrect shapes and strides",
   Context ctx;
   RmsnormAttr attr;
 
-  int64_t n = 2, c = 3, d = 4;
+  int64_t n = 2, c = 3, h = 4, w = 5;
 
   SECTION("Output Y has incorrect shape") {
     attr.setForwardPhase(NormFwdPhase::INFERENCE)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
-    attr.setY(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n + 1, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    attr.setY(
+        std::make_shared<TensorAttr>(TensorAttr()
+                                         .setDim({n + 1, c, h, w})
+                                         .setStride({c * h * w, h * w, w, 1})));
     RmsNormNode node(std::move(attr), ctx);
 
     FUSILLI_REQUIRE_OK(node.preValidateNode());
@@ -340,11 +368,12 @@ TEST_CASE("RmsNormNode postValidateNode detects incorrect shapes and strides",
     attr.setForwardPhase(NormFwdPhase::INFERENCE)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
-    attr.setY(std::make_shared<TensorAttr>(TensorAttr()
-                                               .setDim({n, c, d})
-                                               .setStride({d, c * d, 1})
-                                               .setName("Y_invalid_layout")));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    attr.setY(
+        std::make_shared<TensorAttr>(TensorAttr()
+                                         .setDim({n, c, h, w})
+                                         .setStride({w, c * h * w, h * w, 1})
+                                         .setName("Y_invalid_layout")));
     RmsNormNode node(std::move(attr), ctx);
 
     FUSILLI_REQUIRE_OK(node.preValidateNode());
@@ -361,11 +390,12 @@ TEST_CASE("RmsNormNode postValidateNode detects incorrect shapes and strides",
     attr.setForwardPhase(NormFwdPhase::TRAINING)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setY(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    // Wrong: batch dim should be N, not 1.
     attr.setINV_RMS(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({1, 1, 1}).setStride({1, 1, 1})));
+        TensorAttr().setDim({1, 1, 1, 1}).setStride({1, 1, 1, 1})));
     RmsNormNode node(std::move(attr), ctx);
 
     FUSILLI_REQUIRE_OK(node.preValidateNode());
@@ -374,21 +404,23 @@ TEST_CASE("RmsNormNode postValidateNode detects incorrect shapes and strides",
     REQUIRE(isError(status));
     REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
     REQUIRE(status.getMessage() ==
-            "RmsNorm output INV_RMS tensor must have shape [B, 1, ..., 1] with "
-            "rank equal to input X tensor's rank, and batch dimension equal "
-            "to input X tensor's batch dimension");
+            "RmsNorm output INV_RMS tensor must have shape [N, 1, ..., 1] "
+            "with rank equal to input X tensor's rank, and all non-batch "
+            "dimensions set to 1");
   }
 
   SECTION("Output INV_RMS has incorrect stride") {
     attr.setForwardPhase(NormFwdPhase::TRAINING)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setY(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
-    attr.setINV_RMS(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, 1, 1}).setStride({1, 1, n}).setName(
-            "INV_RMS_invalid_layout")));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
+    attr.setINV_RMS(
+        std::make_shared<TensorAttr>(TensorAttr()
+                                         .setDim({n, 1, 1, 1})
+                                         .setStride({1, 1, n, 1})
+                                         .setName("INV_RMS_invalid_layout")));
     RmsNormNode node(std::move(attr), ctx);
 
     FUSILLI_REQUIRE_OK(node.preValidateNode());
@@ -404,11 +436,11 @@ TEST_CASE("RmsNormNode postValidateNode detects incorrect shapes and strides",
     attr.setForwardPhase(NormFwdPhase::TRAINING)
         .setEpsilon(std::make_shared<TensorAttr>(1e-5f));
     attr.setX(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setY(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, c, d}).setStride({c * d, d, 1})));
+        TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1})));
     attr.setINV_RMS(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({n, 1, 1}).setStride({1, 1, 1})));
+        TensorAttr().setDim({n, 1, 1, 1}).setStride({1, 1, 1, 1})));
     RmsNormNode node(std::move(attr), ctx);
 
     FUSILLI_REQUIRE_OK(node.preValidateNode());


### PR DESCRIPTION
## Summary

- Refactor `norm_utils` to accept explicit `batchDims` and `reductionDims` parameters instead of hardcoding "all non-batch dims"
- Fix RMSNorm scale shape from `[1, C, H, W]` (wrong) to `[1, C, 1, 1]` (per-channel), matching cuDNN/hipDNN convention
- Fix RMSNorm training output (INV_RMS) shape to `[N, 1, 1, 1]` (keepdim convention), consistent with cuDNN/ONNX
- RMSNorm normalized shape is now `[H, W]` (spatial reduction), not `[C, H, W]`
- LayerNorm behavior is unchanged

### Framework consistency

| | LayerNorm scale | RMSNorm scale | Training output | Match? |
|---|---|---|---|---|
| **Fusilli (new)** | `[1, C, H, W]` | `[1, C, 1, 1]` | `[N, 1, 1, 1]` | — |
| cuDNN | `[1, C, H, W]` | `[1, C, 1, 1]` | `[N, 1, 1, 1]` | ✅ |
| ONNX | `X.shape[axis:]` | broadcastable | `[N, 1, ..., 1]` | ✅ |
| PyTorch | `normalized_shape` | `normalized_shape` | `[N]` (no keepdim) | ⚠️ scale diverges |

PyTorch divergence: PyTorch's `nn.RMSNorm` uses `weight.shape = normalized_shape` (same as LayerNorm). Fusilli follows cuDNN/hipDNN where RMSNorm scale is per-channel, reflecting actual LLM usage.

## Test plan

- [x] All 7 RMSNorm tests pass (unit, lit, samples)
- [x] All 22 LayerNorm tests pass (unit, lit, samples, benchmarks)
- [x] pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)