### PR TITLE
[Do not merge] Decouple Handle from Graph::compile, introduce explicit load step

### DIFF
--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -210,7 +210,8 @@ static ErrorObject benchmarkConvFprop(const ConvOptions &opts,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate input, weight and output buffers.
   FUSILLI_ASSIGN_OR_RETURN(auto xBuf,
@@ -341,7 +342,8 @@ static ErrorObject benchmarkConvWGrad(const ConvOptions &opts,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate buffers.
   FUSILLI_ASSIGN_OR_RETURN(auto dyBuf,
@@ -472,7 +474,8 @@ static ErrorObject benchmarkConvDGrad(const ConvOptions &opts,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate buffers.
   FUSILLI_ASSIGN_OR_RETURN(auto dyBuf,
@@ -563,7 +566,8 @@ static ErrorObject benchmarkLayerNormFwd(const LayerNormOptions &opts,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate input and output buffers.
   FUSILLI_ASSIGN_OR_RETURN(
@@ -699,7 +703,8 @@ static ErrorObject benchmarkSdpaFwd(const SdpaOptions &opts,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate input and output buffers.
   FUSILLI_ASSIGN_OR_RETURN(auto qBuf,
@@ -826,7 +831,8 @@ static ErrorObject benchmarkMatmul(const MatmulOptions &opts, DataType aType,
   FUSILLI_CHECK_ERROR(graph.validate());
 
   // Compile
-  FUSILLI_CHECK_ERROR(graph.compile(handle, /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.compile(handle.getBackend(), /*remove=*/!dump));
+  FUSILLI_CHECK_ERROR(graph.load(handle));
 
   // Allocate input, weight and output buffers.
   FUSILLI_ASSIGN_OR_RETURN(auto aBuf,

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -111,12 +111,13 @@ public:
     return ok();
   }
 
-  // Compiles the graph using IREE compiler and sets up the IREE VM
-  // context for future g->execute calls.
+  // Compiles the graph using IREE compiler to produce a VMFB artifact.
+  // Does not create any runtime state; call `load(handle)` afterwards to
+  // set up the IREE VM context for execution.
   //
   // Set `remove = true` to remove compilation artifacts (cache files) when
   // this `Graph` instance goes out of scope.
-  ErrorObject compile(const Handle &handle, bool remove = false) {
+  ErrorObject compile(Backend backend, bool remove = false) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiling Graph");
     FUSILLI_RETURN_ERROR_IF(!isValidated_, ErrorCode::NotValidated,
                             "Graph must be validated before being compiled");
@@ -125,14 +126,33 @@ public:
     FUSILLI_ASSIGN_OR_RETURN(std::string generatedAsm, emitAsm());
 
     // Compile using IREE compiler or reuse cached artifact.
-    FUSILLI_ASSIGN_OR_RETURN(auto vmfbPath,
-                             getCompiledArtifact(handle, generatedAsm, remove));
+    FUSILLI_ASSIGN_OR_RETURN(
+        auto vmfbPath, getCompiledArtifact(backend, generatedAsm, remove));
 
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiled Graph cached at \"" +
                            vmfbPath.string() + "\"");
 
-    // Create per-graph IREE VM context and load the compiled artifact.
-    FUSILLI_CHECK_ERROR(createVmContext(handle, vmfbPath.string()));
+    compiledBackend_ = backend;
+    vmfbPath_ = vmfbPath;
+
+    return ok();
+  }
+
+  // Loads the compiled VMFB artifact onto the device owned by `handle`,
+  // creating a per-graph IREE VM context and querying workspace size.
+  // Must be called after `compile()` and before `execute()`.
+  ErrorObject load(const Handle &handle) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Loading compiled artifact into VM context");
+    FUSILLI_RETURN_ERROR_IF(
+        !compiledBackend_.has_value(), ErrorCode::NotCompiled,
+        "Graph must be compiled before loading (call compile() first)");
+    FUSILLI_RETURN_ERROR_IF(
+        handle.getBackend() != *compiledBackend_, ErrorCode::InvalidArgument,
+        "Handle backend (" + kBackendToStr.at(handle.getBackend()) +
+            ") does not match the backend used for compilation (" +
+            kBackendToStr.at(*compiledBackend_) + ")");
+
+    FUSILLI_CHECK_ERROR(createVmContext(handle, vmfbPath_.string()));
 
     return ok();
   }
@@ -214,13 +234,14 @@ public:
   //     doSomethingWith(hostData);
   //
   // Workspace Buffer Usage:
-  //   After calling compile(), query getWorkspaceSize() to determine if a
-  //   workspace buffer is needed. If size > 0, allocate using
-  //   Buffer::allocateRaw() and pass it to execute(). The same workspace
-  //   buffer can be reused across multiple execute() calls.
+  //   After calling compile() and load(), query getWorkspaceSize() to
+  //   determine if a workspace buffer is needed. If size > 0, allocate
+  //   using Buffer::allocateRaw() and pass it to execute(). The same
+  //   workspace buffer can be reused across multiple execute() calls.
   //
   //   Example:
-  //     graph.compile(handle);
+  //     graph.compile(handle.getBackend());
+  //     graph.load(handle);
   //     auto wsSize = graph.getWorkspaceSize();
   //     std::shared_ptr<Buffer> workspace = nullptr;
   //     if (wsSize.value_or(0) > 0) {
@@ -349,11 +370,11 @@ public:
   // TODO(#13): Make this private. It is public for now to aid testing and
   // debuggability, however the intended user facing API is `Graph::compile()`.
   ErrorOr<std::filesystem::path>
-  getCompiledArtifact(const Handle &handle, const std::string &generatedAsm,
+  getCompiledArtifact(Backend backend, const std::string &generatedAsm,
                       bool remove, std::optional<bool> *reCompiled = nullptr) {
     // Check for cache hit.
     FUSILLI_ASSIGN_OR_RETURN(bool cacheValid,
-                             validateCache(handle, generatedAsm));
+                             validateCache(backend, generatedAsm));
     if (cacheValid) {
       if (reCompiled)
         *reCompiled = false;
@@ -362,7 +383,7 @@ public:
     // (Re)generate cache.
     FUSILLI_ASSIGN_OR_RETURN(
         auto generatedCache,
-        generateCompiledArtifact(handle, generatedAsm, remove));
+        generateCompiledArtifact(backend, generatedAsm, remove));
     cache_ = std::move(generatedCache);
     if (reCompiled)
       *reCompiled = true;
@@ -405,8 +426,8 @@ private:
   // `remove = true` to remove cache files when returned `CachedAssets` lifetime
   // ends.
   ErrorOr<CachedAssets>
-  generateCompiledArtifact(const Handle &handle,
-                           const std::string &generatedAsm, bool remove) {
+  generateCompiledArtifact(Backend backend, const std::string &generatedAsm,
+                           bool remove) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Generating compiled artifacts");
 
     // Create cache files.
@@ -443,7 +464,7 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd = CompileCommand::build(
-          handle.getBackend(), cache.input, cache.output, cache.statistics);
+          backend, cache.input, cache.output, cache.statistics);
       FUSILLI_CHECK_ERROR(cmd.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (CLI)");
       FUSILLI_LOG_ENDL(cmd.toString());
@@ -451,8 +472,8 @@ private:
     } else {
       // Use CompileSession (C API) - DEFAULT.
       FUSILLI_ASSIGN_OR_RETURN(CompileSession session,
-                               CompileSession::build(handle.getBackend(),
-                                                     cache.input, cache.output,
+                               CompileSession::build(backend, cache.input,
+                                                     cache.output,
                                                      cache.statistics));
       FUSILLI_CHECK_ERROR(session.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (C API)");
@@ -469,7 +490,7 @@ private:
   //  - Generated assembly differs
   //  - Compile commands have changed
   //  - Handle/backend (and therefore compile command) has changed
-  ErrorOr<bool> validateCache(const Handle &handle,
+  ErrorOr<bool> validateCache(Backend backend,
                               const std::string &generatedAsm) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Validating cache");
 
@@ -539,13 +560,13 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd =
-          CompileCommand::build(handle.getBackend(), input, output, statistics);
+          CompileCommand::build(backend, input, output, statistics);
       cmdString = cmd.toString();
     } else {
       // Use CompileSession (C API) - DEFAULT.
-      FUSILLI_ASSIGN_OR_RETURN(auto session,
-                               CompileSession::build(handle.getBackend(), input,
-                                                     output, statistics));
+      FUSILLI_ASSIGN_OR_RETURN(
+          auto session,
+          CompileSession::build(backend, input, output, statistics));
       cmdString = session.toString();
     }
 
@@ -613,9 +634,17 @@ private:
   // This is set after `validate()` is run at least once successfully.
   bool isValidated_ = false;
 
+  // Backend used during compile(). Used by load() to verify that the
+  // Handle's backend matches the compiled artifact.
+  std::optional<Backend> compiledBackend_;
+
+  // Path to the compiled VMFB artifact produced by compile().
+  // Consumed by load() to create the VM context.
+  std::filesystem::path vmfbPath_;
+
   // Required workspace buffer size in bytes. Set during createVmContext()
   // by querying the iree.abi.transients.size.constant attribute.
-  // std::nullopt indicates the graph has not been compiled yet.
+  // std::nullopt indicates the graph has not been loaded yet.
   std::optional<size_t> workspaceSize_;
 
   // IREE VM context lifetime managed by the `Graph` object

--- a/samples/batchnorm/batchnorm_infer_nchw.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw.cpp
@@ -56,7 +56,8 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; no scale/bias",
     yT->setName("y").setDataType(DataType::Float).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, meanT, varT, yT);
   };

--- a/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
@@ -59,7 +59,8 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; scale, bias",
     yT->setName("y").setDataType(DataType::Float).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, meanT, varT, yT);
   };

--- a/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
@@ -58,7 +58,8 @@ TEST_CASE("Batch normalization; inference mode; NHWC layout; scale, bias",
     yT->setName("y").setDataType(DataType::Float).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, meanT, varT, yT);
   };

--- a/samples/batchnorm/batchnorm_train_nchw.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw.cpp
@@ -55,7 +55,8 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; no scale/bias",
     sivT->setName("saved_inv_var").setDataType(DataType::Float).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, yT, smT, sivT);
   };

--- a/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
@@ -60,7 +60,8 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; scale, bias",
     sivT->setName("saved_inv_var").setDataType(DataType::Float).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, yT, smT, sivT);
   };

--- a/samples/convolution/conv_dgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc.cpp
@@ -54,7 +54,8 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, wT, dxT);
   };
@@ -157,7 +158,8 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding; "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, wT, dbT, dxT);
   };

--- a/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
@@ -55,7 +55,8 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding;"
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, wT, dxT);
   };

