### PR TITLE
Add swish_beta parameter to SWISH_FWD

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -116,6 +116,11 @@ public:
     return *this;
   }
 
+  PointwiseAttr &setSwishBeta(float beta) {
+    swishBeta_ = beta;
+    return *this;
+  }
+
   // Getters:
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_0)
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_1)
@@ -126,6 +131,7 @@ public:
   float getEluAlpha() const { return eluAlpha_; }
   float getSoftplusBeta() const { return softplusBeta_; }
   float getSoftplusThreshold() const { return softplusThreshold_; }
+  float getSwishBeta() const { return swishBeta_; }
 
   // Utilities for pointwise modes.
   static const std::unordered_map<Mode, std::string> kModeToStr;
@@ -137,6 +143,7 @@ private:
   float eluAlpha_ = 1.0f;
   float softplusBeta_ = 1.0f;
   float softplusThreshold_ = 20.0f;
+  float swishBeta_ = 1.0f;
 };
 
 #define FUSILLI_DECLARE_STRINGIFY_POINTWISE_MODE(mode)                         \

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1801,6 +1801,17 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {5}
 )";
 
+  // Swish: y = x * sigmoid(beta * x). When beta=1 this matches torch.aten.silu,
+  // but we expand it to the composite form so the beta knob is honored.
+  constexpr std::string_view kSwishSchema = R"(
+    {0}
+    %swish_beta_{6} = torch.constant.float {7:e}
+    %swish_scaled_{6} = torch.aten.mul.Scalar {2}, %swish_beta_{6} : {3}, !torch.float -> {4}
+    %swish_sig_{6} = torch.aten.sigmoid %swish_scaled_{6} : {4} -> {4}
+    {1} = torch.aten.mul.Tensor {2}, %swish_sig_{6} : {3}, {4} -> {4}
+    {5}
+)";
+
   constexpr std::string_view kSoftplusSchema = R"(
     {0}
     %softplus_beta_{7} = torch.constant.float {8:e}
@@ -1860,7 +1871,17 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        pointwiseAttr.getSoftplusThreshold() /* {9} */
     );
   }
