### PR TITLE
Add broadcast-compatible scale support for RmsNorm

### DIFF
--- a/include/fusilli/node/norm_utils.h
+++ b/include/fusilli/node/norm_utils.h
@@ -98,6 +98,34 @@ inline void inferScaleBiasDimAndStride(std::shared_ptr<TensorAttr> &tensor,
   inferStride(tensor, getScaleBiasStride(tensor->getDim(), xStride));
 }
 
+// Returns true if scaleDim is broadcast-compatible with the expected
+// scale/bias shape derived from xDim. Each dimension must either match
+// the corresponding X dimension (with batch forced to 1) or be 1.
+inline bool isScaleBiasBroadcastCompatible(const std::vector<int64_t> &scaleDim,
+                                           const std::vector<int64_t> &xDim,
+                                           size_t batchDim = 0) {
+  if (scaleDim.size() != xDim.size())
+    return false;
+  for (size_t i = 0; i < scaleDim.size(); ++i) {
+    int64_t expected = (i == batchDim) ? 1 : xDim[i];
+    if (scaleDim[i] != expected && scaleDim[i] != 1)
+      return false;
+  }
+  return true;
+}
+
+// Infers dim and stride of a scale tensor for RmsNorm.
+// If dims are not set, they default to X's shape with batch=1.
+// If dims are already set (e.g. broadcast-compatible {1,c,1,1}),
+// they are preserved and strides are computed for that shape.
+inline void inferRmsScaleDimAndStride(std::shared_ptr<TensorAttr> &tensor,
+                                      const std::vector<int64_t> &xDim,
+                                      const std::vector<int64_t> &xStride,
+                                      size_t batchDim = 0) {
+  inferDim(tensor, getScaleBiasDim(xDim, batchDim));
+  inferStride(tensor, getScaleBiasStride(tensor->getDim(), xStride));
+}
+
 } // namespace fusilli::norm_utils
 
 #endif // FUSILLI_NODE_NORM_UTILS_H

--- a/include/fusilli/node/rmsnorm_node.h
+++ b/include/fusilli/node/rmsnorm_node.h
@@ -88,14 +88,17 @@ public:
 
     // Shape and layout checks on scale tensor.
     // If scale tensor's dims/strides are not set, they will be inferred in
