### PR TITLE
Add IDENTITY, RSQRT, SIN, SQRT, and TAN pointwise op support

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -47,7 +47,7 @@ namespace fusilli {
   /* OP(GELU_BWD) */                                                           \
   /* OP(GELU_FWD) */                                                           \
   /* OP(GEN_INDEX) */                                                          \
-  /* OP(IDENTITY)  */                                                          \
+  OP(IDENTITY)                                                                 \
   OP(LOG)                                                                      \
   OP(LOGICAL_AND)                                                              \
   OP(LOGICAL_NOT)                                                              \
@@ -59,17 +59,17 @@ namespace fusilli {
   OP(RECIPROCAL)                                                               \
   /* OP(RELU_BWD) */                                                           \
   OP(RELU_FWD)                                                                 \
-  /* OP(RSQRT) */                                                              \
+  OP(RSQRT)                                                                    \
   /* OP(SIGMOID_BWD) */                                                        \
   OP(SIGMOID_FWD)                                                              \
-  /* OP(SIN) */                                                                \
+  OP(SIN)                                                                      \
   /* OP(SOFTPLUS_BWD) */                                                       \
   /* OP(SOFTPLUS_FWD) */                                                       \
-  /* OP(SQRT) */                                                               \
+  OP(SQRT)                                                                     \
   OP(SUB)                                                                      \
   /* OP(SWISH_BWD) */                                                          \
   /* OP(SWISH_FWD) */                                                          \
-  /* OP(TAN) */                                                                \
+  OP(TAN)                                                                      \
   /* OP(TANH_BWD) */                                                           \
   OP(TANH_FWD)
 
@@ -157,10 +157,15 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
         {PointwiseAttr::Mode::MIN_OP, 2},
         {PointwiseAttr::Mode::MUL, 2},
         {PointwiseAttr::Mode::NEG, 1},
+        {PointwiseAttr::Mode::IDENTITY, 1},
         {PointwiseAttr::Mode::RECIPROCAL, 1},
         {PointwiseAttr::Mode::RELU_FWD, 1},
+        {PointwiseAttr::Mode::RSQRT, 1},
         {PointwiseAttr::Mode::SIGMOID_FWD, 1},
+        {PointwiseAttr::Mode::SIN, 1},
+        {PointwiseAttr::Mode::SQRT, 1},
         {PointwiseAttr::Mode::SUB, 2},
+        {PointwiseAttr::Mode::TAN, 1},
         {PointwiseAttr::Mode::TANH_FWD, 1}};
 
 } // namespace fusilli

--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -43,9 +43,9 @@ namespace fusilli {
   OP(EXP)                                                                      \
   OP(FLOOR)                                                                    \
   /* OP(GELU_APPROX_TANH_BWD)  */                                              \
-  /* OP(GELU_APPROX_TANH_FWD)  */                                              \
+  OP(GELU_APPROX_TANH_FWD)                                                     \
   /* OP(GELU_BWD) */                                                           \
-  /* OP(GELU_FWD) */                                                           \
+  OP(GELU_FWD)                                                                 \
   /* OP(GEN_INDEX) */                                                          \
   OP(IDENTITY)                                                                 \
   OP(LOG)                                                                      \
@@ -149,6 +149,8 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
         {PointwiseAttr::Mode::ERF, 1},
         {PointwiseAttr::Mode::EXP, 1},
         {PointwiseAttr::Mode::FLOOR, 1},
+        {PointwiseAttr::Mode::GELU_APPROX_TANH_FWD, 1},
+        {PointwiseAttr::Mode::GELU_FWD, 1},
         {PointwiseAttr::Mode::LOG, 1},
         {PointwiseAttr::Mode::LOGICAL_AND, 2},
         {PointwiseAttr::Mode::LOGICAL_NOT, 1},

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1794,6 +1794,13 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {5}
 )";
 
+  constexpr std::string_view kGeluSchema = R"(
+    {0}
+    %gelu_approximate_{7} = torch.constant.str "{8}"
+    {1} = {6} {2}, %gelu_approximate_{7} : {3}, !torch.str -> {4}
+    {5}
+)";
+
 #define FUSILLI_DECLARE_UNARY_TORCH_EMITTER(PWOP, OPIR)                        \
   FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(PWOP, kUnaryTorchSchema, OPIR)
 #define FUSILLI_DECLARE_BINARY_TORCH_EMITTER(PWOP, OPIR)                       \