-    FUSILLI_DECLARE_UNARY_TORCH_EMITTER(SWISH_FWD, torch.aten.silu)
+  case PointwiseAttr::Mode::SWISH_FWD: {
+    return std::format(kSwishSchema, permuteIN0,    /* {0} */
+                       getResultNamesAsm(),         /* {1} */
+                       getOperandNamesAsm(),        /* {2} */
+                       getOperandTypesAsm(),        /* {3} */
+                       getResultTypesAsm(),         /* {4} */
+                       permuteOUT0,                 /* {5} */
+                       getName(),                   /* {6} */
+                       pointwiseAttr.getSwishBeta() /* {7} */
+    );
+  }
     FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(IDENTITY, kIdentitySchema,
                                             torch.aten.clone)
     FUSILLI_DECLARE_UNARY_TORCH_EMITTER(ERF, torch.aten.erf)

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -38,6 +38,7 @@ static std::string generateName(PointwiseAttr::Mode mode, DataType type,
 
 TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
   const auto dim = std::vector<int64_t>{2, 16, 64, 64};
+  constexpr float kSwishBeta = 2.0f;
 
   auto supportsInteger = [](PointwiseAttr::Mode m) {
     switch (m) {
@@ -124,6 +125,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
 
       // Create Pointwise unary op
       auto pointwiseAttr = PointwiseAttr().setMode(mode);
+      if (mode == PointwiseAttr::Mode::SWISH_FWD)
+        pointwiseAttr.setSwishBeta(kSwishBeta);
       auto pointwiseResult = graph->pointwise(xT, pointwiseAttr);
 
       pointwiseResult->setName("result").setOutput(true);
@@ -267,8 +270,8 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
     }
     case PointwiseAttr::Mode::SWISH_FWD: {
       double xD = static_cast<double>(x);
-      // SWISH(x) = SiLU(x) = x * sigmoid(x).
-      y = xD / (1.0 + std::exp(-xD));
+      // SWISH(x) = x * sigmoid(beta * x).
+      y = xD / (1.0 + std::exp(-static_cast<double>(kSwishBeta) * xD));
       break;
     }
     case PointwiseAttr::Mode::TAN: {

--- a/tests/lit/test_pointwise_asm_emitter_abs.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_abs.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_abs", "pointwise_abs", mode,
-      PointwiseAttr::Mode::ABS, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::ABS)
+                           .setName("pointwise_abs");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_abs", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_add.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_add.cpp
@@ -56,9 +56,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_add", "pointwise_add", mode,
-      PointwiseAttr::Mode::ADD, {16, 256, 64, 32}, {1, 256, 1, 1});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::ADD)
+                           .setName("pointwise_add");
+  auto status = testBinaryPointwiseAsmEmitter("pointwise_asm_emitter_add", mode,
+                                              pointwiseAttr, {16, 256, 64, 32},
+                                              {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_add_square.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_add_square.cpp
@@ -57,9 +57,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::ADD_SQUARE)
+                           .setName("pointwise_add_square");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_add_square", "pointwise_add_square", mode,
-      PointwiseAttr::Mode::ADD_SQUARE, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_add_square", mode, pointwiseAttr,
+      {16, 256, 64, 32}, {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_ceil.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_ceil.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_ceil", "ceil", mode, PointwiseAttr::Mode::CEIL,
-      {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CEIL).setName("ceil");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_ceil", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_eq.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_eq.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_EQ).setName("cmp_eq");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_eq", "cmp_eq", mode,
-      PointwiseAttr::Mode::CMP_EQ, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_eq", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_ge.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_ge.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_GE).setName("cmp_ge");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_ge", "cmp_ge", mode,
-      PointwiseAttr::Mode::CMP_GE, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_ge", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_gt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_gt.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_GT).setName("cmp_gt");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_gt", "cmp_gt", mode,
-      PointwiseAttr::Mode::CMP_GT, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_gt", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_le.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_le.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_LE).setName("cmp_le");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_le", "cmp_le", mode,
-      PointwiseAttr::Mode::CMP_LE, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_le", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_lt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_lt.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_LT).setName("cmp_lt");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_lt", "cmp_lt", mode,
-      PointwiseAttr::Mode::CMP_LT, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_lt", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_cmp_neq.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_cmp_neq.cpp
@@ -55,9 +55,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::CMP_NEQ).setName("cmp_neq");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_cmp_neq", "cmp_neq", mode,
-      PointwiseAttr::Mode::CMP_NEQ, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_cmp_neq", mode, pointwiseAttr, {16, 256, 64, 32},
+      {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_div.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_div.cpp
@@ -55,9 +55,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_div", "pointwise_div", mode,
-      PointwiseAttr::Mode::DIV, {2, 3, 224, 224}, {1, 3, 1, 1});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::DIV)
+                           .setName("pointwise_div");
+  auto status = testBinaryPointwiseAsmEmitter("pointwise_asm_emitter_div", mode,
+                                              pointwiseAttr, {2, 3, 224, 224},
+                                              {1, 3, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_elu.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_elu.cpp
@@ -52,9 +52,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_elu", "pointwise_elu", mode,
-      PointwiseAttr::Mode::ELU_FWD, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::ELU_FWD)
+                           .setName("pointwise_elu");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_elu", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_erf.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_erf.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status =
-      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_erf", "erf", mode,
-                                   PointwiseAttr::Mode::ERF, {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::ERF).setName("erf");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_erf", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_exp.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_exp.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status =
-      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_exp", "exp", mode,
-                                   PointwiseAttr::Mode::EXP, {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::EXP).setName("exp");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_exp", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_floor.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_floor.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::FLOOR).setName("floor");
   auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_floor", "floor", mode, PointwiseAttr::Mode::FLOOR,
-      {16, 256, 64, 32});
+      "pointwise_asm_emitter_floor", mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_approx_tanh_fwd.cpp
@@ -50,10 +50,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_gelu_approx_tanh_fwd",
-      "pointwise_gelu_approx_tanh_fwd", mode,
-      PointwiseAttr::Mode::GELU_APPROX_TANH_FWD, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::GELU_APPROX_TANH_FWD)
+                           .setName("pointwise_gelu_approx_tanh_fwd");
+  auto status =
+      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_gelu_approx_tanh_fwd",
+                                   mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_gelu_fwd.cpp
@@ -50,9 +50,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::GELU_FWD)
+                           .setName("pointwise_gelu_fwd");
   auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_gelu_fwd", "pointwise_gelu_fwd", mode,