--- a/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
@@ -67,7 +67,8 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, bT, reluResult);
   };

--- a/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -51,7 +51,8 @@ TEST_CASE("Convolution fprop; X (NCHW), W (KCRS); 1x1 conv; no padding",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, yT);
   };

--- a/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
@@ -53,7 +53,8 @@ TEST_CASE(
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, yT);
   };

--- a/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -51,7 +51,8 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, yT);
   };

--- a/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
@@ -51,7 +51,8 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 3x3 conv; same padding",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, yT);
   };

--- a/samples/convolution/conv_fprop_with_bias.cpp
+++ b/samples/convolution/conv_fprop_with_bias.cpp
@@ -59,7 +59,8 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, bT, biasResult);
   };

--- a/samples/convolution/conv_fprop_with_relu.cpp
+++ b/samples/convolution/conv_fprop_with_relu.cpp
@@ -55,7 +55,8 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; relu",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, reluResult);
   };

--- a/samples/convolution/conv_fprop_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_with_relu_and_bias.cpp
@@ -64,7 +64,8 @@ TEST_CASE(
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, bT, reluResult);
   };

--- a/samples/convolution/conv_wgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc.cpp
@@ -54,7 +54,8 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, xT, dwT);
   };
@@ -158,7 +159,8 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, xT, dbT, dwT);
   };

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
@@ -54,7 +54,8 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; grouped",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, xT, dwT);
   };

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
@@ -58,7 +58,8 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, dyT, xT, dwT);
   };