@@ -1818,6 +1825,30 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
   }
     FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,
                                             torch.aten.clone)
+  case PointwiseAttr::Mode::GELU_FWD: {
+    return std::format(kGeluSchema, permuteIN0, /* {0} */
+                       getResultNamesAsm(),     /* {1} */
+                       getOperandNamesAsm(),    /* {2} */
+                       getOperandTypesAsm(),    /* {3} */
+                       getResultTypesAsm(),     /* {4} */
+                       permuteOUT0,             /* {5} */
+                       "torch.aten.gelu",       /* {6} */
+                       getName(),               /* {7} */
+                       "none"                   /* {8} */
+    );
+  }
+  case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD: {
+    return std::format(kGeluSchema, permuteIN0, /* {0} */
+                       getResultNamesAsm(),     /* {1} */
+                       getOperandNamesAsm(),    /* {2} */
+                       getOperandTypesAsm(),    /* {3} */
+                       getResultTypesAsm(),     /* {4} */
+                       permuteOUT0,             /* {5} */
+                       "torch.aten.gelu",       /* {6} */
+                       getName(),               /* {7} */
+                       "tanh"                   /* {8} */
+    );
+  }
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(ERF, torch.aten.erf)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(EXP, torch.aten.exp)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(FLOOR, torch.aten.floor)

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1778,6 +1778,13 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {6}
 )";
 
+  constexpr std::string_view kIdentitySchema = R"(
+    {0}
+    %none_{7} = torch.constant.none
+    {1} = {6} {2}, %none_{7} : {3}, !torch.none -> {4}
+    {5}
+)";
+
   constexpr std::string_view kEluSchema = R"(
     {0}
     %elu_alpha_{7} = torch.constant.float {8:e}
@@ -1809,6 +1816,8 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        pointwiseAttr.getEluAlpha() /* {8} */
     );
   }
+    FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,
+                                            torch.aten.clone)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(ERF, torch.aten.erf)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(EXP, torch.aten.exp)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(FLOOR, torch.aten.floor)
@@ -1817,8 +1826,12 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(NEG, torch.aten.neg)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(RECIPROCAL, torch.aten.reciprocal)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(RELU_FWD, torch.aten.relu)
+    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(RSQRT, torch.aten.rsqrt)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(SIGMOID_FWD, torch.aten.sigmoid)
+    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(SIN, torch.aten.sin)
+    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(SQRT, torch.aten.sqrt)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(TANH_FWD, torch.aten.tanh)
+    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(TAN, torch.aten.tan)
 
     FUSILLI_DECLARE_BINARY_TORCH_EMITTER(CMP_EQ, torch.aten.eq.Tensor)
     FUSILLI_DECLARE_BINARY_TORCH_EMITTER(CMP_LT, torch.aten.lt.Tensor)

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -42,6 +42,7 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
   auto supportsInteger = [](PointwiseAttr::Mode m) {
     switch (m) {
     case PointwiseAttr::Mode::ABS:
+    case PointwiseAttr::Mode::IDENTITY:
     case PointwiseAttr::Mode::NEG:
     case PointwiseAttr::Mode::RELU_FWD:
       return true;
@@ -51,8 +52,9 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
   };
 
   auto supportsNegative = [](PointwiseAttr::Mode m) {
-    // LOG is undefined for non-positive inputs.
-    return m != PointwiseAttr::Mode::LOG;
+    // LOG, RSQRT, and SQRT are undefined for non-positive inputs.
+    return m != PointwiseAttr::Mode::LOG && m != PointwiseAttr::Mode::RSQRT &&
+           m != PointwiseAttr::Mode::SQRT;
   };
 
   auto supportsFloat = [](PointwiseAttr::Mode m) {
@@ -63,11 +65,16 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     case PointwiseAttr::Mode::ERF:
     case PointwiseAttr::Mode::EXP:
     case PointwiseAttr::Mode::FLOOR:
+    case PointwiseAttr::Mode::IDENTITY:
     case PointwiseAttr::Mode::LOG:
     case PointwiseAttr::Mode::NEG:
     case PointwiseAttr::Mode::RECIPROCAL:
     case PointwiseAttr::Mode::RELU_FWD:
+    case PointwiseAttr::Mode::RSQRT:
     case PointwiseAttr::Mode::SIGMOID_FWD:
+    case PointwiseAttr::Mode::SIN:
+    case PointwiseAttr::Mode::SQRT:
+    case PointwiseAttr::Mode::TAN:
     case PointwiseAttr::Mode::TANH_FWD:
       return true;
     default:
@@ -83,11 +90,16 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       PointwiseAttr::Mode::ERF,
       PointwiseAttr::Mode::EXP,
       PointwiseAttr::Mode::FLOOR,
+      PointwiseAttr::Mode::IDENTITY,
       PointwiseAttr::Mode::LOG,
       PointwiseAttr::Mode::NEG,
       PointwiseAttr::Mode::RECIPROCAL,
       PointwiseAttr::Mode::RELU_FWD,
+      PointwiseAttr::Mode::RSQRT,
       PointwiseAttr::Mode::SIGMOID_FWD,
+      PointwiseAttr::Mode::SIN,
+      PointwiseAttr::Mode::SQRT,
+      PointwiseAttr::Mode::TAN,
       PointwiseAttr::Mode::TANH_FWD);
   // clang-format on
 
@@ -190,6 +202,10 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       y = std::floor(xD);
       break;
     }