-    // inferPropertiesNode().
+    // inferPropertiesNode(). Scale may be broadcast-compatible with X (each
+    // dim is either 1 or matches X, with batch forced to 1).
     if (sT) {
       if (!sT->getDim().empty()) {
-        FUSILLI_RETURN_ERROR_IF(sT->getDim() !=
-                                    norm_utils::getScaleBiasDim(xT->getDim()),
-                                ErrorCode::InvalidAttribute,
-                                "RmsNorm input tensor SCALE must have shape as "
-                                "tensor X with single batch");
+        FUSILLI_RETURN_ERROR_IF(
+            !norm_utils::isScaleBiasBroadcastCompatible(sT->getDim(),
+                                                        xT->getDim()),
+            ErrorCode::InvalidAttribute,
+            "RmsNorm input tensor SCALE must have a broadcast-compatible "
+            "shape with tensor X (each dim must be 1 or match X, with "
+            "single batch)");
       }
 
       if (!sT->getStride().empty()) {
@@ -140,9 +143,11 @@ public:
     const std::vector<int64_t> &xDim = xT->getDim();
 
     // Infer shape and stride of input SCALE tensor if they're not set.
+    // Scale may be broadcast-compatible; dims are expanded to match X's
+    // shape and strides are computed from the target shape.
     std::shared_ptr<TensorAttr> sT = rmsnormAttr.getSCALE();
     if (sT) {
-      norm_utils::inferScaleBiasDimAndStride(sT, xDim, xT->getStride());
+      norm_utils::inferRmsScaleDimAndStride(sT, xDim, xT->getStride());
     }
 
     // Infer shape and stride of output Y tensor.

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -213,9 +213,22 @@ getScalarConstantAsm(const std::shared_ptr<TensorAttr> &tensor) {
   assert(tensor->isScalar() && tensor->getScalarValue().has_value() &&
          "getScalarConstantAsm called with non-scalar tensor");
   std::string resultName = tensor->getValueNameAsm();
-  std::string mlirType = kDataTypeToMlirTypeAsm.at(tensor->getDataType());
+  std::string mlirDType = kDataTypeToMlirTypeAsm.at(tensor->getDataType());
   std::string resultType = tensor->getTensorTypeAsm(/*isValueTensor=*/true,
                                                     /*useLogicalDims=*/true);
+  // Build the dense tensor shape from actual dimensions (e.g. "1x1x1x1").
+  std::ostringstream shapeOss;
+  const auto &dims = tensor->getDim();
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (i > 0)
+      shapeOss << "x";
+    shapeOss << dims[i];
+  }
+  if (!shapeOss.str().empty())
+    shapeOss << "x";
+  shapeOss << mlirDType;
+
+  std::string mlirType = shapeOss.str();
   // std::visit generates a compile time switch statement executing lambda
   // instantiation per variant alternative.
   // Example output:
@@ -224,7 +237,7 @@ getScalarConstantAsm(const std::shared_ptr<TensorAttr> &tensor) {
   //   int32  42    → dense<0x0000002A>   : tensor<1xi32>
   //   int64  42L   → dense<0x000000000000002A> : tensor<1xi64>
   constexpr std::string_view schema = R"(
-    {0} = torch.vtensor.literal(dense<0x{1}> : tensor<1x{2}>) : {3}
+    {0} = torch.vtensor.literal(dense<0x{1}> : tensor<{2}>) : {3}
 )";
   return std::visit(
       [&](auto val) -> std::string {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -93,6 +93,7 @@ add_fusilli_samples(
     rmsnorm/rmsnorm_infer_nchw.cpp
     rmsnorm/rmsnorm_infer_nchw_scale.cpp
     rmsnorm/rmsnorm_infer_nhwc_scale.cpp
+    rmsnorm/rmsnorm_infer_nhwc_scale_broadcast.cpp
   DEPS
     libfusilli
     libutils

--- a/samples/rmsnorm/rmsnorm_infer_nhwc_scale_broadcast.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nhwc_scale_broadcast.cpp
@@ -21,14 +21,15 @@
 
 using namespace fusilli;
 
-TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
-          "[rmsnorm][graph]") {
+TEST_CASE(
+    "RMS normalization; inference mode; NHWC layout; with broadcast scale",
+    "[rmsnorm][graph]") {
   constexpr int64_t n = 2, c = 3, h = 32, w = 32;
   constexpr float eps = 1e-5f;
 
   auto buildNewGraph = [=](const Handle &handle) {
     auto graph = std::make_shared<Graph>();
-    graph->setName("rmsnorm_infer_sample_nhwc_scale");
+    graph->setName("rmsnorm_infer_sample_nhwc_scale_broadcast");
     graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
 
     auto xT = graph->tensor(TensorAttr()
@@ -36,10 +37,12 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
                                 .setDim({n, c, h, w})
                                 .setStride({c * h * w, 1, c * w, c}));
 
+    // Scale has broadcast-compatible shape: only channel dimension is set,
+    // spatial dims are 1 and will be expanded to match X during inference.
     auto scaleT = graph->tensor(TensorAttr()
                                     .setName("scale")
-                                    .setDim({1, c, h, w})
-                                    .setStride({c * h * w, 1, c * w, c}));
+                                    .setDim({1, c, 1, 1})
+                                    .setStride({c, 1, c, c}));
 
     auto epsilonT = graph->tensor(
         TensorAttr(eps).setDim({1, 1, 1, 1}).setStride({1, 1, 1, 1}));
@@ -73,8 +76,8 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
       rmsnorm_utils::generateIOTensorsForInferForward(n, c, h, w, scale, eps);
 
   // Use a non-unity scale to verify scale is actually applied.
-  size_t scaleSize = 1 * c * h * w;
-  std::vector<float> scaleVals(scaleSize, scale);
+  // Only c elements needed — one per channel, broadcast across spatial dims.
+  std::vector<float> scaleVals(c, scale);
 
   FUSILLI_REQUIRE_ASSIGN(auto xBuf,
                          allocateBufferOfType(handle, xT, inputVals));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,7 @@ add_fusilli_lit_tests(
     lit/test_layernorm_train_asm_emitter_scale_bias_nhwc.cpp
     lit/test_rmsnorm_infer_asm_emitter_nchw.cpp
     lit/test_rmsnorm_infer_asm_emitter_scale_nhwc.cpp
+    lit/test_rmsnorm_infer_asm_emitter_scale_nhwc_broadcast.cpp
     lit/test_matmul_asm_emitter_basic.cpp
     lit/test_matmul_asm_emitter_batched.cpp
     lit/test_matmul_asm_emitter_broadcast_3D.cpp

--- a/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc_broadcast.cpp
+++ b/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc_broadcast.cpp
@@ -1,0 +1,123 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,128],f32>, %arg0_scale: !torch.vtensor<[1,128,1,1],f32>, %arg0_x: !torch.vtensor<[16,64,32,128],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// Graph-level scalar constant emission for epsilon:
+// TORCH-CHECK:       %rmsnorm_infer_EPSILON = torch.vtensor.literal(dense<0x3727C5AC> : tensor<1x1x1x1xf32>) : !torch.vtensor<[1,1,1,1],f32>
+// TORCH-CHECK:       %normalized_shape_val_0_rmsnorm_infer = torch.constant.int 128
+// TORCH-CHECK:       %normalized_shape_val_1_rmsnorm_infer = torch.constant.int 64
+// TORCH-CHECK:       %normalized_shape_val_2_rmsnorm_infer = torch.constant.int 32
+// TORCH-CHECK:       %normalized_shape_rmsnorm_infer = torch.prim.ListConstruct %normalized_shape_val_0_rmsnorm_infer, %normalized_shape_val_1_rmsnorm_infer, %normalized_shape_val_2_rmsnorm_infer : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %eps_rmsnorm_infer = torch.aten.item %rmsnorm_infer_EPSILON : !torch.vtensor<[1,1,1,1],f32> -> !torch.float
+// TORCH-CHECK:       %permute_x_val_0_rmsnorm_infer = torch.constant.int 0
+// TORCH-CHECK:       %permute_x_val_1_rmsnorm_infer = torch.constant.int 3
+// TORCH-CHECK:       %permute_x_val_2_rmsnorm_infer = torch.constant.int 1
+// TORCH-CHECK:       %permute_x_val_3_rmsnorm_infer = torch.constant.int 2
+// TORCH-CHECK:       %permute_x_rmsnorm_infer = torch.prim.ListConstruct %permute_x_val_0_rmsnorm_infer, %permute_x_val_1_rmsnorm_infer, %permute_x_val_2_rmsnorm_infer, %permute_x_val_3_rmsnorm_infer : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_x_rmsnorm_infer_perm = torch.aten.permute %arg0_x, %permute_x_rmsnorm_infer : !torch.vtensor<[16,64,32,128],f32>, !torch.list<int> -> !torch.vtensor<[16,128,64,32],f32>
+// TORCH-CHECK:       %permute_scale_val_0_rmsnorm_infer = torch.constant.int 0
+// TORCH-CHECK:       %permute_scale_val_1_rmsnorm_infer = torch.constant.int 1
+// TORCH-CHECK:       %permute_scale_val_2_rmsnorm_infer = torch.constant.int 2
+// TORCH-CHECK:       %permute_scale_val_3_rmsnorm_infer = torch.constant.int 3
+// TORCH-CHECK:       %permute_scale_rmsnorm_infer = torch.prim.ListConstruct %permute_scale_val_0_rmsnorm_infer, %permute_scale_val_1_rmsnorm_infer, %permute_scale_val_2_rmsnorm_infer, %permute_scale_val_3_rmsnorm_infer : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_scale_rmsnorm_infer_perm = torch.aten.permute %arg0_scale, %permute_scale_rmsnorm_infer : !torch.vtensor<[1,128,1,1],f32>, !torch.list<int> -> !torch.vtensor<[1,128,1,1],f32>
+// TORCH-CHECK:       %result_rmsnorm_infer_perm = torch.aten.rms_norm %arg0_x_rmsnorm_infer_perm, %normalized_shape_rmsnorm_infer, %arg0_scale_rmsnorm_infer_perm, %eps_rmsnorm_infer : !torch.vtensor<[16,128,64,32],f32>, !torch.list<int>, !torch.vtensor<[1,128,1,1],f32>, !torch.float -> !torch.vtensor<[16,128,64,32],f32>
+// TORCH-CHECK:       %permute_y_val_0_rmsnorm_infer = torch.constant.int 0
+// TORCH-CHECK:       %permute_y_val_1_rmsnorm_infer = torch.constant.int 2
+// TORCH-CHECK:       %permute_y_val_2_rmsnorm_infer = torch.constant.int 3
+// TORCH-CHECK:       %permute_y_val_3_rmsnorm_infer = torch.constant.int 1
+// TORCH-CHECK:       %permute_y_rmsnorm_infer = torch.prim.ListConstruct %permute_y_val_0_rmsnorm_infer, %permute_y_val_1_rmsnorm_infer, %permute_y_val_2_rmsnorm_infer, %permute_y_val_3_rmsnorm_infer : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_rmsnorm_infer_perm, %permute_y_rmsnorm_infer : !torch.vtensor<[16,128,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,64,32,128],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,64,32,128],f32>, !torch.tensor<[16,64,32,128],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace fusilli;
+
+static ErrorObject
+testRmsnormInferAsmEmitterScaleNhwcBroadcast(const std::string &mode) {
+  int64_t n = 16, c = 128, h = 64, w = 32;
+  auto graph = std::make_shared<Graph>();
+  graph->setName("rmsnorm_infer_asm_emitter_scale_nhwc_broadcast");
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("arg0_x")
+                              .setDim({n, c, h, w})
+                              .setStride({c * h * w, 1, c * w, c})); // NHWC
+
+  // Scale has broadcast-compatible shape: only channel dimension is set,
+  // spatial dims are 1 and will be broadcast by the rmsnorm op.
+  auto scaleT = graph->tensor(TensorAttr()
+                                  .setName("arg0_scale")
+                                  .setDim({1, c, 1, 1})
+                                  .setStride({c, 1, c, c}));
+
+  auto epsilonT = graph->tensor(
+      TensorAttr(1e-5f).setDim({1, 1, 1, 1}).setStride({1, 1, 1, 1}));
+
+  auto rmsnormAttr = RmsnormAttr()
+                         .setForwardPhase(NormFwdPhase::INFERENCE)
+                         .setEpsilon(epsilonT)
+                         .setName("rmsnorm_infer");
+
+  auto [yT, rT] = graph->rmsnorm(xT, scaleT, rmsnormAttr);
+
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testRmsnormInferAsmEmitterScaleNhwcBroadcast(mode);
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/test_rmsnorm_node.cpp
+++ b/tests/test_rmsnorm_node.cpp
@@ -304,9 +304,10 @@ TEST_CASE("RmsNormNode shape checks on SCALE tensor", "[rmsnorm_node]") {
     auto status = node.preValidateNode();
     REQUIRE(isError(status));
     REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
-    REQUIRE(status.getMessage() ==
-            "RmsNorm input tensor SCALE must have shape as "
-            "tensor X with single batch");
+    REQUIRE(
+        status.getMessage() ==
+        "RmsNorm input tensor SCALE must have a broadcast-compatible shape with"
+        " tensor X (each dim must be 1 or match X, with single batch)");
   }
 }
 


### PR DESCRIPTION
Allow RmsNorm scale tensors to have broadcast-compatible shapes (e.g. {1,c,1,1} instead of {1,c,h,w}), letting torch.aten.rms_norm handle the broadcasting internally. Also update getScalarConstantAsm to emit the actual tensor shape instead of hardcoding tensor<1x...>.