### PR TITLE
[Flake test] use nproc parallelism for CPU config

### DIFF
--- a/.github/workflows/flake-test.yml
+++ b/.github/workflows/flake-test.yml
@@ -49,7 +49,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["cpu-debug", "gpu-debug"]
+        include:
+          - name: cpu-debug
+            parallel: ""
+          - name: gpu-debug
+            parallel: "--parallel 16"
 
     steps:
     - name: "Checkout fusilli"
@@ -64,13 +68,13 @@ jobs:
     - name: "Flake test (libIREECompiler CAPI)"
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend capi --parallel 16 --validate-cache-cleanup \
+        build_tools/scripts/test.sh --backend capi ${{ matrix.parallel }} --validate-cache-cleanup \
           --repeat ${{ env.FLAKE_TEST_ITERATIONS }}
 
     - name: "Flake test (iree-compile CLI)"
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        build_tools/scripts/test.sh --backend cli --parallel 16 --validate-cache-cleanup \
+        build_tools/scripts/test.sh --backend cli ${{ matrix.parallel }} --validate-cache-cleanup \
           --repeat ${{ env.FLAKE_TEST_ITERATIONS }}
 
   # Depends on all other jobs to provide an aggregate job status.


### PR DESCRIPTION
CPU tests aren't bottlenecked by a shared device, so default to `$(nproc)` (via test.sh's default) to maximize resource pressure for flake detection and speed up workflow. GPU config keeps --parallel 16 to avoid device contention timeouts.