--- a/samples/custom_op/custom_op_add.cpp
+++ b/samples/custom_op/custom_op_add.cpp
@@ -74,7 +74,8 @@ TEST_CASE("Custom op: compose built-in pointwise add with custom negate",
     outs[0]->setDim(dim).setStride(stride).setDataType(dt).setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     FUSILLI_REQUIRE_ASSIGN(
         auto aBuf, allocateBufferOfType(handle, aT, dt, double(fillVal)));

--- a/samples/layernorm/layernorm_infer_nchw.cpp
+++ b/samples/layernorm/layernorm_infer_nchw.cpp
@@ -52,7 +52,8 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; no bias/scale",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, yT);
   };

--- a/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
@@ -57,7 +57,8 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; scale, bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, yT);
   };

--- a/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
@@ -57,7 +57,8 @@ TEST_CASE("Layer normalization; inference mode; NHWC layout; scale, bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, yT);
   };

--- a/samples/layernorm/layernorm_train_nchw.cpp
+++ b/samples/layernorm/layernorm_train_nchw.cpp
@@ -54,7 +54,8 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; no bias/scale",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, yT, mT, vT);
   };

--- a/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
@@ -59,7 +59,8 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; scale, bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, yT, mT, vT);
   };

--- a/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
@@ -59,7 +59,8 @@ TEST_CASE("Layer normalization; training mode; NHWC layout; scale, bias",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, sT, bT, yT, mT, vT);
   };

--- a/samples/matmul/matmul_basic.cpp
+++ b/samples/matmul/matmul_basic.cpp
@@ -43,7 +43,8 @@ TEST_CASE("Matrix multiplication; A (M, K), B (K, N); basic matmul",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, cT);
   };
@@ -120,7 +121,8 @@ TEST_CASE(
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, cT);
   };

