### PR TITLE
Add AMAX, AVG, NORM1, NORM2, MUL, MUL_NO_ZEROS reduction modes

### DIFF
--- a/include/fusilli/attributes/reduction_attributes.h
+++ b/include/fusilli/attributes/reduction_attributes.h
@@ -26,6 +26,7 @@ namespace fusilli {
 
 #define FUSILLI_REDUCTION_MODES(OP)                                            \
   OP(NOT_SET)                                                                  \
+  OP(ADD)                                                                      \
   OP(SUM)                                                                      \
   OP(MUL)                                                                      \
   OP(MIN)                                                                      \

--- a/include/fusilli/attributes/reduction_attributes.h
+++ b/include/fusilli/attributes/reduction_attributes.h
@@ -27,15 +27,14 @@ namespace fusilli {
 #define FUSILLI_REDUCTION_MODES(OP)                                            \
   OP(NOT_SET)                                                                  \
   OP(SUM)                                                                      \
-  /* OP(ADD) */                                                                \
-  /* OP(MUL) */                                                                \
+  OP(MUL)                                                                      \
   OP(MIN)                                                                      \
   OP(MAX)                                                                      \
-  /* OP(AMAX) */                                                               \
-  /* OP(AVG) */                                                                \
-  /* OP(NORM1) */                                                              \
-  /* OP(NORM2) */                                                              \
-  /* OP(MUL_NO_ZEROS) */
+  OP(AMAX)                                                                     \
+  OP(AVG)                                                                      \
+  OP(NORM1)                                                                    \
+  OP(NORM2)                                                                    \
+  OP(MUL_NO_ZEROS)
 
 class ReductionAttr : public AttributesCRTP<ReductionAttr> {
 public:

--- a/include/fusilli/attributes/reduction_attributes.h
+++ b/include/fusilli/attributes/reduction_attributes.h
@@ -27,7 +27,7 @@ namespace fusilli {
 #define FUSILLI_REDUCTION_MODES(OP)                                            \
   OP(NOT_SET)                                                                  \
   OP(ADD)                                                                      \
-  OP(SUM)                                                                      \
+  OP(SUM) /* Remove once SUM is deprecated  */                                 \
   OP(MUL)                                                                      \
   OP(MIN)                                                                      \
   OP(MAX)                                                                      \

--- a/include/fusilli/attributes/types.h
+++ b/include/fusilli/attributes/types.h
@@ -45,6 +45,24 @@ enum class DataType : uint8_t {
 #undef DEFINE_ENUM
 };
 
+inline bool isIntegerType(DataType type) {
+  switch (type) {
+  case DataType::Uint8:
+  case DataType::Int4:
+  case DataType::Int8:
+  case DataType::Int16:
+  case DataType::Int32:
+  case DataType::Int64:
+    return true;
+  default:
+    return false;
+  }
+}
+
+inline bool isIntegralOrBoolType(DataType type) {
+  return isIntegerType(type) || type == DataType::Boolean;
+}
+
 // Map from Fusilli types to MLIR types.
 static const std::unordered_map<DataType, std::string> kDataTypeToMlirTypeAsm =
     {

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -443,6 +443,7 @@ private:
 
     // Write input asm to cache.
     FUSILLI_CHECK_ERROR(cache.input.write(generatedAsm));
+    std::cout << generatedAsm << std::endl;
 
     // determine which implementation to use.
     if (checkCompileBackendEnv()) {

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -443,7 +443,6 @@ private:
 
     // Write input asm to cache.
     FUSILLI_CHECK_ERROR(cache.input.write(generatedAsm));
-    std::cout << generatedAsm << std::endl;
 
     // determine which implementation to use.
     if (checkCompileBackendEnv()) {

--- a/include/fusilli/node/reduction_node.h
+++ b/include/fusilli/node/reduction_node.h
@@ -119,6 +119,13 @@ public:
         ErrorCode::InvalidAttribute,
         "Reduction input and output must have the same rank");
 
+    FUSILLI_RETURN_ERROR_IF(
+        reductionAttr.getMode() == ReductionAttr::Mode::AVG &&
+            (isIntegralOrBoolType(xTensor->getDataType()) ||
+             isIntegralOrBoolType(yTensor->getDataType())),
+        ErrorCode::InvalidAttribute,
+        "Reduction AVG is not supported for integral or boolean tensors");
+
     // Validate reduction dimensions - if Y[i] differs from X[i], Y[i] must be 1
     const auto &xDim = xTensor->getDim();
     const auto &yDim = yTensor->getDim();

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2156,6 +2156,150 @@ inline std::string ReductionNode::emitNodePreAsm() const {
                                                     torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MAX, torch.aten.amax)
+  case ReductionAttr::Mode::NORM1: {
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.aten.sum.dim_IntList %abs_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY              // {7}
+    );
+  }
+  case ReductionAttr::Mode::AMAX: {
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    {3}_{2}_perm = torch.aten.amax %abs_{2}, %reduction_dims_{2}, %keepdim_{2} : {5}, !torch.list<int>, !torch.bool -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY              // {7}
+    );
+  }
+  case ReductionAttr::Mode::AVG: {
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %keepdim_{2} = torch.constant.bool true
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.aten.mean.dim {4}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY              // {7}
+    );
+  }
+  case ReductionAttr::Mode::NORM2: {
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %sq_{2} = torch.aten.mul.Tensor {4}, {4} : {5}, {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    %dtype_{2} = torch.constant.none
+    %sumsq_{2} = torch.aten.sum.dim_IntList %sq_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
+    {3}_{2}_perm = torch.aten.sqrt %sumsq_{2} : {6} -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY              // {7}
+    );
+  }
+  case ReductionAttr::Mode::MUL: {
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.prims.prod {4}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY              // {7}
+    );
+  }
+  case ReductionAttr::Mode::MUL_NO_ZEROS: {
+    // Build a bool tensor type matching the (logical) shape of X. This is
+    // used for the mask produced by `torch.aten.ne.Scalar`.
+    std::ostringstream boolTypeOss;
+    boolTypeOss << "!torch.vtensor<[";
+    const auto &xDims = xT->getDim();
+    interleave(
+        xDims.begin(), xDims.end(),
+        [&](int64_t d) { boolTypeOss << std::to_string(d); },
+        [&] { boolTypeOss << ","; });
+    boolTypeOss << "],i1>";
+    std::string boolType = boolTypeOss.str();
+
+    constexpr std::string_view schema = R"(
+    {0}
+    {1}
+    %zero_{2} = torch.constant.int 0
+    %mask_{2} = torch.aten.ne.Scalar {4}, %zero_{2} : {5}, !torch.int -> {8}
+    %one_{2} = torch.constant.int 1
+    %fixed_{2} = torch.aten.where.ScalarOther %mask_{2}, {4}, %one_{2} : {8}, {5}, !torch.int -> {5}
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.prims.prod %fixed_{2}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
+    {7}
+    )";
+
+    return std::format(schema,
+                       permuteX,             // {0}
+                       dimListOss.str(),     // {1}
+                       suffix,               // {2}
+                       getResultNamesAsm(),  // {3}
+                       getOperandNamesAsm(), // {4}
+                       getOperandTypesAsm(), // {5}
+                       getResultTypesAsm(),  // {6}
+                       permuteY,             // {7}
+                       boolType              // {8}
+    );
+  }
   default:
     assert(false && "Unsupported reduction mode");
     return "";

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2241,15 +2241,15 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     std::string boolType = boolTypeOss.str();
 
     return std::format(kMulNoZerosSchema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY,             // {7}
-                       boolType              // {8}
+                       permuteX,             /* {0} */
+                       dimListOss.str(),     /* {1} */
+                       suffix,               /* {2} */
+                       getResultNamesAsm(),  /* {3} */
+                       getOperandNamesAsm(), /* {4} */
+                       getOperandTypesAsm(), /* {5} */
+                       getResultTypesAsm(),  /* {6} */
+                       permuteY,             /* {7} */
+                       boolType              /* {8} */
     );
   }
   default:

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2215,9 +2215,8 @@ inline std::string ReductionNode::emitNodePreAsm() const {
   }
 
   switch (reductionAttr.getMode()) {
+  case ReductionAttr::Mode::ADD:
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(SUM,
-                                                    torch.aten.sum.dim_IntList)
-    FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(ADD,
                                                     torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MAX, torch.aten.amax)

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2240,16 +2240,15 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     boolTypeOss << "],i1>";
     std::string boolType = boolTypeOss.str();
 
-    return std::format(kMulNoZerosSchema,
-                       permuteX,             /* {0} */
-                       dimListOss.str(),     /* {1} */
-                       suffix,               /* {2} */
-                       getResultNamesAsm(),  /* {3} */
-                       getOperandNamesAsm(), /* {4} */
-                       getOperandTypesAsm(), /* {5} */
-                       getResultTypesAsm(),  /* {6} */
-                       permuteY,             /* {7} */
-                       boolType              /* {8} */
+    return std::format(kMulNoZerosSchema, permuteX, /* {0} */
+                       dimListOss.str(),            /* {1} */
+                       suffix,                      /* {2} */
+                       getResultNamesAsm(),         /* {3} */
+                       getOperandNamesAsm(),        /* {4} */
+                       getOperandTypesAsm(),        /* {5} */
+                       getResultTypesAsm(),         /* {6} */
+                       permuteY,                    /* {7} */
+                       boolType                     /* {8} */
     );
   }
   default:

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2217,6 +2217,8 @@ inline std::string ReductionNode::emitNodePreAsm() const {
   switch (reductionAttr.getMode()) {
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(SUM,
                                                     torch.aten.sum.dim_IntList)
+    FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(ADD,
+                                                    torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MAX, torch.aten.amax)
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(AVG, torch.aten.mean.dim)

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2131,6 +2131,56 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     {7}
     )";
 
+  constexpr std::string_view kNorm1Schema = R"(
+    {0}
+    {1}
+    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.aten.sum.dim_IntList %abs_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
+    {7}
+    )";
+
+  constexpr std::string_view kAbsAmaxSchema = R"(
+    {0}
+    {1}
+    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    {3}_{2}_perm = torch.aten.amax %abs_{2}, %reduction_dims_{2}, %keepdim_{2} : {5}, !torch.list<int>, !torch.bool -> {6}
+    {7}
+    )";
+
+  constexpr std::string_view kNorm2Schema = R"(
+    {0}
+    {1}
+    %sq_{2} = torch.aten.mul.Tensor {4}, {4} : {5}, {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    %dtype_{2} = torch.constant.none
+    %sumsq_{2} = torch.aten.sum.dim_IntList %sq_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
+    {3}_{2}_perm = torch.aten.sqrt %sumsq_{2} : {6} -> {6}
+    {7}
+    )";
+
+  constexpr std::string_view kMulSchema = R"(
+    {0}
+    {1}
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.prims.prod {4}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
+    {7}
+    )";
+
+  constexpr std::string_view kMulNoZerosSchema = R"(
+    {0}
+    {1}
+    %zero_{2} = torch.constant.int 0
+    %mask_{2} = torch.aten.ne.Scalar {4}, %zero_{2} : {5}, !torch.int -> {8}
+    %one_{2} = torch.constant.int 1
+    %fixed_{2} = torch.aten.where.ScalarOther %mask_{2}, {4}, %one_{2} : {8}, {5}, !torch.int -> {5}
+    %dtype_{2} = torch.constant.none
+    {3}_{2}_perm = torch.prims.prod %fixed_{2}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
+    {7}
+    )";
+
 #define FUSILLI_DECLARE_REDUCTION_EMITTER(MODE, SCHEMA, OPIR)                  \
   case ReductionAttr::Mode::MODE: {                                            \
     return std::format(SCHEMA, permuteX,     /* {0} */                         \
@@ -2151,118 +2201,30 @@ inline std::string ReductionNode::emitNodePreAsm() const {
 #define FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(MODE, OPIR)            \
   FUSILLI_DECLARE_REDUCTION_EMITTER(MODE, kKeepdimDtypeReductionSchema, OPIR)
 
+#define FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER(MODE, SCHEMA)                 \
+  case ReductionAttr::Mode::MODE: {                                            \
+    return std::format(SCHEMA, permuteX,     /* {0} */                         \
+                       dimListOss.str(),     /* {1} */                         \
+                       suffix,               /* {2} */                         \
+                       getResultNamesAsm(),  /* {3} */                         \
+                       getOperandNamesAsm(), /* {4} */                         \
+                       getOperandTypesAsm(), /* {5} */                         \
+                       getResultTypesAsm(),  /* {6} */                         \
+                       permuteY              /* {7} */                         \
+    );                                                                         \
+  }
+
   switch (reductionAttr.getMode()) {
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(SUM,
                                                     torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MAX, torch.aten.amax)
-  case ReductionAttr::Mode::NORM1: {
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
-    %keepdim_{2} = torch.constant.bool true
-    %dtype_{2} = torch.constant.none
-    {3}_{2}_perm = torch.aten.sum.dim_IntList %abs_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
-    {7}
-    )";
+    FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(AVG, torch.aten.mean.dim)
+    FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER(NORM1, kNorm1Schema)
+    FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER(NORM2, kNorm2Schema)
+    FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER(AMAX, kAbsAmaxSchema)
+    FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER(MUL, kMulSchema)
 
-    return std::format(schema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY              // {7}
-    );
-  }
-  case ReductionAttr::Mode::AMAX: {
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
-    %keepdim_{2} = torch.constant.bool true
-    {3}_{2}_perm = torch.aten.amax %abs_{2}, %reduction_dims_{2}, %keepdim_{2} : {5}, !torch.list<int>, !torch.bool -> {6}
-    {7}
-    )";
-
-    return std::format(schema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY              // {7}
-    );
-  }
-  case ReductionAttr::Mode::AVG: {
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %keepdim_{2} = torch.constant.bool true
-    %dtype_{2} = torch.constant.none
-    {3}_{2}_perm = torch.aten.mean.dim {4}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
-    {7}
-    )";
-
-    return std::format(schema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY              // {7}
-    );
-  }
-  case ReductionAttr::Mode::NORM2: {
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %sq_{2} = torch.aten.mul.Tensor {4}, {4} : {5}, {5} -> {5}
-    %keepdim_{2} = torch.constant.bool true
-    %dtype_{2} = torch.constant.none
-    %sumsq_{2} = torch.aten.sum.dim_IntList %sq_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
-    {3}_{2}_perm = torch.aten.sqrt %sumsq_{2} : {6} -> {6}
-    {7}
-    )";
-
-    return std::format(schema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY              // {7}
-    );
-  }
-  case ReductionAttr::Mode::MUL: {
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %dtype_{2} = torch.constant.none
-    {3}_{2}_perm = torch.prims.prod {4}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
-    {7}
-    )";
-
-    return std::format(schema,
-                       permuteX,             // {0}
-                       dimListOss.str(),     // {1}
-                       suffix,               // {2}
-                       getResultNamesAsm(),  // {3}
-                       getOperandNamesAsm(), // {4}
-                       getOperandTypesAsm(), // {5}
-                       getResultTypesAsm(),  // {6}
-                       permuteY              // {7}
-    );
-  }
   case ReductionAttr::Mode::MUL_NO_ZEROS: {
     // Build a bool tensor type matching the (logical) shape of X. This is
     // used for the mask produced by `torch.aten.ne.Scalar`.
@@ -2276,19 +2238,7 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     boolTypeOss << "],i1>";
     std::string boolType = boolTypeOss.str();
 
-    constexpr std::string_view schema = R"(
-    {0}
-    {1}
-    %zero_{2} = torch.constant.int 0
-    %mask_{2} = torch.aten.ne.Scalar {4}, %zero_{2} : {5}, !torch.int -> {8}
-    %one_{2} = torch.constant.int 1
-    %fixed_{2} = torch.aten.where.ScalarOther %mask_{2}, {4}, %one_{2} : {8}, {5}, !torch.int -> {5}
-    %dtype_{2} = torch.constant.none
-    {3}_{2}_perm = torch.prims.prod %fixed_{2}, %reduction_dims_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.none -> {6}
-    {7}
-    )";
-
-    return std::format(schema,
+    return std::format(kMulNoZerosSchema,
                        permuteX,             // {0}
                        dimListOss.str(),     // {1}
                        suffix,               // {2}
@@ -2309,6 +2259,7 @@ inline std::string ReductionNode::emitNodePreAsm() const {
 #undef FUSILLI_DECLARE_REDUCTION_EMITTER
 #undef FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER
 #undef FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER
+#undef FUSILLI_DECLARE_CUSTOM_REDUCTION_EMITTER
 
 //===----------------------------------------------------------------------===//
 //

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2165,15 +2165,6 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     {7}
     )";
 
-  constexpr std::string_view kAbsAmaxSchema = R"(
-    {0}
-    {1}
-    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
-    %keepdim_{2} = torch.constant.bool true
-    {3}_{2}_perm = torch.aten.amax %abs_{2}, %reduction_dims_{2}, %keepdim_{2} : {5}, !torch.list<int>, !torch.bool -> {6}
-    {7}
-    )";
-
   constexpr std::string_view kNorm2Schema = R"(
     {0}
     {1}
@@ -2182,6 +2173,15 @@ inline std::string ReductionNode::emitNodePreAsm() const {
     %dtype_{2} = torch.constant.none
     %sumsq_{2} = torch.aten.sum.dim_IntList %sq_{2}, %reduction_dims_{2}, %keepdim_{2}, %dtype_{2} : {5}, !torch.list<int>, !torch.bool, !torch.none -> {6}
     {3}_{2}_perm = torch.aten.sqrt %sumsq_{2} : {6} -> {6}
+    {7}
+    )";
+
+  constexpr std::string_view kAbsAmaxSchema = R"(
+    {0}
+    {1}
+    %abs_{2} = torch.aten.abs {4} : {5} -> {5}
+    %keepdim_{2} = torch.constant.bool true
+    {3}_{2}_perm = torch.aten.amax %abs_{2}, %reduction_dims_{2}, %keepdim_{2} : {5}, !torch.list<int>, !torch.bool -> {6}
     {7}
     )";
 
