### PR TITLE
Add SOFTPLUS_FWD and SWISH_FWD pointwise ops

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -64,11 +64,11 @@ namespace fusilli {
   OP(SIGMOID_FWD)                                                              \
   OP(SIN)                                                                      \
   /* OP(SOFTPLUS_BWD) */                                                       \
-  /* OP(SOFTPLUS_FWD) */                                                       \
+  OP(SOFTPLUS_FWD)                                                             \
   OP(SQRT)                                                                     \
   OP(SUB)                                                                      \
   /* OP(SWISH_BWD) */                                                          \
-  /* OP(SWISH_FWD) */                                                          \
+  OP(SWISH_FWD)                                                                \
   OP(TAN)                                                                      \
   /* OP(TANH_BWD) */                                                           \
   OP(TANH_FWD)
@@ -106,6 +106,16 @@ public:
     return *this;
   }
 
+  PointwiseAttr &setSoftplusBeta(float beta) {
+    softplusBeta_ = beta;
+    return *this;
+  }
+
+  PointwiseAttr &setSoftplusThreshold(float threshold) {
+    softplusThreshold_ = threshold;
+    return *this;
+  }
+
   // Getters:
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_0)
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_1)
@@ -114,6 +124,8 @@ public:
 
   Mode getMode() const { return mode_; }
   float getEluAlpha() const { return eluAlpha_; }
+  float getSoftplusBeta() const { return softplusBeta_; }
+  float getSoftplusThreshold() const { return softplusThreshold_; }
 
   // Utilities for pointwise modes.
   static const std::unordered_map<Mode, std::string> kModeToStr;
@@ -123,6 +135,8 @@ public:
 private:
   Mode mode_ = Mode::NOT_SET;
   float eluAlpha_ = 1.0f;
+  float softplusBeta_ = 1.0f;
+  float softplusThreshold_ = 20.0f;
 };
 
 #define FUSILLI_DECLARE_STRINGIFY_POINTWISE_MODE(mode)                         \
@@ -165,8 +179,10 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
         {PointwiseAttr::Mode::RSQRT, 1},
         {PointwiseAttr::Mode::SIGMOID_FWD, 1},
         {PointwiseAttr::Mode::SIN, 1},
+        {PointwiseAttr::Mode::SOFTPLUS_FWD, 1},
         {PointwiseAttr::Mode::SQRT, 1},
         {PointwiseAttr::Mode::SUB, 2},
+        {PointwiseAttr::Mode::SWISH_FWD, 1},
         {PointwiseAttr::Mode::TAN, 1},
         {PointwiseAttr::Mode::TANH_FWD, 1}};
 

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1801,6 +1801,14 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {5}
 )";
 
+  constexpr std::string_view kSoftplusSchema = R"(
+    {0}
+    %softplus_beta_{7} = torch.constant.float {8:e}
+    %softplus_threshold_{7} = torch.constant.float {9:e}
+    {1} = {6} {2}, %softplus_beta_{7}, %softplus_threshold_{7} : {3}, !torch.float, !torch.float -> {4}
+    {5}
+)";
+
 #define FUSILLI_DECLARE_UNARY_TORCH_EMITTER(PWOP, OPIR)                        \
   FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(PWOP, kUnaryTorchSchema, OPIR)
 #define FUSILLI_DECLARE_BINARY_TORCH_EMITTER(PWOP, OPIR)                       \
@@ -1839,6 +1847,20 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        approx                   /* {8} */
     );
   }
+  case PointwiseAttr::Mode::SOFTPLUS_FWD: {
+    return std::format(kSoftplusSchema, permuteIN0,         /* {0} */
+                       getResultNamesAsm(),                 /* {1} */
+                       getOperandNamesAsm(),                /* {2} */
+                       getOperandTypesAsm(),                /* {3} */
+                       getResultTypesAsm(),                 /* {4} */
+                       permuteOUT0,                         /* {5} */
+                       "torch.aten.softplus",               /* {6} */
+                       getName(),                           /* {7} */
+                       pointwiseAttr.getSoftplusBeta(),     /* {8} */
+                       pointwiseAttr.getSoftplusThreshold() /* {9} */
+    );
+  }
+    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(SWISH_FWD, torch.aten.silu)
     FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,
                                             torch.aten.clone)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(ERF, torch.aten.erf)

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -75,7 +75,9 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     case PointwiseAttr::Mode::RSQRT:
     case PointwiseAttr::Mode::SIGMOID_FWD:
     case PointwiseAttr::Mode::SIN:
+    case PointwiseAttr::Mode::SOFTPLUS_FWD:
     case PointwiseAttr::Mode::SQRT:
+    case PointwiseAttr::Mode::SWISH_FWD:
     case PointwiseAttr::Mode::TAN:
     case PointwiseAttr::Mode::TANH_FWD:
       return true;
@@ -102,7 +104,9 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       PointwiseAttr::Mode::RSQRT,
       PointwiseAttr::Mode::SIGMOID_FWD,
       PointwiseAttr::Mode::SIN,
+      PointwiseAttr::Mode::SOFTPLUS_FWD,
       PointwiseAttr::Mode::SQRT,
+      PointwiseAttr::Mode::SWISH_FWD,
       PointwiseAttr::Mode::TAN,
       PointwiseAttr::Mode::TANH_FWD);
   // clang-format on
@@ -248,9 +252,23 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
       y = std::sin(xD);
       break;
     }
+    case PointwiseAttr::Mode::SOFTPLUS_FWD: {
+      double xD = static_cast<double>(x);
+      // SOFTPLUS(x) = log(1 + exp(x)); for x > threshold, result ~= x.
+      // Matches torch.aten.softplus with beta=1.0 and threshold=20.0.
+      constexpr double threshold = 20.0;
+      y = xD > threshold ? xD : std::log1p(std::exp(xD));
+      break;
+    }
     case PointwiseAttr::Mode::SQRT: {
       double xD = static_cast<double>(x);
       y = std::sqrt(xD);
+      break;
+    }
+    case PointwiseAttr::Mode::SWISH_FWD: {
+      double xD = static_cast<double>(x);
+      // SWISH(x) = SiLU(x) = x * sigmoid(x).
+      y = xD / (1.0 + std::exp(-xD));
       break;
     }
     case PointwiseAttr::Mode::TAN: {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,7 +176,9 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_rsqrt.cpp
     lit/test_pointwise_asm_emitter_sigmoid.cpp
     lit/test_pointwise_asm_emitter_sin.cpp
+    lit/test_pointwise_asm_emitter_softplus_fwd.cpp
     lit/test_pointwise_asm_emitter_sqrt.cpp
+    lit/test_pointwise_asm_emitter_swish_fwd.cpp
     lit/test_pointwise_asm_emitter_tan.cpp
     lit/test_pointwise_asm_emitter_tanh.cpp
     lit/test_pointwise_asm_emitter_sub.cpp

--- a/tests/lit/test_pointwise_asm_emitter_softplus_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_softplus_fwd.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_softplus_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_softplus_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_softplus_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_softplus_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_softplus_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_softplus_fwd, %permute_IN_0_val_1_pointwise_softplus_fwd, %permute_IN_0_val_2_pointwise_softplus_fwd, %permute_IN_0_val_3_pointwise_softplus_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_softplus_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_softplus_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %softplus_beta_pointwise_softplus_fwd = torch.constant.float 1.000000e+00
+// TORCH-CHECK:       %softplus_threshold_pointwise_softplus_fwd = torch.constant.float 2.000000e+01
+// TORCH-CHECK:       %result_pointwise_softplus_fwd_perm = torch.aten.softplus %arg0_pointwise_softplus_fwd_perm, %softplus_beta_pointwise_softplus_fwd, %softplus_threshold_pointwise_softplus_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.float, !torch.float -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_softplus_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_softplus_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_softplus_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_softplus_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_softplus_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_softplus_fwd, %permute_OUT_0_val_1_pointwise_softplus_fwd, %permute_OUT_0_val_2_pointwise_softplus_fwd, %permute_OUT_0_val_3_pointwise_softplus_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_softplus_fwd_perm, %permute_OUT_0_pointwise_softplus_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "pointwise_utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_softplus_fwd", "pointwise_softplus_fwd", mode,
+      PointwiseAttr::Mode::SOFTPLUS_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_swish_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_swish_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_swish_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_swish_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_swish_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_swish_fwd, %permute_IN_0_val_1_pointwise_swish_fwd, %permute_IN_0_val_2_pointwise_swish_fwd, %permute_IN_0_val_3_pointwise_swish_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_swish_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_swish_fwd_perm = torch.aten.silu %arg0_pointwise_swish_fwd_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_swish_fwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_swish_fwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_swish_fwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_swish_fwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_swish_fwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_swish_fwd, %permute_OUT_0_val_1_pointwise_swish_fwd, %permute_OUT_0_val_2_pointwise_swish_fwd, %permute_OUT_0_val_3_pointwise_swish_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_swish_fwd_perm, %permute_OUT_0_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "pointwise_utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testUnaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_swish_fwd", "pointwise_swish_fwd", mode,
+      PointwiseAttr::Mode::SWISH_FWD, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Emit torch.aten.softplus with configurable beta and threshold attributes (defaulting to 1.0 and 20.0) and torch.aten.silu for swish. Adds sample and lit tests for both ops.