-      PointwiseAttr::Mode::GELU_FWD, {16, 256, 64, 32});
+      "pointwise_asm_emitter_gelu_fwd", mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_identity.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_identity.cpp
@@ -50,9 +50,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::IDENTITY)
+                           .setName("pointwise_identity");
   auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_identity", "pointwise_identity", mode,
-      PointwiseAttr::Mode::IDENTITY, {16, 256, 64, 32});
+      "pointwise_asm_emitter_identity", mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_log.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_log.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status =
-      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_log", "log", mode,
-                                   PointwiseAttr::Mode::LOG, {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::LOG).setName("log");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_log", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_logical_and.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_logical_and.cpp
@@ -55,9 +55,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::LOGICAL_AND)
+                           .setName("logical_and");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_logical_and", "logical_and", mode,
-      PointwiseAttr::Mode::LOGICAL_AND, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_logical_and", mode, pointwiseAttr,
+      {16, 256, 64, 32}, {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_logical_not.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_logical_not.cpp
@@ -49,9 +49,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_logical_not", "logical_not", mode,
-      PointwiseAttr::Mode::LOGICAL_NOT, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::LOGICAL_NOT)
+                           .setName("logical_not");
+  auto status =
+      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_logical_not", mode,
+                                   pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_logical_or.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_logical_or.cpp
@@ -55,9 +55,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::LOGICAL_OR)
+                           .setName("logical_or");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_logical_or", "logical_or", mode,
-      PointwiseAttr::Mode::LOGICAL_OR, {16, 256, 64, 32}, {1, 256, 1, 1});
+      "pointwise_asm_emitter_logical_or", mode, pointwiseAttr,
+      {16, 256, 64, 32}, {1, 256, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_max.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_max.cpp
@@ -52,9 +52,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_max", "pointwise_max", mode,
-      PointwiseAttr::Mode::MAX_OP, {2, 3, 128, 128}, {128});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::MAX_OP)
+                           .setName("pointwise_max");
+  auto status =
+      testBinaryPointwiseAsmEmitter("pointwise_asm_emitter_max", mode,
+                                    pointwiseAttr, {2, 3, 128, 128}, {128});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_min.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_min.cpp
@@ -52,9 +52,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_min", "pointwise_min", mode,
-      PointwiseAttr::Mode::MIN_OP, {2, 3, 128, 128}, {128});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::MIN_OP)
+                           .setName("pointwise_min");
+  auto status =
+      testBinaryPointwiseAsmEmitter("pointwise_asm_emitter_min", mode,
+                                    pointwiseAttr, {2, 3, 128, 128}, {128});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_mul.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_mul.cpp
@@ -52,9 +52,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_mul", "pointwise_mul", mode,
-      PointwiseAttr::Mode::MUL, {2, 3, 128, 128}, {128});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::MUL)
+                           .setName("pointwise_mul");
+  auto status =
+      testBinaryPointwiseAsmEmitter("pointwise_asm_emitter_mul", mode,
+                                    pointwiseAttr, {2, 3, 128, 128}, {128});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_neg.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_neg.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status =
-      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_neg", "neg", mode,
-                                   PointwiseAttr::Mode::NEG, {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::NEG).setName("neg");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_neg", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_reciprocal.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_reciprocal.cpp
@@ -49,9 +49,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_reciprocal", "reciprocal", mode,
-      PointwiseAttr::Mode::RECIPROCAL, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::RECIPROCAL)
+                           .setName("reciprocal");
+  auto status =
+      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_reciprocal", mode,
+                                   pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_relu.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_relu.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_relu", "pointwise_relu", mode,
-      PointwiseAttr::Mode::RELU_FWD, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::RELU_FWD)
+                           .setName("pointwise_relu");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_relu", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_rsqrt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_rsqrt.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::RSQRT)
+                           .setName("pointwise_rsqrt");
   auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_rsqrt", "pointwise_rsqrt", mode,
-      PointwiseAttr::Mode::RSQRT, {16, 256, 64, 32});
+      "pointwise_asm_emitter_rsqrt", mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_sigmoid.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sigmoid.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SIGMOID_FWD)
+                           .setName("sigmoid");
   auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_sigmoid", "sigmoid", mode,