--- a/samples/matmul/matmul_basic_with_bias.cpp
+++ b/samples/matmul/matmul_basic_with_bias.cpp
@@ -53,7 +53,8 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B (K, N), bias (1, N); "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, biasT, resultT);
   };
@@ -148,7 +149,8 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B^T (N, K), bias (1, N); "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, biasT, resultT);
   };

--- a/samples/matmul/matmul_batched.cpp
+++ b/samples/matmul/matmul_batched.cpp
@@ -48,7 +48,8 @@ TEST_CASE(
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, cT);
   };
@@ -130,7 +131,8 @@ TEST_CASE("Batched matrix multiplication with broadcast; A (B, M, K), B (1, K, "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, cT);
   };

--- a/samples/matmul/matmul_batched_with_bias.cpp
+++ b/samples/matmul/matmul_batched_with_bias.cpp
@@ -57,7 +57,8 @@ TEST_CASE("Batched matrix multiplication with bias; A (B, M, K), B (B, K, N), "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, biasT, resultT);
   };
@@ -159,7 +160,8 @@ TEST_CASE("Batched matrix multiplication with broadcast and bias; A (B, M, K), "
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, biasT, resultT);
   };

--- a/samples/matmul/matmul_int4_fp16.cpp
+++ b/samples/matmul/matmul_int4_fp16.cpp
@@ -44,7 +44,8 @@ TEST_CASE("Int4 x fp16 matmul", "[matmul][int4]") {
     cT->setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, aT, bT, cT);
   };

--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -70,7 +70,8 @@ TEST_CASE("Pointwise add with transposed operand", "[pointwise][graph]") {
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handleArg, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handleArg.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handleArg));
 
     return std::make_tuple(graph, aT, bT, resultT);
   };

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -75,7 +75,8 @@ TEST_CASE("Pointwise binary compare ops", "[pointwise][graph]") {
     yT->setName("result").setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, x0T, x1T, yT);
   };

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -80,7 +80,9 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
       FUSILLI_REQUIRE_OK(graph->validate());
 
       // Compile
-      FUSILLI_REQUIRE_OK(graph->compile(handleArg, /*remove=*/true));
+      FUSILLI_REQUIRE_OK(
+          graph->compile(handleArg.getBackend(), /*remove=*/true));
+      FUSILLI_REQUIRE_OK(graph->load(handleArg));
 
       return std::make_tuple(graph, x0T, x1T, pointwiseResult);
     };

--- a/samples/pointwise/pointwise_scalar_mul.cpp
+++ b/samples/pointwise/pointwise_scalar_mul.cpp
@@ -46,7 +46,8 @@ TEST_CASE("Pointwise MUL with scalar operand", "[pointwise][scalar][graph]") {
   yT->setName("result").setOutput(true);
 
   FUSILLI_REQUIRE_OK(graph->validate());
-  FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(graph->load(handle));
 
   // Allocate input buffer (all elements = inputVal).
   FUSILLI_REQUIRE_ASSIGN(

--- a/samples/pointwise/pointwise_unary_logical_ops.cpp
+++ b/samples/pointwise/pointwise_unary_logical_ops.cpp
@@ -59,7 +59,8 @@ TEST_CASE("Pointwise unary logical ops", "[pointwise][graph]") {
 
     // Validate and compile.
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     // Allocate input buffer.
     FUSILLI_REQUIRE_ASSIGN(auto xBuf, allocateBufferOfType(handle, xT, dt, x));

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -124,7 +124,9 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       FUSILLI_REQUIRE_OK(graph->validate());
 
       // Compile
-      FUSILLI_REQUIRE_OK(graph->compile(handleArg, /*remove=*/true));
+      FUSILLI_REQUIRE_OK(
+          graph->compile(handleArg.getBackend(), /*remove=*/true));
+      FUSILLI_REQUIRE_OK(graph->load(handleArg));
 
       return std::make_tuple(graph, xT, pointwiseResult);
     };

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -73,7 +73,8 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
 
     // Validate and compile.
     FUSILLI_REQUIRE_OK(graph->validate());
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     // Calculate total input size
     int64_t xSize = 1;

--- a/samples/rmsnorm/rmsnorm_infer_nchw.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw.cpp
@@ -52,7 +52,8 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; no scale",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, yT);
   };

--- a/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
@@ -54,7 +54,8 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; with scale",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, scaleT, yT);
   };