@@ -2239,7 +2239,8 @@ inline std::string ReductionNode::emitNodePreAsm() const {
   }
 
   switch (reductionAttr.getMode()) {
-  case ReductionAttr::Mode::ADD:
+    FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(ADD,
+                                                    torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(SUM,
                                                     torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2239,8 +2239,7 @@ inline std::string ReductionNode::emitNodePreAsm() const {
   }
 
   switch (reductionAttr.getMode()) {
-    FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(ADD,
-                                                    torch.aten.sum.dim_IntList)
+  case ReductionAttr::Mode::ADD:
     FUSILLI_DECLARE_KEEPDIM_DTYPE_REDUCTION_EMITTER(SUM,
                                                     torch.aten.sum.dim_IntList)
     FUSILLI_DECLARE_KEEPDIM_REDUCTION_EMITTER(MIN, torch.aten.amin)

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -23,6 +23,46 @@
 
 using namespace fusilli;
 
+// Builds the input tensor data for a given reduction mode. The reduction
+// in this sample is checked at output index (d0=0, d1=0), which corresponds
+// to xData indices [0, 64). Each branch picks values that produce a
+// non-trivial, deterministic expected value at that output index while
+// staying in range for fp16/int32.
+template <typename T>
+static std::vector<T> generateReductionInputData(ReductionAttr::Mode mode,
+                                                 int64_t xSize) {
+  std::vector<T> xData(xSize);
+  switch (mode) {
+  case ReductionAttr::Mode::MUL: {
+    // Mostly 1s with a 2 and a 3 inside the (d0=0, d1=0) block so the
+    // product over that block is 6 — non-trivial enough to verify the
+    // multiplication actually happens (rather than degenerating to 1).
+    std::fill(xData.begin(), xData.end(), T(1));
+    xData[10] = T(2);
+    xData[50] = T(3);
+    break;
+  }
+  case ReductionAttr::Mode::MUL_NO_ZEROS: {
+    // Same shape as MUL but with zeros sprinkled in. The expected
+    // product over the (d0=0, d1=0) block is still 6 because zeros
+    // are excluded from the reduction.
+    std::fill(xData.begin(), xData.end(), T(1));
+    xData[10] = T(2);
+    xData[50] = T(3);
+    xData[5] = T(0);
+    xData[20] = T(0);
+    break;
+  }
+  default: {
+    // Values from -50 to 49.
+    for (int64_t i = 0; i < xSize; ++i)
+      xData[i] = static_cast<T>(i % 100 - 50);
+    break;
+  }
+  }
+  return xData;
+}
+
 // Based on parameters, generates a unique name for the graph
 static std::string generateName(ReductionAttr::Mode mode, DataType type,
                                 const std::vector<int64_t> &xDim,
@@ -48,7 +88,13 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
   const auto mode = GENERATE(
       ReductionAttr::Mode::SUM,
       ReductionAttr::Mode::MIN,
-      ReductionAttr::Mode::MAX);
+      ReductionAttr::Mode::MAX,
+      ReductionAttr::Mode::NORM1,
+      ReductionAttr::Mode::AMAX,
+      ReductionAttr::Mode::AVG,
+      ReductionAttr::Mode::NORM2,
+      ReductionAttr::Mode::MUL,
+      ReductionAttr::Mode::MUL_NO_ZEROS);
   // clang-format on
 
   auto execute = [&]<typename T>(Handle &handle, DataType dt, T initValue) {
@@ -80,11 +126,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
     for (auto d : xDims)
       xSize *= d;
 
-    std::vector<T> xData(xSize);
-    for (int64_t i = 0; i < xSize; ++i) {
-      // Values from -50 to 49
-      xData[i] = static_cast<T>(i % 100 - 50);
-    }
+    std::vector<T> xData = generateReductionInputData<T>(mode, xSize);
 
     FUSILLI_REQUIRE_ASSIGN(auto xBuf, allocateBufferOfType(handle, xT, xData));
     FUSILLI_REQUIRE_ASSIGN(auto yBuf,
@@ -117,6 +159,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
 
     // Initialize to same value as output buffer
     T expectedValue = initValue;
+    double sumSq = 0.0;
 
     // Perform reduction
     for (int64_t d2 = 0; d2 < 8; ++d2) {
@@ -132,11 +175,43 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
         case ReductionAttr::Mode::MAX:
           expectedValue = std::max(expectedValue, xData[inIdx]);
           break;
+        case ReductionAttr::Mode::NORM1:
+          expectedValue =
+              static_cast<T>(static_cast<double>(expectedValue) +
+                             std::abs(static_cast<double>(xData[inIdx])));
+          break;
+        case ReductionAttr::Mode::AMAX:
+          expectedValue = std::max(
+              expectedValue,
+              static_cast<T>(std::abs(static_cast<double>(xData[inIdx]))));
+          break;
+        case ReductionAttr::Mode::AVG:
+          expectedValue = expectedValue + xData[inIdx];
+          break;
+        case ReductionAttr::Mode::NORM2: {
+          double v = static_cast<double>(xData[inIdx]);
+          sumSq += v * v;
+          break;
+        }
+        case ReductionAttr::Mode::MUL:
+          expectedValue = expectedValue * xData[inIdx];
+          break;
+        case ReductionAttr::Mode::MUL_NO_ZEROS:
+          if (xData[inIdx] != T(0))
+            expectedValue = expectedValue * xData[inIdx];
+          break;
         default:
           break;
         }
       }
     }
+    if (mode == ReductionAttr::Mode::NORM2)
+      expectedValue = static_cast<T>(std::sqrt(sumSq));
+
+    // Finalize AVG by dividing the accumulated sum by the number of
+    // reduced elements (8 * 8 = 64). Integer types use integer division.
+    if (mode == ReductionAttr::Mode::AVG)
+      expectedValue = expectedValue / T(64);
 
     // Read output buffer
     std::vector<T> result;
@@ -145,10 +220,19 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
     // Validate output size and check the first value (d0=0, d1=0)
     REQUIRE(result.size() == ySize);
     int64_t checkIdx = d0 * 16 + d1;
-    if constexpr (std::is_floating_point_v<T>)
+    if constexpr (std::is_floating_point_v<T>) {
       REQUIRE(std::abs(result[checkIdx] - expectedValue) < T(0.01));
-    else
-      REQUIRE(result[checkIdx] == expectedValue);
+    } else {
+      if (mode == ReductionAttr::Mode::NORM2) {
+        // sqrt may round; allow off-by-one for integer types.
+        T diff = result[checkIdx] > expectedValue
+                     ? result[checkIdx] - expectedValue
+                     : expectedValue - result[checkIdx];
+        REQUIRE(diff <= T(1));
+      } else {
+        REQUIRE(result[checkIdx] == expectedValue);
+      }
+    }
   };
 
   // Create handle for the target backend.
@@ -163,13 +247,22 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
       return std::numeric_limits<T>::max();
     case ReductionAttr::Mode::MAX:
       return std::numeric_limits<T>::lowest();
+    case ReductionAttr::Mode::MUL:
+    case ReductionAttr::Mode::MUL_NO_ZEROS:
+      return T(1);
+    case ReductionAttr::Mode::NORM1:
+    case ReductionAttr::Mode::AMAX:
+    case ReductionAttr::Mode::AVG:
+    case ReductionAttr::Mode::NORM2:
     default:
       return T(0);
     }
   };
 
-  // int32
-  execute(handle, DataType::Int32, getInitValue.template operator()<int>());
+  // torch.aten.mean.dim is not defined on integer tensors, so AVG only
+  // exercises the floating-point paths.
+  if (mode != ReductionAttr::Mode::AVG)
+    execute(handle, DataType::Int32, getInitValue.template operator()<int>());
   // fp16
   execute(handle, DataType::Half, getInitValue.template operator()<half>());
   // fp32

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -86,12 +86,13 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
 
   // clang-format off
   const auto mode = GENERATE(
+      ReductionAttr::Mode::ADD,
       ReductionAttr::Mode::SUM,
       ReductionAttr::Mode::MIN,
       ReductionAttr::Mode::MAX,
-      ReductionAttr::Mode::NORM1,
       ReductionAttr::Mode::AMAX,
       ReductionAttr::Mode::AVG,
+      ReductionAttr::Mode::NORM1,
       ReductionAttr::Mode::NORM2,
       ReductionAttr::Mode::MUL,
       ReductionAttr::Mode::MUL_NO_ZEROS);
@@ -166,6 +167,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
       for (int64_t d3 = 0; d3 < 8; ++d3) {
         int64_t inIdx = ((d0 * 16 + d1) * 8 + d2) * 8 + d3;
         switch (mode) {
+        case ReductionAttr::Mode::ADD:
         case ReductionAttr::Mode::SUM:
           expectedValue = expectedValue + xData[inIdx];
           break;
@@ -241,6 +243,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
   // Determine initial value based on reduction mode
   auto getInitValue = [&]<typename T>() -> T {
     switch (mode) {
+    case ReductionAttr::Mode::ADD:
     case ReductionAttr::Mode::SUM:
       return T(0);
     case ReductionAttr::Mode::MIN:
@@ -250,9 +253,9 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
     case ReductionAttr::Mode::MUL:
     case ReductionAttr::Mode::MUL_NO_ZEROS:
       return T(1);
-    case ReductionAttr::Mode::NORM1:
     case ReductionAttr::Mode::AMAX:
     case ReductionAttr::Mode::AVG:
+    case ReductionAttr::Mode::NORM1:
     case ReductionAttr::Mode::NORM2:
     default:
       return T(0);

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -243,9 +243,6 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
   // Determine initial value based on reduction mode
   auto getInitValue = [&]<typename T>() -> T {
     switch (mode) {
-    case ReductionAttr::Mode::ADD:
-    case ReductionAttr::Mode::SUM:
-      return T(0);
     case ReductionAttr::Mode::MIN:
       return std::numeric_limits<T>::max();
     case ReductionAttr::Mode::MAX:
@@ -253,6 +250,8 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
     case ReductionAttr::Mode::MUL:
     case ReductionAttr::Mode::MUL_NO_ZEROS:
       return T(1);
+    case ReductionAttr::Mode::ADD:
+    case ReductionAttr::Mode::SUM:
     case ReductionAttr::Mode::AMAX:
     case ReductionAttr::Mode::AVG:
     case ReductionAttr::Mode::NORM1:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,7 +223,13 @@ add_fusilli_lit_tests(
     lit/test_sdpa_asm_emitter_cross_attn.cpp
     lit/test_reduction_asm_emitter_sum.cpp
     lit/test_reduction_asm_emitter_min.cpp
+    lit/test_reduction_asm_emitter_amax.cpp
     lit/test_reduction_asm_emitter_max.cpp
+    lit/test_reduction_asm_emitter_mul.cpp
+    lit/test_reduction_asm_emitter_mul_no_zeros.cpp
+    lit/test_reduction_asm_emitter_norm1.cpp
+    lit/test_reduction_asm_emitter_avg.cpp
+    lit/test_reduction_asm_emitter_norm2.cpp
   DEPS
     libfusilli
     libutils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,7 +223,7 @@ add_fusilli_lit_tests(
     lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
     lit/test_sdpa_asm_emitter_custom_scale.cpp
     lit/test_sdpa_asm_emitter_cross_attn.cpp
-    lit/test_reduction_asm_emitter_sum.cpp
+    lit/test_reduction_asm_emitter_add.cpp
     lit/test_reduction_asm_emitter_min.cpp
     lit/test_reduction_asm_emitter_amax.cpp
     lit/test_reduction_asm_emitter_max.cpp

--- a/tests/lit/test_reduction_asm_emitter_add.cpp
+++ b/tests/lit/test_reduction_asm_emitter_add.cpp
@@ -12,24 +12,24 @@
 //
 // TORCH-CHECK:   module @module {
 // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
-// TORCH-CHECK:       %permute_X_val_0_reduction_sum = torch.constant.int 0
-// TORCH-CHECK:       %permute_X_val_1_reduction_sum = torch.constant.int 1
-// TORCH-CHECK:       %permute_X_val_2_reduction_sum = torch.constant.int 2
-// TORCH-CHECK:       %permute_X_val_3_reduction_sum = torch.constant.int 3
-// TORCH-CHECK:       %permute_X_reduction_sum = torch.prim.ListConstruct %permute_X_val_0_reduction_sum, %permute_X_val_1_reduction_sum, %permute_X_val_2_reduction_sum, %permute_X_val_3_reduction_sum : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %arg0_input_reduction_sum_perm = torch.aten.permute %arg0_input, %permute_X_reduction_sum : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
-// TORCH-CHECK:       %reduction_dims_val_0_reduction_sum = torch.constant.int 2
-// TORCH-CHECK:       %reduction_dims_val_1_reduction_sum = torch.constant.int 3
-// TORCH-CHECK:       %reduction_dims_reduction_sum = torch.prim.ListConstruct %reduction_dims_val_0_reduction_sum, %reduction_dims_val_1_reduction_sum : (!torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %keepdim_reduction_sum = torch.constant.bool true
-// TORCH-CHECK:       %dtype_reduction_sum = torch.constant.none
-// TORCH-CHECK:       %result_reduction_sum_perm = torch.aten.sum.dim_IntList %arg0_input_reduction_sum_perm, %reduction_dims_reduction_sum, %keepdim_reduction_sum, %dtype_reduction_sum : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
-// TORCH-CHECK:       %permute_Y_val_0_reduction_sum = torch.constant.int 0
-// TORCH-CHECK:       %permute_Y_val_1_reduction_sum = torch.constant.int 1
-// TORCH-CHECK:       %permute_Y_val_2_reduction_sum = torch.constant.int 2
-// TORCH-CHECK:       %permute_Y_val_3_reduction_sum = torch.constant.int 3
-// TORCH-CHECK:       %permute_Y_reduction_sum = torch.prim.ListConstruct %permute_Y_val_0_reduction_sum, %permute_Y_val_1_reduction_sum, %permute_Y_val_2_reduction_sum, %permute_Y_val_3_reduction_sum : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_sum_perm, %permute_Y_reduction_sum : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_X_val_0_reduction_add = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_add = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_add = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_add = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_add = torch.prim.ListConstruct %permute_X_val_0_reduction_add, %permute_X_val_1_reduction_add, %permute_X_val_2_reduction_add, %permute_X_val_3_reduction_add : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_add_perm = torch.aten.permute %arg0_input, %permute_X_reduction_add : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_add = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_add = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_add = torch.prim.ListConstruct %reduction_dims_val_0_reduction_add, %reduction_dims_val_1_reduction_add : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %keepdim_reduction_add = torch.constant.bool true
+// TORCH-CHECK:       %dtype_reduction_add = torch.constant.none
+// TORCH-CHECK:       %result_reduction_add_perm = torch.aten.sum.dim_IntList %arg0_input_reduction_add_perm, %reduction_dims_reduction_add, %keepdim_reduction_add, %dtype_reduction_add : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_add = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_add = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_add = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_add = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_add = torch.prim.ListConstruct %permute_Y_val_0_reduction_add, %permute_Y_val_1_reduction_add, %permute_Y_val_2_reduction_add, %permute_Y_val_3_reduction_add : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_add_perm, %permute_Y_reduction_add : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
 // TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
 // TORCH-CHECK:       return
 // TORCH-CHECK:     }
@@ -53,10 +53,10 @@
 
 using namespace fusilli;
 
-static ErrorObject testReductionAsmEmitterSum(const std::string &mode) {
+static ErrorObject testReductionAsmEmitterAdd(const std::string &mode) {
   int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
   auto graph = std::make_shared<Graph>();
-  graph->setName("reduction_asm_emitter_sum");
+  graph->setName("reduction_asm_emitter_add");
   graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
 
   auto xT = graph->tensor(TensorAttr()
@@ -64,8 +64,8 @@ static ErrorObject testReductionAsmEmitterSum(const std::string &mode) {
                               .setDim({d0, d1, d2, d3})
                               .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
   auto reductionAttr = ReductionAttr()
-                           .setMode(ReductionAttr::Mode::SUM)
-                           .setName("reduction_sum");
+                           .setMode(ReductionAttr::Mode::ADD)
+                           .setName("reduction_add");
   auto yT = graph->reduction(xT, reductionAttr);
   yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
   yT->setName("result").setOutput(true);
@@ -92,7 +92,7 @@ static ErrorObject testReductionAsmEmitterSum(const std::string &mode) {
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testReductionAsmEmitterSum(mode);
+  auto status = testReductionAsmEmitterAdd(mode);
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_reduction_asm_emitter_amax.cpp
+++ b/tests/lit/test_reduction_asm_emitter_amax.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_amax = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_amax = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_amax = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_amax = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_amax = torch.prim.ListConstruct %permute_X_val_0_reduction_amax, %permute_X_val_1_reduction_amax, %permute_X_val_2_reduction_amax, %permute_X_val_3_reduction_amax : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_amax_perm = torch.aten.permute %arg0_input, %permute_X_reduction_amax : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_amax = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_amax = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_amax = torch.prim.ListConstruct %reduction_dims_val_0_reduction_amax, %reduction_dims_val_1_reduction_amax : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %abs_reduction_amax = torch.aten.abs %arg0_input_reduction_amax_perm : !torch.vtensor<[16,256,64,64],f32> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %keepdim_reduction_amax = torch.constant.bool true
+// TORCH-CHECK:       %result_reduction_amax_perm = torch.aten.amax %abs_reduction_amax, %reduction_dims_reduction_amax, %keepdim_reduction_amax : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_amax = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_amax = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_amax = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_amax = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_amax = torch.prim.ListConstruct %permute_Y_val_0_reduction_amax, %permute_Y_val_1_reduction_amax, %permute_Y_val_2_reduction_amax, %permute_Y_val_3_reduction_amax : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_amax_perm, %permute_Y_reduction_amax : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 2
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 2
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterAmax(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_amax");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::AMAX)
+                           .setName("reduction_amax");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterAmax(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_reduction_asm_emitter_avg.cpp
+++ b/tests/lit/test_reduction_asm_emitter_avg.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_avg = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_avg = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_avg = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_avg = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_avg = torch.prim.ListConstruct %permute_X_val_0_reduction_avg, %permute_X_val_1_reduction_avg, %permute_X_val_2_reduction_avg, %permute_X_val_3_reduction_avg : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_avg_perm = torch.aten.permute %arg0_input, %permute_X_reduction_avg : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_avg = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_avg = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_avg = torch.prim.ListConstruct %reduction_dims_val_0_reduction_avg, %reduction_dims_val_1_reduction_avg : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %keepdim_reduction_avg = torch.constant.bool true
+// TORCH-CHECK:       %dtype_reduction_avg = torch.constant.none
+// TORCH-CHECK:       %result_reduction_avg_perm = torch.aten.mean.dim %arg0_input_reduction_avg_perm, %reduction_dims_reduction_avg, %keepdim_reduction_avg, %dtype_reduction_avg : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_avg = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_avg = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_avg = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_avg = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_avg = torch.prim.ListConstruct %permute_Y_val_0_reduction_avg, %permute_Y_val_1_reduction_avg, %permute_Y_val_2_reduction_avg, %permute_Y_val_3_reduction_avg : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_avg_perm, %permute_Y_reduction_avg : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterAvg(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_avg");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::AVG)
+                           .setName("reduction_avg");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterAvg(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_reduction_asm_emitter_mul.cpp
+++ b/tests/lit/test_reduction_asm_emitter_mul.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_mul = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_mul = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_mul = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_mul = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_mul = torch.prim.ListConstruct %permute_X_val_0_reduction_mul, %permute_X_val_1_reduction_mul, %permute_X_val_2_reduction_mul, %permute_X_val_3_reduction_mul : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_mul_perm = torch.aten.permute %arg0_input, %permute_X_reduction_mul : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_mul = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_mul = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_mul = torch.prim.ListConstruct %reduction_dims_val_0_reduction_mul, %reduction_dims_val_1_reduction_mul : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %dtype_reduction_mul = torch.constant.none
+// TORCH-CHECK:       %result_reduction_mul_perm = torch.prims.prod %arg0_input_reduction_mul_perm, %reduction_dims_reduction_mul, %dtype_reduction_mul : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_mul = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_mul = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_mul = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_mul = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_mul = torch.prim.ListConstruct %permute_Y_val_0_reduction_mul, %permute_Y_val_1_reduction_mul, %permute_Y_val_2_reduction_mul, %permute_Y_val_3_reduction_mul : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_mul_perm, %permute_Y_reduction_mul : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterMul(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_mul");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::MUL)
+                           .setName("reduction_mul");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterMul(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_reduction_asm_emitter_mul_no_zeros.cpp
+++ b/tests/lit/test_reduction_asm_emitter_mul_no_zeros.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_mul_no_zeros = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_mul_no_zeros = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_mul_no_zeros = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_mul_no_zeros = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_mul_no_zeros = torch.prim.ListConstruct %permute_X_val_0_reduction_mul_no_zeros, %permute_X_val_1_reduction_mul_no_zeros, %permute_X_val_2_reduction_mul_no_zeros, %permute_X_val_3_reduction_mul_no_zeros : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_mul_no_zeros_perm = torch.aten.permute %arg0_input, %permute_X_reduction_mul_no_zeros : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_mul_no_zeros = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_mul_no_zeros = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_mul_no_zeros = torch.prim.ListConstruct %reduction_dims_val_0_reduction_mul_no_zeros, %reduction_dims_val_1_reduction_mul_no_zeros : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %zero_reduction_mul_no_zeros = torch.constant.int 0
+// TORCH-CHECK:       %mask_reduction_mul_no_zeros = torch.aten.ne.Scalar %arg0_input_reduction_mul_no_zeros_perm, %zero_reduction_mul_no_zeros : !torch.vtensor<[16,256,64,64],f32>, !torch.int -> !torch.vtensor<[16,256,64,64],i1>
+// TORCH-CHECK:       %one_reduction_mul_no_zeros = torch.constant.int 1
+// TORCH-CHECK:       %fixed_reduction_mul_no_zeros = torch.aten.where.ScalarOther %mask_reduction_mul_no_zeros, %arg0_input_reduction_mul_no_zeros_perm, %one_reduction_mul_no_zeros : !torch.vtensor<[16,256,64,64],i1>, !torch.vtensor<[16,256,64,64],f32>, !torch.int -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %dtype_reduction_mul_no_zeros = torch.constant.none
+// TORCH-CHECK:       %result_reduction_mul_no_zeros_perm = torch.prims.prod %fixed_reduction_mul_no_zeros, %reduction_dims_reduction_mul_no_zeros, %dtype_reduction_mul_no_zeros : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_mul_no_zeros = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_mul_no_zeros = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_mul_no_zeros = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_mul_no_zeros = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_mul_no_zeros = torch.prim.ListConstruct %permute_Y_val_0_reduction_mul_no_zeros, %permute_Y_val_1_reduction_mul_no_zeros, %permute_Y_val_2_reduction_mul_no_zeros, %permute_Y_val_3_reduction_mul_no_zeros : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_mul_no_zeros_perm, %permute_Y_reduction_mul_no_zeros : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterMulNoZeros(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_mul_no_zeros");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::MUL_NO_ZEROS)
+                           .setName("reduction_mul_no_zeros");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterMulNoZeros(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_reduction_asm_emitter_norm1.cpp
+++ b/tests/lit/test_reduction_asm_emitter_norm1.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_norm1 = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_norm1 = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_norm1 = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_norm1 = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_norm1 = torch.prim.ListConstruct %permute_X_val_0_reduction_norm1, %permute_X_val_1_reduction_norm1, %permute_X_val_2_reduction_norm1, %permute_X_val_3_reduction_norm1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_norm1_perm = torch.aten.permute %arg0_input, %permute_X_reduction_norm1 : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_norm1 = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_norm1 = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_norm1 = torch.prim.ListConstruct %reduction_dims_val_0_reduction_norm1, %reduction_dims_val_1_reduction_norm1 : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %abs_reduction_norm1 = torch.aten.abs %arg0_input_reduction_norm1_perm : !torch.vtensor<[16,256,64,64],f32> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %keepdim_reduction_norm1 = torch.constant.bool true
+// TORCH-CHECK:       %dtype_reduction_norm1 = torch.constant.none
+// TORCH-CHECK:       %result_reduction_norm1_perm = torch.aten.sum.dim_IntList %abs_reduction_norm1, %reduction_dims_reduction_norm1, %keepdim_reduction_norm1, %dtype_reduction_norm1 : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_norm1 = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_norm1 = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_norm1 = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_norm1 = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_norm1 = torch.prim.ListConstruct %permute_Y_val_0_reduction_norm1, %permute_Y_val_1_reduction_norm1, %permute_Y_val_2_reduction_norm1, %permute_Y_val_3_reduction_norm1 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_norm1_perm, %permute_Y_reduction_norm1 : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterNorm1(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_norm1");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::NORM1)
+                           .setName("reduction_norm1");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterNorm1(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_reduction_asm_emitter_norm2.cpp
+++ b/tests/lit/test_reduction_asm_emitter_norm2.cpp
@@ -1,0 +1,103 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,1,1],f32>, %arg0_input: !torch.vtensor<[16,256,64,64],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_X_val_0_reduction_norm2 = torch.constant.int 0
+// TORCH-CHECK:       %permute_X_val_1_reduction_norm2 = torch.constant.int 1
+// TORCH-CHECK:       %permute_X_val_2_reduction_norm2 = torch.constant.int 2
+// TORCH-CHECK:       %permute_X_val_3_reduction_norm2 = torch.constant.int 3
+// TORCH-CHECK:       %permute_X_reduction_norm2 = torch.prim.ListConstruct %permute_X_val_0_reduction_norm2, %permute_X_val_1_reduction_norm2, %permute_X_val_2_reduction_norm2, %permute_X_val_3_reduction_norm2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_input_reduction_norm2_perm = torch.aten.permute %arg0_input, %permute_X_reduction_norm2 : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %reduction_dims_val_0_reduction_norm2 = torch.constant.int 2
+// TORCH-CHECK:       %reduction_dims_val_1_reduction_norm2 = torch.constant.int 3
+// TORCH-CHECK:       %reduction_dims_reduction_norm2 = torch.prim.ListConstruct %reduction_dims_val_0_reduction_norm2, %reduction_dims_val_1_reduction_norm2 : (!torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %sq_reduction_norm2 = torch.aten.mul.Tensor %arg0_input_reduction_norm2_perm, %arg0_input_reduction_norm2_perm : !torch.vtensor<[16,256,64,64],f32>, !torch.vtensor<[16,256,64,64],f32> -> !torch.vtensor<[16,256,64,64],f32>
+// TORCH-CHECK:       %keepdim_reduction_norm2 = torch.constant.bool true
+// TORCH-CHECK:       %dtype_reduction_norm2 = torch.constant.none
+// TORCH-CHECK:       %sumsq_reduction_norm2 = torch.aten.sum.dim_IntList %sq_reduction_norm2, %reduction_dims_reduction_norm2, %keepdim_reduction_norm2, %dtype_reduction_norm2 : !torch.vtensor<[16,256,64,64],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %result_reduction_norm2_perm = torch.aten.sqrt %sumsq_reduction_norm2 : !torch.vtensor<[16,256,1,1],f32> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       %permute_Y_val_0_reduction_norm2 = torch.constant.int 0
+// TORCH-CHECK:       %permute_Y_val_1_reduction_norm2 = torch.constant.int 1
+// TORCH-CHECK:       %permute_Y_val_2_reduction_norm2 = torch.constant.int 2
+// TORCH-CHECK:       %permute_Y_val_3_reduction_norm2 = torch.constant.int 3
+// TORCH-CHECK:       %permute_Y_reduction_norm2 = torch.prim.ListConstruct %permute_Y_val_0_reduction_norm2, %permute_Y_val_1_reduction_norm2, %permute_Y_val_2_reduction_norm2, %permute_Y_val_3_reduction_norm2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_reduction_norm2_perm, %permute_Y_reduction_norm2 : !torch.vtensor<[16,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[16,256,1,1],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,1,1],f32>, !torch.tensor<[16,256,1,1],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject testReductionAsmEmitterNorm2(const std::string &mode) {
+  int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 64;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("reduction_asm_emitter_norm2");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_input")
+                              .setDim({d0, d1, d2, d3})
+                              .setStride({d1 * d2 * d3, d2 * d3, d3, 1}));
+  auto reductionAttr = ReductionAttr()
+                           .setMode(ReductionAttr::Mode::NORM2)
+                           .setName("reduction_norm2");
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testReductionAsmEmitterNorm2(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/test_reduction_node.cpp
+++ b/tests/test_reduction_node.cpp
@@ -163,6 +163,35 @@ TEST_CASE("ReductionNode with SUM mode", "[reduction_node]") {
   FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 }
 
+TEST_CASE("ReductionNode rejects AVG on integral or boolean tensors",
+          "[reduction_node]") {
+  Context ctx;
+  ReductionAttr attr;
+  attr.setMode(ReductionAttr::Mode::AVG);
+
+  auto x = std::make_shared<TensorAttr>();
+  x->setDim({2, 3}).setStride({3, 1}).setDataType(DataType::Float);
+
+  auto y = std::make_shared<TensorAttr>();
+  y->setDim({2, 1}).setStride({1, 1}).setDataType(DataType::Float);
+
+  SECTION("integer input") { x->setDataType(DataType::Int32); }
+  SECTION("boolean input") { x->setDataType(DataType::Boolean); }
+  SECTION("integer output") { y->setDataType(DataType::Int32); }
+
+  attr.setX(x).setY(y);
+
+  ReductionNode node(std::move(attr), ctx);
+  FUSILLI_REQUIRE_OK(node.preValidateNode());
+  FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+  auto status = node.postValidateNode();
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+  REQUIRE(status.getMessage() ==
+          "Reduction AVG is not supported for integral or boolean tensors");
+}
+
 TEST_CASE("ReductionNode with MAX mode full tensor reduction",
           "[reduction_node]") {
   Context ctx;


### PR DESCRIPTION
Enable the remaining cuDNN reduction modes in ReductionAttr and add the corresponding MLIR schemas to the asm emitter:

- NORM1 lowers to abs + sum.dim_IntList.
- AMAX lowers to abs + amax.
- AVG lowers to mean.dim (float dtypes only — torch.aten.mean.dim is not defined on integer tensors, so the sample skips int32 for AVG).
- NORM2 lowers to mul + sum.dim_IntList + sqrt.
- MUL lowers directly to torch.prims.prod.
- MUL_NO_ZEROS uses aten.ne.Scalar to build an i1 mask, then aten.where.ScalarOther to substitute 1 for zero entries before feeding the result to torch.prims.prod, so zero inputs are excluded from the product.

Extend samples/reduction/reduction_ops.cpp to exercise every new mode. Input data is built by a per-mode generateReductionInputData helper so MUL/MUL_NO_ZEROS get a non-trivial pattern (mostly 1s with a 2 and a 3, plus injected zeros for MUL_NO_ZEROS) that stays in range for fp16/int32, and the expected value is computed by the existing reference reduction loop rather than hardcoded.

Add lit tests for each new mode under tests/lit/ and register them in tests/CMakeLists.txt.