+    case PointwiseAttr::Mode::IDENTITY: {
+      y = x;
+      break;
+    }
     case PointwiseAttr::Mode::LOG: {
       double xD = static_cast<double>(x);
       y = std::log(xD);
@@ -202,6 +218,26 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     case PointwiseAttr::Mode::RECIPROCAL: {
       double xD = static_cast<double>(x);
       y = 1.0 / xD;
+      break;
+    }
+    case PointwiseAttr::Mode::RSQRT: {
+      double xD = static_cast<double>(x);
+      y = 1.0 / std::sqrt(xD);
+      break;
+    }
+    case PointwiseAttr::Mode::SIN: {
+      double xD = static_cast<double>(x);
+      y = std::sin(xD);
+      break;
+    }
+    case PointwiseAttr::Mode::SQRT: {
+      double xD = static_cast<double>(x);
+      y = std::sqrt(xD);
+      break;
+    }
+    case PointwiseAttr::Mode::TAN: {
+      double xD = static_cast<double>(x);
+      y = std::tan(xD);
       break;
     }
     default:

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -65,6 +65,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     case PointwiseAttr::Mode::ERF:
     case PointwiseAttr::Mode::EXP:
     case PointwiseAttr::Mode::FLOOR:
+    case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD:
+    case PointwiseAttr::Mode::GELU_FWD:
     case PointwiseAttr::Mode::IDENTITY:
     case PointwiseAttr::Mode::LOG:
     case PointwiseAttr::Mode::NEG:
@@ -90,6 +92,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       PointwiseAttr::Mode::ERF,
       PointwiseAttr::Mode::EXP,
       PointwiseAttr::Mode::FLOOR,
+      PointwiseAttr::Mode::GELU_APPROX_TANH_FWD,
+      PointwiseAttr::Mode::GELU_FWD,
       PointwiseAttr::Mode::IDENTITY,
       PointwiseAttr::Mode::LOG,
       PointwiseAttr::Mode::NEG,
@@ -202,6 +206,20 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       y = std::floor(xD);
       break;
     }
