### PR TITLE
Flake test: drop --extra-verbose to reduce log noise

### DIFF
--- a/.github/workflows/build-and-test-linux.yml
+++ b/.github/workflows/build-and-test-linux.yml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ contains(matrix.name, 'debug') || contains(matrix.name, 'release') || contains(matrix.name, 'asan') }}
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend capi --extra-verbose --validate-cache-cleanup
+        build_tools/scripts/test.sh --backend capi --validate-cache-cleanup
 
     - name: "Test fusilli (iree-compile CLI)"
       # Excluded for ASAN runs: the CLI backend spawns `iree-compile`
@@ -57,7 +57,7 @@ jobs:
       if: ${{ contains(matrix.name, 'debug') || contains(matrix.name, 'release') }}
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend cli --extra-verbose --validate-cache-cleanup
+        build_tools/scripts/test.sh --backend cli --validate-cache-cleanup
 
     - name: "Run code coverage"
       if: ${{ contains(matrix.name, 'codecov') }}

--- a/.github/workflows/build-and-test-win.yml
+++ b/.github/workflows/build-and-test-win.yml
@@ -66,11 +66,11 @@ jobs:
           cmake --build ${{ env.BUILD_DIR_POWERSHELL}} --config Release --target all
       - name: "Running Fusilli tests (libIREECompiler CAPI)"
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_POWERSHELL}} --output-on-failure --extra-verbose --timeout 120
+          ctest --test-dir ${{ env.BUILD_DIR_POWERSHELL}} --output-on-failure --timeout 120
       - name: "Running Fusilli tests (iree-compile CLI)"
         run: |
           $env:FUSILLI_COMPILE_BACKEND_USE_CLI = "1"
-          ctest --test-dir ${{ env.BUILD_DIR_POWERSHELL}} --output-on-failure --extra-verbose --timeout 120
+          ctest --test-dir ${{ env.BUILD_DIR_POWERSHELL}} --output-on-failure --timeout 120
       - name: "Clean up build dir"
         if: always()
         run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}

--- a/.github/workflows/flake-test.yml
+++ b/.github/workflows/flake-test.yml
@@ -64,13 +64,13 @@ jobs:
     - name: "Flake test (libIREECompiler CAPI)"
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend capi --parallel 16 --extra-verbose --validate-cache-cleanup \
+        build_tools/scripts/test.sh --backend capi --parallel 16 --validate-cache-cleanup \
           --repeat ${{ env.FLAKE_TEST_ITERATIONS }}
 
     - name: "Flake test (iree-compile CLI)"
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend cli --parallel 16 --extra-verbose --validate-cache-cleanup \
+        build_tools/scripts/test.sh --backend cli --parallel 16 --validate-cache-cleanup \
           --repeat ${{ env.FLAKE_TEST_ITERATIONS }}
 
   # Depends on all other jobs to provide an aggregate job status.


### PR DESCRIPTION
`--output-on-failure` (always on in test.sh) already prints full output for any test that fails. `--extra-verbose` prints full output for every passing run too.