-      PointwiseAttr::Mode::SIGMOID_FWD, {16, 256, 64, 32});
+      "pointwise_asm_emitter_sigmoid", mode, pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_sin.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sin.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_sin", "pointwise_sin", mode,
-      PointwiseAttr::Mode::SIN, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SIN)
+                           .setName("pointwise_sin");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_sin", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_softplus_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_softplus_fwd.cpp
@@ -51,9 +51,12 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_softplus_fwd", "pointwise_softplus_fwd", mode,
-      PointwiseAttr::Mode::SOFTPLUS_FWD, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SOFTPLUS_FWD)
+                           .setName("pointwise_softplus_fwd");
+  auto status =
+      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_softplus_fwd", mode,
+                                   pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_sqrt.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sqrt.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_sqrt", "pointwise_sqrt", mode,
-      PointwiseAttr::Mode::SQRT, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SQRT)
+                           .setName("pointwise_sqrt");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_sqrt", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_sub.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_sub.cpp
@@ -53,9 +53,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SUB)
+                           .setName("pointwise_sub");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_sub", "pointwise_sub", mode,
-      PointwiseAttr::Mode::SUB, {3, 16, 16}, {3, 1, 1});
+      "pointwise_asm_emitter_sub", mode, pointwiseAttr, {3, 16, 16}, {3, 1, 1});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
@@ -52,9 +52,13 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testSwishPointwiseAsmEmitter("pointwise_asm_emitter_swish_fwd",
-                                             "pointwise_swish_fwd", mode,
-                                             {16, 256, 64, 32}, /*beta=*/2.0f);
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SWISH_FWD)
+                           .setName("pointwise_swish_fwd")
+                           .setSwishBeta(2.0f);
+  auto status =
+      testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_swish_fwd", mode,
+                                   pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_swish_fwd.cpp
@@ -18,7 +18,10 @@
 // TORCH-CHECK:       %permute_IN_0_val_3_pointwise_swish_fwd = torch.constant.int 3
 // TORCH-CHECK:       %permute_IN_0_pointwise_swish_fwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_swish_fwd, %permute_IN_0_val_1_pointwise_swish_fwd, %permute_IN_0_val_2_pointwise_swish_fwd, %permute_IN_0_val_3_pointwise_swish_fwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %arg0_pointwise_swish_fwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
-// TORCH-CHECK:       %result_pointwise_swish_fwd_perm = torch.aten.silu %arg0_pointwise_swish_fwd_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %swish_beta_pointwise_swish_fwd = torch.constant.float 2.000000e+00
+// TORCH-CHECK:       %swish_scaled_pointwise_swish_fwd = torch.aten.mul.Scalar %arg0_pointwise_swish_fwd_perm, %swish_beta_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.float -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %swish_sig_pointwise_swish_fwd = torch.aten.sigmoid %swish_scaled_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_swish_fwd_perm = torch.aten.mul.Tensor %arg0_pointwise_swish_fwd_perm, %swish_sig_pointwise_swish_fwd : !torch.vtensor<[16,256,64,32],f32>, !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
 // TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_swish_fwd = torch.constant.int 0
 // TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_swish_fwd = torch.constant.int 1
 // TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_swish_fwd = torch.constant.int 2