+    case PointwiseAttr::Mode::GELU_FWD: {
+      double xD = static_cast<double>(x);
+      // GELU(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+      y = 0.5 * xD * (1.0 + std::erf(xD / std::sqrt(2.0)));
+      break;
+    }
+    case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD: {
+      double xD = static_cast<double>(x);
+      // GELU tanh approx: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715*x^3)))
+      constexpr double kSqrt2OverPi = 0.7978845608028654;
+      const double inner = kSqrt2OverPi * (xD + 0.044715 * xD * xD * xD);
+      y = 0.5 * xD * (1.0 + std::tanh(inner));
+      break;
+    }
     case PointwiseAttr::Mode::IDENTITY: {
       y = x;
       break;
@@ -251,8 +269,11 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
 
     auto isClose = [](T lhs, T rhs) -> bool {
       if (std::is_floating_point<T>::value || std::is_same<T, half>::value) {
-        return std::abs(static_cast<double>(lhs) - static_cast<double>(rhs)) <
-               1e-3;
+        const double lhsD = static_cast<double>(lhs);
+        const double rhsD = static_cast<double>(rhs);
+        const double absTol = 1e-3;
+        const double relTol = 1e-3;
+        return std::abs(lhsD - rhsD) <= absTol + relTol * std::abs(rhsD);
       }
       return lhs == rhs;
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,8 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_erf.cpp
     lit/test_pointwise_asm_emitter_exp.cpp
     lit/test_pointwise_asm_emitter_floor.cpp
+    lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
+    lit/test_pointwise_asm_emitter_gelu_fwd.cpp
     lit/test_pointwise_asm_emitter_identity.cpp
     lit/test_pointwise_asm_emitter_log.cpp
     lit/test_pointwise_asm_emitter_logical_and.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,7 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_erf.cpp
     lit/test_pointwise_asm_emitter_exp.cpp
     lit/test_pointwise_asm_emitter_floor.cpp
+    lit/test_pointwise_asm_emitter_identity.cpp
     lit/test_pointwise_asm_emitter_log.cpp
     lit/test_pointwise_asm_emitter_logical_and.cpp
     lit/test_pointwise_asm_emitter_logical_not.cpp
@@ -170,7 +171,11 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_mul_scalar.cpp
     lit/test_pointwise_asm_emitter_neg.cpp
     lit/test_pointwise_asm_emitter_reciprocal.cpp
+    lit/test_pointwise_asm_emitter_rsqrt.cpp
     lit/test_pointwise_asm_emitter_sigmoid.cpp
+    lit/test_pointwise_asm_emitter_sin.cpp
+    lit/test_pointwise_asm_emitter_sqrt.cpp
+    lit/test_pointwise_asm_emitter_tan.cpp
     lit/test_pointwise_asm_emitter_tanh.cpp
     lit/test_pointwise_asm_emitter_sub.cpp
     lit/test_conv_wgrad_asm_emitter_nhwc_krsc.cpp

--- a/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_gelu_approx_tanh_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_gelu_approx_tanh_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_gelu_approx_tanh_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_gelu_approx_tanh_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_gelu_approx_tanh_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_1_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_2_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_3_pointwise_gelu_approx_tanh_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_gelu_approx_tanh_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %gelu_approximate_pointwise_gelu_approx_tanh_fwd = torch.constant.str "tanh"
+// TORCH-CHECK:       %result_pointwise_gelu_approx_tanh_fwd_perm = torch.aten.gelu %arg0_pointwise_gelu_approx_tanh_fwd_perm, %gelu_approximate_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.str -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_gelu_approx_tanh_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_gelu_approx_tanh_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_gelu_approx_tanh_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_gelu_approx_tanh_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_gelu_approx_tanh_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_1_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_2_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_3_pointwise_gelu_approx_tanh_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_gelu_approx_tanh_fwd_perm, %permute_OUT_0_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_gelu_approx_tanh_fwd",
+      "pointwise_gelu_approx_tanh_fwd", mode,
+      PointwiseAttr::Mode::GELU_APPROX_TANH_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_gelu_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_gelu_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_gelu_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_gelu_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_gelu_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_gelu_fwd, %permute_IN_0_val_1_pointwise_gelu_fwd, %permute_IN_0_val_2_pointwise_gelu_fwd, %permute_IN_0_val_3_pointwise_gelu_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_gelu_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %gelu_approximate_pointwise_gelu_fwd = torch.constant.str "none"
+// TORCH-CHECK:       %result_pointwise_gelu_fwd_perm = torch.aten.gelu %arg0_pointwise_gelu_fwd_perm, %gelu_approximate_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.str -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_gelu_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_gelu_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_gelu_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_gelu_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_gelu_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_gelu_fwd, %permute_OUT_0_val_1_pointwise_gelu_fwd, %permute_OUT_0_val_2_pointwise_gelu_fwd, %permute_OUT_0_val_3_pointwise_gelu_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_gelu_fwd_perm, %permute_OUT_0_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_gelu_fwd", "pointwise_gelu_fwd", mode,
+      PointwiseAttr::Mode::GELU_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_identity.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_identity.cpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_identity = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_identity = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_identity = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_identity = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_identity = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_identity, %permute_IN_0_val_1_pointwise_identity, %permute_IN_0_val_2_pointwise_identity, %permute_IN_0_val_3_pointwise_identity : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_identity_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_identity : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %none_pointwise_identity = torch.constant.none
+// TORCH-CHECK:       %result_pointwise_identity_perm = torch.aten.clone %arg0_pointwise_identity_perm, %none_pointwise_identity : !torch.vtensor<[16,256,64,32],f32>, !torch.none -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_identity = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_identity = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_identity = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_identity = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_identity = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_identity, %permute_OUT_0_val_1_pointwise_identity, %permute_OUT_0_val_2_pointwise_identity, %permute_OUT_0_val_3_pointwise_identity : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_identity_perm, %permute_OUT_0_pointwise_identity : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 0
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 0
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_identity", "pointwise_identity", mode,
+      PointwiseAttr::Mode::IDENTITY, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_rsqrt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_rsqrt.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_rsqrt = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_rsqrt = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_rsqrt = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_rsqrt = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_rsqrt = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_rsqrt, %permute_IN_0_val_1_pointwise_rsqrt, %permute_IN_0_val_2_pointwise_rsqrt, %permute_IN_0_val_3_pointwise_rsqrt : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_rsqrt_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_rsqrt : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_rsqrt_perm = torch.aten.rsqrt %arg0_pointwise_rsqrt_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_rsqrt = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_rsqrt = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_rsqrt = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_rsqrt = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_rsqrt = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_rsqrt, %permute_OUT_0_val_1_pointwise_rsqrt, %permute_OUT_0_val_2_pointwise_rsqrt, %permute_OUT_0_val_3_pointwise_rsqrt : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_rsqrt_perm, %permute_OUT_0_pointwise_rsqrt : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_rsqrt", "pointwise_rsqrt", mode,
+      PointwiseAttr::Mode::RSQRT, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_sin.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sin.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_sin = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_sin = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_sin = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_sin = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_sin = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_sin, %permute_IN_0_val_1_pointwise_sin, %permute_IN_0_val_2_pointwise_sin, %permute_IN_0_val_3_pointwise_sin : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_sin_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_sin : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_sin_perm = torch.aten.sin %arg0_pointwise_sin_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_sin = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_sin = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_sin = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_sin = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_sin = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_sin, %permute_OUT_0_val_1_pointwise_sin, %permute_OUT_0_val_2_pointwise_sin, %permute_OUT_0_val_3_pointwise_sin : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_sin_perm, %permute_OUT_0_pointwise_sin : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_sin", "pointwise_sin", mode,
+      PointwiseAttr::Mode::SIN, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_sqrt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sqrt.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_sqrt = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_sqrt = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_sqrt = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_sqrt = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_sqrt = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_sqrt, %permute_IN_0_val_1_pointwise_sqrt, %permute_IN_0_val_2_pointwise_sqrt, %permute_IN_0_val_3_pointwise_sqrt : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_sqrt_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_sqrt : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_sqrt_perm = torch.aten.sqrt %arg0_pointwise_sqrt_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_sqrt = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_sqrt = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_sqrt = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_sqrt = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_sqrt = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_sqrt, %permute_OUT_0_val_1_pointwise_sqrt, %permute_OUT_0_val_2_pointwise_sqrt, %permute_OUT_0_val_3_pointwise_sqrt : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_sqrt_perm, %permute_OUT_0_pointwise_sqrt : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_sqrt", "pointwise_sqrt", mode,
+      PointwiseAttr::Mode::SQRT, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_tan.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_tan.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_tan = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_tan = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_tan = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_tan = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_tan = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_tan, %permute_IN_0_val_1_pointwise_tan, %permute_IN_0_val_2_pointwise_tan, %permute_IN_0_val_3_pointwise_tan : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_tan_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_tan : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_tan_perm = torch.aten.tan %arg0_pointwise_tan_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_tan = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_tan = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_tan = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_tan = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_tan = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_tan, %permute_OUT_0_val_1_pointwise_tan, %permute_OUT_0_val_2_pointwise_tan, %permute_OUT_0_val_3_pointwise_tan : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_tan_perm, %permute_OUT_0_pointwise_tan : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_tan", "pointwise_tan", mode,
+      PointwiseAttr::Mode::TAN, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Enable five additional unary pointwise operations with ASM emitter
support, sample tests, and lit tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Rob Suderman <rob.suderman@gmail.com>