--- a/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
@@ -54,7 +54,8 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
     FUSILLI_REQUIRE_OK(graph->validate());
 
     // Compile
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, scaleT, yT);
   };

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -188,7 +188,8 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
                       bool isCausal, std::optional<float> scale, bool enableGqa,
                       bool hasAttnMask, float dropoutP) {
   FUSILLI_REQUIRE_OK(ctx.graph->validate());
-  FUSILLI_REQUIRE_OK(ctx.graph->compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(ctx.graph->compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(ctx.graph->load(handle));
 
   FUSILLI_REQUIRE_ASSIGN(auto qBuf,
                          allocateBufferOfType(handle, ctx.qT, dt, 0.01));

--- a/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
+++ b/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
@@ -74,7 +74,8 @@ TEST_CASE("Convolution fprop with hip stream; X (NCHW), W (KCRS); 1x1 conv; no "
   FUSILLI_REQUIRE_OK(graph.validate());
 
   // Compile
-  FUSILLI_REQUIRE_OK(graph.compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(graph.compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(graph.load(handle));
 
   // Allocate input buffer.
   FUSILLI_REQUIRE_ASSIGN(

--- a/tests/lit/test_batchnorm_infer_asm_emitter_nchw.cpp
+++ b/tests/lit/test_batchnorm_infer_asm_emitter_nchw.cpp
@@ -98,7 +98,8 @@ static ErrorObject testBatchnormInferAsmEmitterNchw(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_batchnorm_train_asm_emitter_nchw.cpp
+++ b/tests/lit/test_batchnorm_train_asm_emitter_nchw.cpp
@@ -99,7 +99,8 @@ static ErrorObject testBatchnormTrainAsmEmitterNchw(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -111,7 +111,8 @@ static ErrorObject testConvAsmEmitterXNchwWKcrs(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -113,7 +113,8 @@ testConvAsmEmitterXNchwWKcrsWithPad(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -111,7 +111,8 @@ static ErrorObject testConvAsmEmitterXNchwWKrsc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_ndhwc_kdrsc.cpp
+++ b/tests/lit/test_conv_asm_emitter_ndhwc_kdrsc.cpp
@@ -123,7 +123,8 @@ static ErrorObject testConvAsmEmitterXNdhwcWKdrsc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_ndhwc_kdrsc_grouped.cpp
+++ b/tests/lit/test_conv_asm_emitter_ndhwc_kdrsc_grouped.cpp
@@ -113,7 +113,8 @@ testConvAsmEmitterXNdhwcWKdrscGrouped(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
+++ b/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
@@ -113,7 +113,8 @@ static ErrorObject testConvAsmEmitterXNhwcWKcrs(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
+++ b/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
@@ -113,7 +113,8 @@ static ErrorObject testConvAsmEmitterXNhwcWKrsc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nhwc_krsc_grouped.cpp
+++ b/tests/lit/test_conv_asm_emitter_nhwc_krsc_grouped.cpp
@@ -117,7 +117,8 @@ testConvAsmEmitterXNhwcWKrscGrouped(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -116,7 +116,8 @@ testConvAsmEmitterXNhwcWKrscWithPad(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_relu.cpp
+++ b/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_relu.cpp
@@ -165,7 +165,8 @@ testConvAsmEmitterXNhwcWKrscWithRelu(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_dgrad_asm_emitter_nhwc_kcrs.cpp
+++ b/tests/lit/test_conv_dgrad_asm_emitter_nhwc_kcrs.cpp
@@ -133,7 +133,8 @@ testConvDgradAsmEmitterDyNhwcDxNhwc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_dgrad_asm_emitter_nhwc_kcrs_grouped.cpp
+++ b/tests/lit/test_conv_dgrad_asm_emitter_nhwc_kcrs_grouped.cpp
@@ -136,7 +136,8 @@ testConvDgradAsmEmitterDyNhwcDxNhwcGrouped(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc.cpp
+++ b/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc.cpp
@@ -132,7 +132,8 @@ static ErrorObject testConvWgradAsmEmitterDyNhwcXNhwc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc_grouped.cpp
+++ b/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc_grouped.cpp
@@ -136,7 +136,8 @@ testConvWgradAsmEmitterDyNhwcXNhwcGrouped(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc_grouped_strided.cpp
+++ b/tests/lit/test_conv_wgrad_asm_emitter_nhwc_krsc_grouped_strided.cpp
@@ -139,7 +139,8 @@ testConvWgradAsmEmitterDyNhwcXNhwcGroupedStrided(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_custom_op_asm_emitter_sdpa.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_sdpa.cpp
@@ -138,7 +138,8 @@ static ErrorObject testCustomOpAsmEmitterSdpa(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_layernorm_infer_asm_emitter_nchw.cpp
+++ b/tests/lit/test_layernorm_infer_asm_emitter_nchw.cpp
@@ -90,7 +90,8 @@ static ErrorObject testLayernormInferAsmEmitterNchw(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc.cpp
+++ b/tests/lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc.cpp
@@ -111,7 +111,8 @@ testLayernormInferAsmEmitterScaleBiasNhwc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc_small_batch.cpp
+++ b/tests/lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc_small_batch.cpp
@@ -111,7 +111,8 @@ testLayernormInferAsmEmitterScaleBiasNhwcSmallBatch(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_layernorm_train_asm_emitter_nchw.cpp
+++ b/tests/lit/test_layernorm_train_asm_emitter_nchw.cpp
@@ -105,7 +105,8 @@ static ErrorObject testLayernormTrainAsmEmitterNchw(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_layernorm_train_asm_emitter_scale_bias_nhwc.cpp
+++ b/tests/lit/test_layernorm_train_asm_emitter_scale_bias_nhwc.cpp
@@ -126,7 +126,8 @@ testLayernormInferAsmEmitterScaleBiasNhwc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_matmul_asm_emitter_basic.cpp
+++ b/tests/lit/test_matmul_asm_emitter_basic.cpp
@@ -84,7 +84,8 @@ static ErrorObject testMatmulAsmEmitterBasic(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_matmul_asm_emitter_batched.cpp
+++ b/tests/lit/test_matmul_asm_emitter_batched.cpp
@@ -91,7 +91,8 @@ static ErrorObject testMatmulAsmEmitterBatched(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_matmul_asm_emitter_broadcast_3D.cpp
+++ b/tests/lit/test_matmul_asm_emitter_broadcast_3D.cpp
@@ -98,7 +98,8 @@ static ErrorObject testMatmulAsmEmitterBroadcast3D(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_matmul_asm_emitter_broadcast_4D.cpp
+++ b/tests/lit/test_matmul_asm_emitter_broadcast_4D.cpp
@@ -104,7 +104,8 @@ static ErrorObject testMatmulAsmEmitterBroadcast(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_matmul_asm_emitter_noncontiguous.cpp
+++ b/tests/lit/test_matmul_asm_emitter_noncontiguous.cpp
@@ -104,7 +104,8 @@ static ErrorObject testMatmulAsmEmitterNoncontiguous(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_pointwise_asm_emitter_add_transposed.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_add_transposed.cpp
@@ -86,7 +86,8 @@ testPointwiseAsmEmitterAddTransposed(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_pointwise_asm_emitter_mul_scalar.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_mul_scalar.cpp
@@ -81,7 +81,8 @@ static ErrorObject testPointwiseMulScalarAsmEmitter(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_reduction_asm_emitter_max.cpp
+++ b/tests/lit/test_reduction_asm_emitter_max.cpp
@@ -79,7 +79,8 @@ static ErrorObject testReductionAsmEmitterMax(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_reduction_asm_emitter_min.cpp
+++ b/tests/lit/test_reduction_asm_emitter_min.cpp
@@ -79,7 +79,8 @@ static ErrorObject testReductionAsmEmitterMin(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_reduction_asm_emitter_sum.cpp
+++ b/tests/lit/test_reduction_asm_emitter_sum.cpp
@@ -80,7 +80,8 @@ static ErrorObject testReductionAsmEmitterSum(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_rmsnorm_infer_asm_emitter_nchw.cpp
+++ b/tests/lit/test_rmsnorm_infer_asm_emitter_nchw.cpp
@@ -87,7 +87,8 @@ static ErrorObject testRmsnormInferAsmEmitterNchw(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc.cpp
+++ b/tests/lit/test_rmsnorm_infer_asm_emitter_scale_nhwc.cpp
@@ -95,7 +95,8 @@ testRmsnormInferAsmEmitterScaleNhwc(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
@@ -98,7 +98,8 @@ static ErrorObject testSdpaAsmEmitterBasicMha(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_causal.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_causal.cpp
@@ -100,7 +100,8 @@ static ErrorObject testSdpaAsmEmitterCausal(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_cross_attn.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_cross_attn.cpp
@@ -109,7 +109,8 @@ static ErrorObject testSdpaAsmEmitterCrossAttn(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
@@ -98,7 +98,8 @@ static ErrorObject testSdpaAsmEmitterCustomScale(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_gqa.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_gqa.cpp
@@ -109,7 +109,8 @@ static ErrorObject testSdpaAsmEmitterGqa(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/lit/test_sdpa_asm_emitter_with_mask.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_with_mask.cpp
@@ -113,7 +113,8 @@ static ErrorObject testSdpaAsmEmitterWithMask(const std::string &mode) {
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;

--- a/tests/test_custom_op.cpp
+++ b/tests/test_custom_op.cpp
@@ -121,7 +121,8 @@ TEST_CASE("CustomOp compile + execute round-trip", "[custom_op]") {
   FUSILLI_REQUIRE_OK(g.validate());
 
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.load(handle));
 
   // Allocate buffers.
   FUSILLI_REQUIRE_ASSIGN(
@@ -190,7 +191,8 @@ TEST_CASE("CustomOp composition: built-in op -> custom op", "[custom_op]") {
   FUSILLI_REQUIRE_OK(g.validate());
 
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.load(handle));
 
   FUSILLI_REQUIRE_ASSIGN(
       auto aBuf,

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -175,40 +175,35 @@ TEST_CASE("Graph asm_emitter requires validation to be run first", "[graph]") {
 
 TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
           "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle cpuHandle, Handle::create(Backend::CPU));
-#if defined(FUSILLI_ENABLE_AMDGPU)
-  FUSILLI_REQUIRE_ASSIGN(Handle gpuHandle, Handle::create(Backend::AMDGPU));
-#endif
-
   Graph g = testGraph(/*validate=*/true);
 
   FUSILLI_REQUIRE_ASSIGN(std::string generatedAsm, g.emitAsm());
 
   // Cache should be empty, compilation artifacts should be generated.
   std::optional<bool> reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
   // Cache should hit, no compilation should be required.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
 
 #if defined(FUSILLI_ENABLE_AMDGPU)
-  // Cache should miss based on different handle / device / compile command.
+  // Cache should miss based on different backend / compile command.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(gpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::AMDGPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
-  // Cache should hit with a re-run on the different handle.
+  // Cache should hit with a re-run on the different backend.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(gpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::AMDGPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
@@ -216,14 +211,14 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
 
   // Cache should miss because of different generated asm.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
   // Cache should hit with the same generated asm.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
@@ -231,7 +226,7 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
   // Cache should miss because graph name change.
   g.setName("new_graph_name");
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
@@ -240,8 +235,6 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
 TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
           "other/previous Graph instances",
           "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   std::string generatedAsm;
   {
     Graph g = testGraph(/*validate=*/true);
@@ -250,14 +243,14 @@ TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
 
     // Cache should be empty.
     std::optional<bool> reCompiled = std::nullopt;
-    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                              /*remove=*/false, &reCompiled));
     REQUIRE(reCompiled.has_value());
     REQUIRE(reCompiled.value());
 
     // Cache should hit with the same generated asm.
     reCompiled = std::nullopt;
-    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                              /*remove=*/false, &reCompiled));
     REQUIRE(reCompiled.has_value());
     REQUIRE(!reCompiled.value());
@@ -274,20 +267,19 @@ TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
 
   // Nonetheless a new instance should regenerate cache.
   std::optional<bool> reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 }
 
 TEST_CASE("Graph `getCompiledArtifact` invalid input IR", "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   std::string graphName;
   {
     Graph g;
     g.setName("invalid_input_ir");
     ErrorObject err =
-        g.getCompiledArtifact(handle, "invalid mlir", /*remove=*/true);
+        g.getCompiledArtifact(kDefaultBackend, "invalid mlir", /*remove=*/true);
     REQUIRE(isError(err));
     REQUIRE(err.getCode() == ErrorCode::CompileFailure);
     // Error message varies between subprocess and C API backends.
@@ -301,22 +293,45 @@ TEST_CASE("Graph `getCompiledArtifact` invalid input IR", "[graph]") {
 }
 
 TEST_CASE("Graph `compile` method fails without validation", "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   Graph g = testGraph(/*validate=*/false);
 
-  auto status = g.compile(handle, /*remove=*/true);
+  auto status = g.compile(kDefaultBackend, /*remove=*/true);
   REQUIRE(isError(status));
   REQUIRE(status.getCode() == ErrorCode::NotValidated);
   REQUIRE(status.getMessage() ==
           "Graph must be validated before being compiled");
 }
 
-TEST_CASE("Graph `compile` recompilations with changed handle", "[graph]") {
+TEST_CASE("Graph `load` fails without prior compile", "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  Graph g = testGraph(/*validate=*/true);
+
+  auto status = g.load(handle);
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::NotCompiled);
+  REQUIRE(status.getMessage() ==
+          "Graph must be compiled before loading (call compile() first)");
+}
+
+#if defined(FUSILLI_ENABLE_AMDGPU)
+TEST_CASE("Graph `load` fails with backend mismatch", "[graph]") {
+  // Compile for CPU, then try to load with a GPU handle.
+  Graph g = testGraph(/*validate=*/true);
+  FUSILLI_REQUIRE_OK(g.compile(Backend::CPU, /*remove=*/true));
+
+  FUSILLI_REQUIRE_ASSIGN(Handle gpuHandle, Handle::create(Backend::AMDGPU));
+  auto status = g.load(gpuHandle);
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidArgument);
+  REQUIRE(status.getMessage().find("does not match") != std::string::npos);
+}
+#endif
+
+TEST_CASE("Graph `compile` recompilations with changed backend", "[graph]") {
   // This test constructs a single graph but compiles it with different
-  // handles and backends, ensuring that the graph did not use cached
-  // artifacts from a previous compilation and correctly re-compiled
-  // for the new handle/backend.
+  // backends, ensuring that the graph did not use cached artifacts from
+  // a previous compilation and correctly re-compiled for the new backend.
   Graph g = testGraph(/*validate=*/true);
 
   // Path to compile command cache file.
@@ -324,8 +339,7 @@ TEST_CASE("Graph `compile` recompilations with changed handle", "[graph]") {
   std::filesystem::path cmdPath =
       cacheDir / g.getName() / "iree-compile-command.txt";
 
-  FUSILLI_REQUIRE_ASSIGN(Handle cpuHandle, Handle::create(Backend::CPU));
-  FUSILLI_REQUIRE_OK(g.compile(cpuHandle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.compile(Backend::CPU, /*remove=*/true));
 
   std::string cpuCmd;
   REQUIRE(std::filesystem::exists(cmdPath));
@@ -335,8 +349,7 @@ TEST_CASE("Graph `compile` recompilations with changed handle", "[graph]") {
   REQUIRE(!cpuCmd.empty());
 
 #if defined(FUSILLI_ENABLE_AMDGPU)
-  FUSILLI_REQUIRE_ASSIGN(Handle gpuHandle, Handle::create(Backend::AMDGPU));
-  FUSILLI_REQUIRE_OK(g.compile(gpuHandle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.compile(Backend::AMDGPU, /*remove=*/true));
 
   std::string gpuCmd;
   REQUIRE(std::filesystem::exists(cmdPath));
@@ -345,7 +358,7 @@ TEST_CASE("Graph `compile` recompilations with changed handle", "[graph]") {
   std::getline(gpuCmdFile, gpuCmd);
   REQUIRE(!gpuCmd.empty());
 
-  // The compile commands should be different for CPU and GPU handles.
+  // The compile commands should be different for CPU and GPU backends.
   REQUIRE(cpuCmd != gpuCmd);
 #endif
 }
@@ -382,7 +395,8 @@ TEST_CASE("Graph `execute`", "[graph]") {
 
     FUSILLI_REQUIRE_OK(graph->validate());
 
-    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(graph->load(handle));
 
     return std::make_tuple(graph, xT, wT, yT);
   };
@@ -390,7 +404,7 @@ TEST_CASE("Graph `execute`", "[graph]") {
   // Create handle for the target backend.
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
-  // Build graph for the given handle (device), validate and compile it.
+  // Build graph for the given handle (device), validate, compile and load.
   auto [graph, X, W, Y] = buildNewGraph(handle);
 
   // Allocate input buffer.
@@ -500,10 +514,11 @@ TEST_CASE("Graph `getWorkspaceSize` after compilation", "[graph]") {
 
   Graph g = testGraph(/*validate=*/true);
 
-  // Compile the graph.
-  FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
+  // Compile and load the graph.
+  FUSILLI_REQUIRE_OK(g.compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.load(handle));
 
-  // After compilation, getWorkspaceSize returns the queried transient size.
+  // After loading, getWorkspaceSize returns the queried transient size.
   // It should have a value (not nullopt). The actual size is
   // implementation-dependent.
   auto workspaceSize = g.getWorkspaceSize();
@@ -515,7 +530,8 @@ TEST_CASE("Graph `getWorkspaceSize` consistency across multiple queries",
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
   Graph g = testGraph(/*validate=*/true);
-  FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.compile(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.load(handle));
 
   // Multiple queries should return the same value.
   auto size1 = g.getWorkspaceSize();

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -356,7 +356,8 @@ inline ErrorObject testUnaryPointwiseAsmEmitter(const std::string &graphName,
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;
@@ -395,7 +396,8 @@ inline ErrorObject testBinaryPointwiseAsmEmitter(const std::string &graphName,
 
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->compile(handle.getBackend(), /*remove=*/true));
+    FUSILLI_CHECK_ERROR(graph->load(handle));
     FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
                                              CachedAssetsType::Statistics));
     std::cout << stats << std::endl;


### PR DESCRIPTION
This demonstrates syntactic sugar API re-arrangement to remove `handle` dependency from `Graph::compile`. It shifts the VM context load step to its own `Graph::load` API. This doesn't inherently remove the handle dependency from the one-time setup that runs outside the hot execute loop. It just makes it so the `compile` in isolation looks clean with no handle requirement.

I personally think this is NOT a change worth landing. It is 
1) incomplete: Even without the handle dependency, we still don't inherently support compiling for multiple backends and having the execute pick the one that matches
1) unnecessary: Adds an extra user-facing `graph->load` call for no good reason - the current approach hides this underneath the compile call as loading the compiled bytecode into the VM session and setup is an implementation detail that serves no good purpose being exposed to the user


Perhaps at a later point we might support multi-backend compilations and caching - this decoupling of handle from compile is best revisited with the new architecture in place.