### PR TITLE
Change CompileSession and CompileCommand APIs to take backend instead of handle

### DIFF
--- a/include/fusilli/backend/compile_command.h
+++ b/include/fusilli/backend/compile_command.h
@@ -48,7 +48,7 @@ public:
   // This constructs the full command with:
   // - iree-compile executable path
   // - input file path
-  // - backend-specific flags from Handle
+  // - backend-specific flags
   // - statistics output flags
   // - output file specification
   //

--- a/include/fusilli/backend/compile_command.h
+++ b/include/fusilli/backend/compile_command.h
@@ -14,7 +14,6 @@
 #define FUSILLI_BACKEND_COMPILE_COMMAND_H
 
 #include "fusilli/backend/backend.h"
-#include "fusilli/backend/handle.h"
 #include "fusilli/support/cache.h"
 #include "fusilli/support/external_tools.h"
 #include "fusilli/support/extras.h"
@@ -34,7 +33,7 @@ namespace fusilli {
 //
 // Usage:
 //   ErrorOr<CompileCommand> cmd = CompileCommand::build(
-//       handle, inputFile, outputFile, statisticsFile);
+//       backend, inputFile, outputFile, statisticsFile);
 //   FUSILLI_CHECK_ERROR(cmd->writeTo(commandFile));
 //   FUSILLI_CHECK_ERROR(cmd->execute());
 //
@@ -54,13 +53,13 @@ public:
   // - output file specification
   //
   // Returns CompileCommand containing the built command or error.
-  static CompileCommand build(const Handle &handle, const CacheFile &input,
+  static CompileCommand build(Backend backend, const CacheFile &input,
                               const CacheFile &output,
                               const CacheFile &statistics) {
     std::vector<std::string> args = {getIreeCompilePath(), input.path.string()};
 
     // Get backend-specific flags.
-    auto flags = getBackendFlags(handle.getBackend());
+    auto flags = getBackendFlags(backend);
     for (const auto &flag : flags) {
       args.push_back(flag);
     }

--- a/include/fusilli/backend/compile_session.h
+++ b/include/fusilli/backend/compile_session.h
@@ -163,7 +163,7 @@ private:
 // - Compiles input files to output files
 //
 // Usage:
-//   ErrorOr<CompileSession> session = context->createSession(handle);
+//   ErrorOr<CompileSession> session = context->createSession(backend);
 //   FUSILLI_CHECK_ERROR(session->addFlag("--iree-hal-target-backends=rocm"));
 //   FUSILLI_CHECK_ERROR(session->compile(inputFile, outputFile));
 //

--- a/include/fusilli/backend/compile_session.h
+++ b/include/fusilli/backend/compile_session.h
@@ -21,7 +21,6 @@
 #define FUSILLI_BACKEND_COMPILE_SESSION_H
 
 #include "fusilli/backend/backend.h"
-#include "fusilli/backend/handle.h"
 #include "fusilli/support/cache.h"
 #include "fusilli/support/dllib.h"
 #include "fusilli/support/external_tools.h"
@@ -57,7 +56,7 @@ class CompileSession;
 // Usage:
 //   ErrorOr<CompileContext*> ctx =
 //       CompileContext::create();
-//   ErrorOr<CompileSession> session = ctx->createSession(handle);
+//   ErrorOr<CompileSession> session = ctx->createSession(backend);
 //   FUSILLI_CHECK_ERROR(session->compile(inputFile, outputFile));
 //
 // Design principles:
@@ -89,7 +88,7 @@ public:
   // Sessions can have different flags and configurations.
   //
   // Returns ErrorOr<CompileSession> containing the session or error.
-  ErrorOr<CompileSession> createSession(const Handle &handle);
+  ErrorOr<CompileSession> createSession(Backend backend);
 
   // Gets the API version of the loaded compiler.
   int getAPIVersion() const;
@@ -175,8 +174,7 @@ private:
 class CompileSession {
 public:
   // Static factory method matching CompileCommand::build().
-  static ErrorOr<CompileSession> build(const Handle &handle,
-                                       const CacheFile &input,
+  static ErrorOr<CompileSession> build(Backend backend, const CacheFile &input,
                                        const CacheFile &output,
                                        const CacheFile &statistics);
 
@@ -372,8 +370,7 @@ inline ErrorObject CompileContext::loadSymbols() noexcept {
   return ok();
 }
 
-inline ErrorOr<CompileSession>
-CompileContext::createSession(const Handle &handle) {
+inline ErrorOr<CompileSession> CompileContext::createSession(Backend backend) {
   FUSILLI_LOG_LABEL_ENDL("INFO: Creating compiler session");
 
   // Create a new IREE compiler session.
@@ -382,9 +379,6 @@ CompileContext::createSession(const Handle &handle) {
     return fusilli::error(ErrorCode::CompileFailure,
                           "Failed to create compiler session");
   }
-
-  // Get the backend type from the handle.
-  Backend backend = handle.getBackend();
 
   // Create the CompileSession object.
   CompileSession compileSession(this, session, backend);
@@ -580,7 +574,7 @@ inline ErrorObject CompileSession::compile(std::string_view input,
 // ----------------------------------------------------------------------------
 
 inline ErrorOr<CompileSession>
-CompileSession::build(const Handle &handle, const CacheFile &input,
+CompileSession::build(Backend backend, const CacheFile &input,
                       const CacheFile &output, const CacheFile &statistics) {
   FUSILLI_LOG_LABEL_ENDL("INFO: Building compile session");
 
@@ -588,7 +582,7 @@ CompileSession::build(const Handle &handle, const CacheFile &input,
   FUSILLI_ASSIGN_OR_RETURN(auto *context, CompileContext::create());
 
   // Create session with backend-specific flags.
-  FUSILLI_ASSIGN_OR_RETURN(auto session, context->createSession(handle));
+  FUSILLI_ASSIGN_OR_RETURN(auto session, context->createSession(backend));
 
   // Add statistics flags (matching CompileCommand behavior).
   FUSILLI_CHECK_ERROR(

--- a/include/fusilli/backend/handle.h
+++ b/include/fusilli/backend/handle.h
@@ -121,12 +121,10 @@ public:
 
   Backend getBackend() const { return backend_; }
 
-  // Allow Graph, Buffer, and CompileCommand objects to access private Handle
-  // methods namely `getDevice()`, `getInstance()`, and `getBackend()`.
+  // Allow Graph and Buffer to access private Handle methods `getDevice()`
+  // and `getInstance()`.
   friend class Graph;
   friend class Buffer;
-  friend class CompileCommand;
-  friend class CompileContext;
 
 private:
   // Creates static singleton IREE VM instance shared across

--- a/include/fusilli/backend/handle.h
+++ b/include/fusilli/backend/handle.h
@@ -119,6 +119,8 @@ public:
   Handle &operator=(Handle &&) noexcept = default;
   ~Handle() = default;
 
+  Backend getBackend() const { return backend_; }
+
   // Allow Graph, Buffer, and CompileCommand objects to access private Handle
   // methods namely `getDevice()`, `getInstance()`, and `getBackend()`.
   friend class Graph;
@@ -142,8 +144,6 @@ private:
   // Private constructor (use factory `create` method for handle creation).
   Handle(Backend backend, IreeVmInstanceSharedPtrType instance)
       : backend_(backend), instance_(std::move(instance)) {}
-
-  Backend getBackend() const { return backend_; }
 
   // Returns a raw pointer to the underlying IREE HAL device.
   // WARNING: The returned raw pointer is not safe to store since

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -443,7 +443,7 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd = CompileCommand::build(
-          handle, cache.input, cache.output, cache.statistics);
+          handle.getBackend(), cache.input, cache.output, cache.statistics);
       FUSILLI_CHECK_ERROR(cmd.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (CLI)");
       FUSILLI_LOG_ENDL(cmd.toString());
@@ -451,8 +451,8 @@ private:
     } else {
       // Use CompileSession (C API) - DEFAULT.
       FUSILLI_ASSIGN_OR_RETURN(CompileSession session,
-                               CompileSession::build(handle, cache.input,
-                                                     cache.output,
+                               CompileSession::build(handle.getBackend(),
+                                                     cache.input, cache.output,
                                                      cache.statistics));
       FUSILLI_CHECK_ERROR(session.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (C API)");
@@ -539,13 +539,13 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd =
-          CompileCommand::build(handle, input, output, statistics);
+          CompileCommand::build(handle.getBackend(), input, output, statistics);
       cmdString = cmd.toString();
     } else {
       // Use CompileSession (C API) - DEFAULT.
-      FUSILLI_ASSIGN_OR_RETURN(
-          auto session,
-          CompileSession::build(handle, input, output, statistics));
+      FUSILLI_ASSIGN_OR_RETURN(auto session,
+                               CompileSession::build(handle.getBackend(), input,
+                                                     output, statistics));
       cmdString = session.toString();
     }
 

--- a/tests/test_compile_command.cpp
+++ b/tests/test_compile_command.cpp
@@ -42,7 +42,8 @@ TEST_CASE("CompileCommand::build with CPU backend", "[CompileCommand]") {
   REQUIRE(input.write(getSimpleMLIRModule()).isOk());
 
   // Build the compile command.
-  CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
+  CompileCommand cmd =
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Verify the command arguments.
   const auto &args = cmd.getArgs();
@@ -122,7 +123,8 @@ TEST_CASE("CompileCommand::build with AMDGPU backend", "[CompileCommand]") {
   REQUIRE(input.write(getSimpleMLIRModule()).isOk());
 
   // Build the compile command.
-  CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
+  CompileCommand cmd =
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Verify the command arguments.
   const auto &args = cmd.getArgs();
@@ -177,7 +179,8 @@ TEST_CASE("CompileCommand::toString format", "[CompileCommand]") {
       ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
-  CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
+  CompileCommand cmd =
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Get string representation.
   std::string cmdStr = cmd.toString();
@@ -219,7 +222,8 @@ TEST_CASE("CompileCommand::writeTo", "[CompileCommand]") {
       ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
-  CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
+  CompileCommand cmd =
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Write to cache file.
   FUSILLI_REQUIRE_OK(cmd.writeTo(commandFile));
@@ -251,7 +255,8 @@ TEST_CASE("CompileCommand::getArgs", "[CompileCommand]") {
       ScopeExit([&] { std::filesystem::remove_all(input.path.parent_path()); });
 
   // Build the compile command.
-  CompileCommand cmd = CompileCommand::build(handle, input, output, statistics);
+  CompileCommand cmd =
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Get args and verify structure.
   const auto &args = cmd.getArgs();
@@ -294,12 +299,12 @@ TEST_CASE("CompileCommand round-trip serialization", "[CompileCommand]") {
 
   // Build and write command.
   CompileCommand cmd1 =
-      CompileCommand::build(handle, input, output, statistics);
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
   FUSILLI_REQUIRE_OK(cmd1.writeTo(commandFile));
 
   // Build another command with the same parameters.
   CompileCommand cmd2 =
-      CompileCommand::build(handle, input, output, statistics);
+      CompileCommand::build(handle.getBackend(), input, output, statistics);
 
   // Read the serialized command.
   FUSILLI_REQUIRE_ASSIGN(std::string serializedCmd, commandFile.read());

--- a/tests/test_compile_session.cpp
+++ b/tests/test_compile_session.cpp
@@ -95,7 +95,7 @@ TEST_CASE("CompileContext::createSession with CPU backend",
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
 
   // Create a session.
-  auto maybeSession = context->createSession(handle);
+  auto maybeSession = context->createSession(handle.getBackend());
   FUSILLI_REQUIRE_OK(maybeSession);
 
   FUSILLI_REQUIRE_ASSIGN(CompileSession session, std::move(maybeSession));
@@ -115,7 +115,7 @@ TEST_CASE("CompileContext::createSession with AMDGPU backend",
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
 
   // Create a session.
-  auto maybeSession = context->createSession(handle);
+  auto maybeSession = context->createSession(handle.getBackend());
   FUSILLI_REQUIRE_OK(maybeSession);
 
   FUSILLI_REQUIRE_ASSIGN(CompileSession session, std::move(maybeSession));
@@ -135,9 +135,12 @@ TEST_CASE("CompileContext supports multiple sessions",
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
   // Create multiple sessions from the same context.
-  FUSILLI_REQUIRE_ASSIGN(auto session1, context->createSession(handle));
-  FUSILLI_REQUIRE_ASSIGN(auto session2, context->createSession(handle));
-  FUSILLI_REQUIRE_ASSIGN(auto session3, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session1,
+                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session2,
+                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session3,
+                         context->createSession(handle.getBackend()));
 
   // All sessions should be valid.
   SUCCEED("Multiple sessions created successfully");
@@ -148,7 +151,8 @@ TEST_CASE("CompileSession::addFlag", "[CompileSession]") {
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Add a flag.
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -162,7 +166,8 @@ TEST_CASE("CompileSession::addFlags", "[CompileSession]") {
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Add multiple flags.
   std::vector<std::string> flags = {
@@ -181,7 +186,8 @@ TEST_CASE("CompileSession::compile with valid MLIR",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -215,7 +221,8 @@ TEST_CASE("CompileSession::compile with custom flags",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Add custom optimization flags.
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -254,7 +261,8 @@ TEST_CASE("CompileSession::compile with invalid MLIR",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -285,7 +293,8 @@ TEST_CASE("CompileSession::compile with missing input file",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Create cache files but don't write to input.
   FUSILLI_REQUIRE_ASSIGN(
@@ -311,7 +320,8 @@ TEST_CASE("CompileSession move semantics", "[CompileSession]") {
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session1, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session1,
+                         context->createSession(handle.getBackend()));
 
   // Add a flag to session1.
   FUSILLI_REQUIRE_OK(session1.addFlag("--iree-opt-level=O3"));
@@ -332,7 +342,8 @@ TEST_CASE("CompileSession::compile with AMDGPU backend",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -369,7 +380,8 @@ TEST_CASE("CompileSession cleanup on destruction", "[CompileSession]") {
 
   // Create a session in a nested scope.
   {
-    FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+    FUSILLI_REQUIRE_ASSIGN(auto session,
+                           context->createSession(handle.getBackend()));
 
     // Use the session.
     FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -379,7 +391,8 @@ TEST_CASE("CompileSession cleanup on destruction", "[CompileSession]") {
 
   // Should be able to create a new session after the previous one was
   // destroyed.
-  FUSILLI_REQUIRE_ASSIGN(auto session2, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session2,
+                         context->createSession(handle.getBackend()));
   FUSILLI_REQUIRE_OK(session2.addFlag("--iree-opt-level=O2"));
 
   SUCCEED("Session cleanup and recreation works correctly");
@@ -390,7 +403,8 @@ TEST_CASE("CompileSession with invalid flag", "[CompileSession][error]") {
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(handle));
+  FUSILLI_REQUIRE_ASSIGN(auto session,
+                         context->createSession(handle.getBackend()));
 
   // Try to add an invalid flag.
   auto result = session.addFlag("--this-is-not-a-valid-iree-flag-xyz123");
@@ -443,7 +457,7 @@ TEST_CASE("CompileSession::build with CPU backend", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle, input, output, statistics));
+      CompileSession::build(handle.getBackend(), input, output, statistics));
 
   // Verify that flags were added (including statistics flags).
   const auto &args = session.getArgs();
@@ -482,7 +496,7 @@ TEST_CASE("CompileSession::toString format", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle, input, output, statistics));
+      CompileSession::build(handle.getBackend(), input, output, statistics));
 
   std::string cmdStr = session.toString();
 
@@ -510,7 +524,7 @@ TEST_CASE("CompileSession::writeTo", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle, input, output, statistics));
+      CompileSession::build(handle.getBackend(), input, output, statistics));
 
   FUSILLI_REQUIRE_OK(session.writeTo(commandFile));
 
@@ -538,7 +552,7 @@ TEST_CASE("CompileSession::execute with valid MLIR", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle, input, output, statistics));
+      CompileSession::build(handle.getBackend(), input, output, statistics));
 
   // Execute compilation.
   FUSILLI_REQUIRE_OK(session.execute());
@@ -568,7 +582,7 @@ TEST_CASE("CompileSession::getArgs", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle, input, output, statistics));
+      CompileSession::build(handle.getBackend(), input, output, statistics));
 
   const auto &args = session.getArgs();
 
@@ -588,7 +602,7 @@ TEST_CASE("CompileSession::addFlag with tuning spec path",
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CompileSession session,
-                         context->createSession(handle));
+                         context->createSession(handle.getBackend()));
 
   ErrorObject result =
       session.addFlag("--iree-codegen-tuning-spec-path=" +
@@ -610,7 +624,7 @@ TEST_CASE("CompileSession::compile with tuning spec",
   REQUIRE(context != nullptr);
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CompileSession session,
-                         context->createSession(handle));
+                         context->createSession(handle.getBackend()));
 
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-codegen-tuning-spec-path=" +
                                      getTestTuningSpecPath().generic_string()));


### PR DESCRIPTION
Handle requires a runtime to invoke. Compilation should only need the backend target to avoid constructing a full runtime unnecessarily.