@@ -49,9 +52,9 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_swish_fwd", "pointwise_swish_fwd", mode,
-      PointwiseAttr::Mode::SWISH_FWD, {16, 256, 64, 32});
+  auto status = testSwishPointwiseAsmEmitter("pointwise_asm_emitter_swish_fwd",
+                                             "pointwise_swish_fwd", mode,
+                                             {16, 256, 64, 32}, /*beta=*/2.0f);
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_tan.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_tan.cpp
@@ -49,9 +49,11 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_tan", "pointwise_tan", mode,
-      PointwiseAttr::Mode::TAN, {16, 256, 64, 32});
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::TAN)
+                           .setName("pointwise_tan");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_tan", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_pointwise_asm_emitter_tanh.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_tanh.cpp
@@ -49,9 +49,10 @@ using namespace fusilli;
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testUnaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_TANH", "tanh", mode, PointwiseAttr::Mode::TANH_FWD,
-      {16, 256, 64, 32});
+  auto pointwiseAttr =
+      PointwiseAttr().setMode(PointwiseAttr::Mode::TANH_FWD).setName("tanh");
+  auto status = testUnaryPointwiseAsmEmitter("pointwise_asm_emitter_TANH", mode,
+                                             pointwiseAttr, {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/pointwise_utils.h
+++ b/tests/pointwise_utils.h
@@ -99,6 +99,46 @@ inline ErrorObject testBinaryPointwiseAsmEmitter(const std::string &graphName,
   return ok();
 }
 
+inline ErrorObject testSwishPointwiseAsmEmitter(const std::string &graphName,
+                                                const std::string &opName,
+                                                const std::string &mode,
+                                                std::vector<int64_t> inDims,
+                                                float beta) {
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName(graphName);
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  auto xT = createTestTensor("arg0", inDims, graph.get());
+
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::SWISH_FWD)
+                           .setName(opName)
+                           .setSwishBeta(beta);
+
+  auto yT = graph->pointwise(xT, pointwiseAttr);
+
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
 } // namespace fusilli
 
 #endif // FUSILLI_TESTS_POINTWISE_UTILS_H

--- a/tests/pointwise_utils.h
+++ b/tests/pointwise_utils.h
@@ -24,9 +24,8 @@
 namespace fusilli {
 
 inline ErrorObject testUnaryPointwiseAsmEmitter(const std::string &graphName,
-                                                const std::string &opName,
                                                 const std::string &mode,
-                                                PointwiseAttr::Mode pwMode,
+                                                PointwiseAttr &pointwiseAttr,
                                                 std::vector<int64_t> inDims) {
 
   auto graph = std::make_shared<Graph>();
@@ -34,8 +33,6 @@ inline ErrorObject testUnaryPointwiseAsmEmitter(const std::string &graphName,
   graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
 
   auto xT = createTestTensor("arg0", inDims, graph.get());
-
-  auto pointwiseAttr = PointwiseAttr().setMode(pwMode).setName(opName);
 
   auto yT = graph->pointwise(xT, pointwiseAttr);
 
@@ -61,9 +58,8 @@ inline ErrorObject testUnaryPointwiseAsmEmitter(const std::string &graphName,
 }
 
 inline ErrorObject testBinaryPointwiseAsmEmitter(const std::string &graphName,
-                                                 const std::string &opName,
                                                  const std::string &mode,
-                                                 PointwiseAttr::Mode pwMode,
+                                                 PointwiseAttr &pointwiseAttr,
                                                  std::vector<int64_t> lhsDims,
                                                  std::vector<int64_t> rhsDims) {
 
@@ -74,49 +70,7 @@ inline ErrorObject testBinaryPointwiseAsmEmitter(const std::string &graphName,
   auto xT = createTestTensor("arg0", lhsDims, graph.get());
   auto bT = createTestTensor("arg1", rhsDims, graph.get());
 
-  auto pointwiseAttr = PointwiseAttr().setMode(pwMode).setName(opName);
-
   auto yT = graph->pointwise(xT, bT, pointwiseAttr);
-
-  yT->setName("result").setOutput(true);
-
-  FUSILLI_CHECK_ERROR(graph->validate());
-
-  if (mode == "default") {
-    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
-    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
-    std::cout << generatedAsm << std::endl;
-  }
-
-  if (mode == "stats") {
-    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
-    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
-    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
-                                             CachedAssetsType::Statistics));
-    std::cout << stats << std::endl;
-  }
-
-  return ok();
-}
-
-inline ErrorObject testSwishPointwiseAsmEmitter(const std::string &graphName,
-                                                const std::string &opName,
-                                                const std::string &mode,
-                                                std::vector<int64_t> inDims,
-                                                float beta) {
-
-  auto graph = std::make_shared<Graph>();
-  graph->setName(graphName);
-  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
-
-  auto xT = createTestTensor("arg0", inDims, graph.get());
-
-  auto pointwiseAttr = PointwiseAttr()
-                           .setMode(PointwiseAttr::Mode::SWISH_FWD)
-                           .setName(opName)
-                           .setSwishBeta(beta);
-
-  auto yT = graph->pointwise(xT, pointwiseAttr);
 
   yT->setName("result").setOutput(true);
 


### PR DESCRIPTION
Expands the SWISH_FWD emission from torch.aten.silu (beta=1 only) to the composite x * sigmoid(beta * x) form, driven by a new PointwiseAttr::setSwishBeta (default 1.0). Sample and lit tests set a non-default beta so the new knob is exercised.