### PR TITLE
Add GELU_FWD and GELU_APPROX_TANH_FWD pointwise ops

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -43,9 +43,9 @@ namespace fusilli {
   OP(EXP)                                                                      \
   OP(FLOOR)                                                                    \
   /* OP(GELU_APPROX_TANH_BWD)  */                                              \
-  /* OP(GELU_APPROX_TANH_FWD)  */                                              \
+  OP(GELU_APPROX_TANH_FWD)                                                     \
   /* OP(GELU_BWD) */                                                           \
-  /* OP(GELU_FWD) */                                                           \
+  OP(GELU_FWD)                                                                 \
   /* OP(GEN_INDEX) */                                                          \
   OP(IDENTITY)                                                                 \
   OP(LOG)                                                                      \
@@ -149,6 +149,8 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
         {PointwiseAttr::Mode::ERF, 1},
         {PointwiseAttr::Mode::EXP, 1},
         {PointwiseAttr::Mode::FLOOR, 1},
+        {PointwiseAttr::Mode::GELU_APPROX_TANH_FWD, 1},
+        {PointwiseAttr::Mode::GELU_FWD, 1},
         {PointwiseAttr::Mode::LOG, 1},
         {PointwiseAttr::Mode::LOGICAL_AND, 2},
         {PointwiseAttr::Mode::LOGICAL_NOT, 1},

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1823,19 +1823,11 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        pointwiseAttr.getEluAlpha() /* {8} */
     );
   }
-  case PointwiseAttr::Mode::GELU_FWD: {
-    return std::format(kGeluSchema, permuteIN0, /* {0} */
-                       getResultNamesAsm(),     /* {1} */
-                       getOperandNamesAsm(),    /* {2} */
-                       getOperandTypesAsm(),    /* {3} */
-                       getResultTypesAsm(),     /* {4} */
-                       permuteOUT0,             /* {5} */
-                       "torch.aten.gelu",       /* {6} */
-                       getName(),               /* {7} */
-                       "none"                   /* {8} */
-    );
-  }
+  case PointwiseAttr::Mode::GELU_FWD:
   case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD: {
+    const char *approx =
+        pointwiseAttr.getMode() == PointwiseAttr::Mode::GELU_FWD ? "none"
+                                                                 : "tanh";
     return std::format(kGeluSchema, permuteIN0, /* {0} */
                        getResultNamesAsm(),     /* {1} */
                        getOperandNamesAsm(),    /* {2} */
@@ -1844,7 +1836,7 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        permuteOUT0,             /* {5} */
                        "torch.aten.gelu",       /* {6} */
                        getName(),               /* {7} */
-                       "tanh"                   /* {8} */
+                       approx                   /* {8} */
     );
   }
     FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1794,6 +1794,13 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {5}
 )";
 
+  constexpr std::string_view kGeluSchema = R"(
+    {0}
+    %gelu_approximate_{7} = torch.constant.str "{8}"
+    {1} = {6} {2}, %gelu_approximate_{7} : {3}, !torch.str -> {4}
+    {5}
+)";
+
 #define FUSILLI_DECLARE_UNARY_TORCH_EMITTER(PWOP, OPIR)                        \
   FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(PWOP, kUnaryTorchSchema, OPIR)
 #define FUSILLI_DECLARE_BINARY_TORCH_EMITTER(PWOP, OPIR)                       \
@@ -1814,6 +1821,30 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        "torch.aten.elu",           /* {6} */
                        getName(),                  /* {7} */
                        pointwiseAttr.getEluAlpha() /* {8} */
+    );
+  }
+  case PointwiseAttr::Mode::GELU_FWD: {
+    return std::format(kGeluSchema, permuteIN0, /* {0} */
+                       getResultNamesAsm(),     /* {1} */
+                       getOperandNamesAsm(),    /* {2} */
+                       getOperandTypesAsm(),    /* {3} */
+                       getResultTypesAsm(),     /* {4} */
+                       permuteOUT0,             /* {5} */
+                       "torch.aten.gelu",       /* {6} */
+                       getName(),               /* {7} */
+                       "none"                   /* {8} */
+    );
+  }
+  case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD: {
+    return std::format(kGeluSchema, permuteIN0, /* {0} */
+                       getResultNamesAsm(),     /* {1} */
+                       getOperandNamesAsm(),    /* {2} */
+                       getOperandTypesAsm(),    /* {3} */
+                       getResultTypesAsm(),     /* {4} */
+                       permuteOUT0,             /* {5} */
+                       "torch.aten.gelu",       /* {6} */
+                       getName(),               /* {7} */
+                       "tanh"                   /* {8} */
     );
   }
     FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -65,6 +65,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     case PointwiseAttr::Mode::ERF:
     case PointwiseAttr::Mode::EXP:
     case PointwiseAttr::Mode::FLOOR:
+    case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD:
+    case PointwiseAttr::Mode::GELU_FWD:
     case PointwiseAttr::Mode::IDENTITY:
     case PointwiseAttr::Mode::LOG:
     case PointwiseAttr::Mode::NEG:
@@ -90,6 +92,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       PointwiseAttr::Mode::ERF,
       PointwiseAttr::Mode::EXP,
       PointwiseAttr::Mode::FLOOR,
+      PointwiseAttr::Mode::GELU_APPROX_TANH_FWD,
+      PointwiseAttr::Mode::GELU_FWD,
       PointwiseAttr::Mode::IDENTITY,
       PointwiseAttr::Mode::LOG,
       PointwiseAttr::Mode::NEG,
@@ -202,6 +206,20 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       y = std::floor(xD);
       break;
     }
+    case PointwiseAttr::Mode::GELU_FWD: {
+      double xD = static_cast<double>(x);
+      // GELU(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+      y = 0.5 * xD * (1.0 + std::erf(xD / std::sqrt(2.0)));
+      break;
+    }
+    case PointwiseAttr::Mode::GELU_APPROX_TANH_FWD: {
+      double xD = static_cast<double>(x);
+      // GELU tanh approx: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715*x^3)))
+      constexpr double kSqrt2OverPi = 0.7978845608028654;
+      const double inner = kSqrt2OverPi * (xD + 0.044715 * xD * xD * xD);
+      y = 0.5 * xD * (1.0 + std::tanh(inner));
+      break;
+    }
     case PointwiseAttr::Mode::IDENTITY: {
       y = x;
       break;
@@ -251,8 +269,11 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
 
     auto isClose = [](T lhs, T rhs) -> bool {
       if (std::is_floating_point<T>::value || std::is_same<T, half>::value) {
-        return std::abs(static_cast<double>(lhs) - static_cast<double>(rhs)) <
-               1e-3;
+        const double lhsD = static_cast<double>(lhs);
+        const double rhsD = static_cast<double>(rhs);
+        const double absTol = 1e-3;
+        const double relTol = 1e-3;
+        return std::abs(lhsD - rhsD) <= absTol + relTol * std::abs(rhsD);
       }
       return lhs == rhs;
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,8 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_erf.cpp
     lit/test_pointwise_asm_emitter_exp.cpp
     lit/test_pointwise_asm_emitter_floor.cpp
+    lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
+    lit/test_pointwise_asm_emitter_gelu_fwd.cpp
     lit/test_pointwise_asm_emitter_identity.cpp
     lit/test_pointwise_asm_emitter_log.cpp
     lit/test_pointwise_asm_emitter_logical_and.cpp

--- a/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_gelu_approx_tanh_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_gelu_approx_tanh_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_gelu_approx_tanh_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_gelu_approx_tanh_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_gelu_approx_tanh_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_1_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_2_pointwise_gelu_approx_tanh_fwd, %permute_IN_0_val_3_pointwise_gelu_approx_tanh_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_gelu_approx_tanh_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %gelu_approximate_pointwise_gelu_approx_tanh_fwd = torch.constant.str "tanh"
+// TORCH-CHECK:       %result_pointwise_gelu_approx_tanh_fwd_perm = torch.aten.gelu %arg0_pointwise_gelu_approx_tanh_fwd_perm, %gelu_approximate_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.str -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_gelu_approx_tanh_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_gelu_approx_tanh_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_gelu_approx_tanh_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_gelu_approx_tanh_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_gelu_approx_tanh_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_1_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_2_pointwise_gelu_approx_tanh_fwd, %permute_OUT_0_val_3_pointwise_gelu_approx_tanh_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_gelu_approx_tanh_fwd_perm, %permute_OUT_0_pointwise_gelu_approx_tanh_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_gelu_approx_tanh_fwd",
+      "pointwise_gelu_approx_tanh_fwd", mode,
+      PointwiseAttr::Mode::GELU_APPROX_TANH_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_gelu_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_gelu_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_gelu_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_gelu_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_gelu_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_gelu_fwd, %permute_IN_0_val_1_pointwise_gelu_fwd, %permute_IN_0_val_2_pointwise_gelu_fwd, %permute_IN_0_val_3_pointwise_gelu_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_gelu_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %gelu_approximate_pointwise_gelu_fwd = torch.constant.str "none"
+// TORCH-CHECK:       %result_pointwise_gelu_fwd_perm = torch.aten.gelu %arg0_pointwise_gelu_fwd_perm, %gelu_approximate_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.str -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_gelu_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_gelu_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_gelu_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_gelu_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_gelu_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_gelu_fwd, %permute_OUT_0_val_1_pointwise_gelu_fwd, %permute_OUT_0_val_2_pointwise_gelu_fwd, %permute_OUT_0_val_3_pointwise_gelu_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_gelu_fwd_perm, %permute_OUT_0_pointwise_gelu_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_gelu_fwd", "pointwise_gelu_fwd", mode,
+      PointwiseAttr::Mode::GELU_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Emit torch.aten.gelu with approximate="none" for GELU_FWD and approximate="tanh" for GELU_APPROX_TANH_FWD. Includes sample and lit tests, and loosens the unary op tolerance to a combined absolute + relative threshold to accommodate GELU's fp16 precision.