### PR TITLE
Add BINARY_SELECT pointwise op

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -28,7 +28,7 @@ namespace fusilli {
   OP(ABS)                                                                      \
   OP(ADD)                                                                      \
   /* OP(ADD_SQUARE)  */                                                        \
-  /* OP(BINARY_SELECT)  */                                                     \
+  OP(BINARY_SELECT)                                                            \
   OP(CEIL)                                                                     \
   OP(CMP_EQ)                                                                   \
   OP(CMP_GE)                                                                   \
@@ -151,6 +151,7 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
     PointwiseAttr::kModeToRequiredInputCount = {
         {PointwiseAttr::Mode::ABS, 1},
         {PointwiseAttr::Mode::ADD, 2},
+        {PointwiseAttr::Mode::BINARY_SELECT, 3},
         {PointwiseAttr::Mode::CEIL, 1},
         {PointwiseAttr::Mode::CMP_EQ, 2},
         {PointwiseAttr::Mode::CMP_LT, 2},

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -305,6 +305,11 @@ public:
                                         const std::shared_ptr<TensorAttr> &in1,
                                         PointwiseAttr &attributes);
 
+  std::shared_ptr<TensorAttr> pointwise(const std::shared_ptr<TensorAttr> &in0,
+                                        const std::shared_ptr<TensorAttr> &in1,
+                                        const std::shared_ptr<TensorAttr> &in2,
+                                        PointwiseAttr &attributes);
+
   std::shared_ptr<TensorAttr> reduction(const std::shared_ptr<TensorAttr> &x,
                                         ReductionAttr &attributes);
 
@@ -979,6 +984,41 @@ Graph::pointwise(const std::shared_ptr<TensorAttr> &in0,
 
   // Set inputs.
   pointwiseAttr.setIN_0(in0).setIN_1(in1);
+
+  // Set outputs.
+  auto out = outputTensor(pointwiseAttr.getName() + "_OUT_0");
+  pointwiseAttr.setOUT_0(out);
+
+  // Create node and add to Graph's subNodes_.
+  subNodes_.emplace_back(
+      std::make_unique<PointwiseNode>(std::move(pointwiseAttr), context));
+
+  return out;
+}
+
+// Create a PointwiseNode for cases with three operands (e.g. BINARY_SELECT),
+// populate it with the specified attributes, create output tensors and add the
+// node to the graph's sub nodes.
+inline std::shared_ptr<TensorAttr>
+Graph::pointwise(const std::shared_ptr<TensorAttr> &in0,
+                 const std::shared_ptr<TensorAttr> &in1,
+                 const std::shared_ptr<TensorAttr> &in2,
+                 PointwiseAttr &pointwiseAttr) {
+  // Populate names when not set.
+  if (pointwiseAttr.getName().empty())
+    pointwiseAttr.setName("pointwise_" + std::to_string(subNodes_.size()));
+  if (in0 && in0->getName().empty())
+    in0->setName(pointwiseAttr.getName() + "_IN_0");
+  if (in1 && in1->getName().empty())
+    in1->setName(pointwiseAttr.getName() + "_IN_1");
+  if (in2 && in2->getName().empty())
+    in2->setName(pointwiseAttr.getName() + "_IN_2");
+
+  FUSILLI_LOG_LABEL_ENDL("INFO: Adding PointwiseNode '"
+                         << pointwiseAttr.getName() << "' to Graph");
+
+  // Set inputs.
+  pointwiseAttr.setIN_0(in0).setIN_1(in1).setIN_2(in2);
 
   // Set outputs.
   auto out = outputTensor(pointwiseAttr.getName() + "_OUT_0");

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1739,6 +1739,21 @@ inline std::string PointwiseNode::getResultNamesAndTypesAsm() const {
     );                                                                         \
   }
 
+#define FUSILLI_DECLARE_TERNARY_POINTWISE_EMITTER(PWOP, SCHEMA, OPIR)          \
+  case PointwiseAttr::Mode::PWOP: {                                            \
+    return std::format(SCHEMA, permuteIN0,   /* {0} */                         \
+                       permuteIN1,           /* {1} */                         \
+                       permuteIN2,           /* {2} */                         \
+                       getResultNamesAsm(),  /* {3} */                         \
+                       getOperandNamesAsm(), /* {4} */                         \
+                       getOperandTypesAsm(), /* {5} */                         \
+                       getResultTypesAsm(),  /* {6} */                         \
+                       permuteOUT0,          /* {7} */                         \
+                       #OPIR,                /* {8} */                         \
+                       getName()             /* {9} */                         \
+    );                                                                         \
+  }
+
 inline std::string PointwiseNode::emitNodePreAsm() const {
   std::string uniqueSSASuffix = pointwiseAttr.getName();
 
@@ -1751,6 +1766,11 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
   std::string permuteIN1 =
       pointwiseAttr.getIN_1()
           ? getLayoutConversionOpsAsm(pointwiseAttr.getIN_1(), "permute_IN_1",
+                                      uniqueSSASuffix, /*isInput=*/true)
+          : "";
+  std::string permuteIN2 =
+      pointwiseAttr.getIN_2()
+          ? getLayoutConversionOpsAsm(pointwiseAttr.getIN_2(), "permute_IN_2",
                                       uniqueSSASuffix, /*isInput=*/true)
           : "";
   std::string permuteOUT0 =
@@ -1768,6 +1788,14 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {1}
     {2} = {7} {3} : {4} -> {5}
     {6}
+)";
+
+  constexpr std::string_view kTernaryTorchSchema = R"(
+    {0}
+    {1}
+    {2}
+    {3} = {8} {4} : {5} -> {6}
+    {7}
 )";
 
   constexpr std::string_view kSubAddSchema = R"(
@@ -1813,6 +1841,8 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
   FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER(PWOP, kUnaryTorchSchema, OPIR)
 #define FUSILLI_DECLARE_BINARY_TORCH_EMITTER(PWOP, OPIR)                       \
   FUSILLI_DECLARE_BINARY_POINTWISE_EMITTER(PWOP, kBinaryTorchSchema, OPIR)
+#define FUSILLI_DECLARE_TERNARY_TORCH_EMITTER(PWOP, OPIR)                      \
+  FUSILLI_DECLARE_TERNARY_POINTWISE_EMITTER(PWOP, kTernaryTorchSchema, OPIR)
 #define FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER(PWOP, OPIR)                      \
   FUSILLI_DECLARE_BINARY_POINTWISE_EMITTER(PWOP, kSubAddSchema, OPIR)
 
@@ -1894,6 +1924,8 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER(ADD, torch.aten.add.Tensor)
     FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER(SUB, torch.aten.sub.Tensor)
 
+    FUSILLI_DECLARE_TERNARY_TORCH_EMITTER(BINARY_SELECT, torch.aten.where.self)
+
   default:
     assert(false && "Unsupported pointwise mode");
     return "";
@@ -1902,8 +1934,10 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
 
 #undef FUSILLI_DECLARE_UNARY_POINTWISE_EMITTER
 #undef FUSILLI_DECLARE_BINARY_POINTWISE_EMITTER
+#undef FUSILLI_DECLARE_TERNARY_POINTWISE_EMITTER
 #undef FUSILLI_DECLARE_UNARY_TORCH_EMITTER
 #undef FUSILLI_DECLARE_BINARY_TORCH_EMITTER
+#undef FUSILLI_DECLARE_TERNARY_TORCH_EMITTER
 #undef FUSILLI_DECLARE_SUB_ADD_TORCH_EMITTER
 
 //===----------------------------------------------------------------------===//

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -41,6 +41,7 @@ add_fusilli_samples(
   SRCS
     pointwise/pointwise_binary_ops.cpp
     pointwise/pointwise_binary_cmp_ops.cpp
+    pointwise/pointwise_ternary_ops.cpp
     pointwise/pointwise_unary_ops.cpp
     pointwise/pointwise_add_transposed.cpp
     pointwise/pointwise_scalar_mul.cpp

--- a/samples/pointwise/pointwise_ternary_ops.cpp
+++ b/samples/pointwise/pointwise_ternary_ops.cpp
@@ -1,0 +1,153 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+// Based on parameters, generates a unique name for the graph
+static std::string generateName(PointwiseAttr::Mode mode, DataType type,
+                                const std::vector<std::vector<int64_t>> &dims) {
+  std::string name =
+      std::format("pointwise_{}_dt{}", PointwiseAttr::kModeToStr.at(mode),
+                  kDataTypeToMlirTypeAsm.at(type));
+  for (size_t i = 0; i < dims.size(); ++i) {
+    name += std::format("_in{}", i);
+    for (const auto &d : dims[i]) {
+      name += std::format("_{}", d);
+    }
+  }
+  return name;
+};
+
+TEST_CASE("Pointwise ternary ops", "[pointwise][graph]") {
+  const auto dims = std::vector<std::vector<int64_t>>{
+      std::vector<int64_t>{2, 16, 64, 64}, std::vector<int64_t>{2, 16, 64, 64},
+      GENERATE(std::vector<int64_t>{2, 16, 64, 64},
+               std::vector<int64_t>{1, 16, 1, 1})};
+
+  // clang-format off
+  const auto mode = GENERATE(PointwiseAttr::Mode::BINARY_SELECT);
+  // clang-format on
+
+  auto execute = [&]<typename T>(Handle &handle, DataType dt, bool cond,
+                                 T xTrue, T xFalse) {
+    auto buildNewGraph = [&](Handle &handleArg) {
+      // Create graph
+      auto graph = std::make_shared<Graph>();
+      graph->setName(generateName(mode, dt, dims));
+      graph->setIODataType(dt).setComputeDataType(dt);
+
+      // Condition tensor is boolean regardless of the IO data type.
+      auto condT = graph->tensor(
+          TensorAttr()
+              .setName("cond")
+              .setDataType(DataType::Boolean)
+              .setDim(dims[0])
+              .setStride(generateStrideFromDim(
+                  dims[0], getContiguousStrideOrder(dims[0].size()))));
+      auto xTrueT = graph->tensor(
+          TensorAttr().setName("x_true").setDim(dims[1]).setStride(
+              generateStrideFromDim(dims[1],
+                                    getContiguousStrideOrder(dims[1].size()))));
+      auto xFalseT = graph->tensor(
+          TensorAttr().setName("x_false").setDim(dims[2]).setStride(
+              generateStrideFromDim(dims[2],
+                                    getContiguousStrideOrder(dims[2].size()))));
+
+      // Create Pointwise op
+      auto pointwiseAttr = PointwiseAttr().setMode(mode);
+      auto pointwiseResult =
+          graph->pointwise(condT, xTrueT, xFalseT, pointwiseAttr);
+
+      pointwiseResult->setName("result").setOutput(true);
+
+      // Validate, infer missing properties
+      FUSILLI_REQUIRE_OK(graph->validate());
+
+      // Compile
+      FUSILLI_REQUIRE_OK(graph->compile(handleArg, /*remove=*/true));
+
+      return std::make_tuple(graph, condT, xTrueT, xFalseT, pointwiseResult);
+    };
+    // Build graph for the given handle (device), validate and compile it.
+    auto [graph, condT, xTrueT, xFalseT, yT] = buildNewGraph(handle);
+
+    // Allocate input buffers.
+    FUSILLI_REQUIRE_ASSIGN(
+        auto condBuf,
+        allocateBufferOfType(handle, condT, DataType::Boolean, cond));
+    FUSILLI_REQUIRE_ASSIGN(auto xTrueBuf,
+                           allocateBufferOfType(handle, xTrueT, dt, xTrue));
+    FUSILLI_REQUIRE_ASSIGN(auto xFalseBuf,
+                           allocateBufferOfType(handle, xFalseT, dt, xFalse));
+
+    // Allocate output buffer.
+    FUSILLI_REQUIRE_ASSIGN(auto yBuf,
+                           allocateBufferOfType(handle, yT, dt, 0.0f));
+
+    // Create variant pack.
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {
+            {condT, condBuf},
+            {xTrueT, xTrueBuf},
+            {xFalseT, xFalseBuf},
+            {yT, yBuf},
+        };
+
+    // Allocate workspace buffer if needed.
+    FUSILLI_REQUIRE_ASSIGN(
+        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+
+    // Execute graph once.
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    // Calculate reference value.
+    T y = cond ? xTrue : xFalse;
+
+    // Read output buffers.
+    std::vector<T> result;
+    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+    for (auto val : result)
+      REQUIRE(val == y);
+
+    // Execute graph a few times.
+    constexpr size_t numIters = 1;
+    for (size_t i = 0; i < numIters; ++i)
+      FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    // Repeat output buffer checks.
+    result.clear();
+    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+    for (auto val : result)
+      REQUIRE(val == y);
+  };
+
+  // Create handle for the target backend.
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  // int32: true/false condition cases.
+  execute(handle, DataType::Int32, true, int(7), int(-3));
+  execute(handle, DataType::Int32, false, int(7), int(-3));
+  // fp16: true/false condition cases.
+  execute(handle, DataType::Half, true, half(1.5f), half(-2.5f));
+  execute(handle, DataType::Half, false, half(1.5f), half(-2.5f));
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_relu.cpp
     lit/test_pointwise_asm_emitter_add.cpp
     lit/test_pointwise_asm_emitter_add_transposed.cpp
+    lit/test_pointwise_asm_emitter_binary_select.cpp
     lit/test_pointwise_asm_emitter_ceil.cpp
     lit/test_pointwise_asm_emitter_cmp_eq.cpp
     lit/test_pointwise_asm_emitter_cmp_neq.cpp

--- a/tests/lit/test_pointwise_asm_emitter_binary_select.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_binary_select.cpp
@@ -1,0 +1,73 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%[[RESULT0:.+]]: !torch.tensor<[16,256,64,32],f32>, %[[ARG0:.+]]: !torch.vtensor<[16,256,64,32],i1>, %[[ARG1:.+]]: !torch.vtensor<[16,256,64,32],f32>, %[[ARG2:.+]]: !torch.vtensor<[1,256,1,1],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %[[PERM0_0:.+]] = torch.constant.int 0
+// TORCH-CHECK:       %[[PERM0_1:.+]] = torch.constant.int 1
+// TORCH-CHECK:       %[[PERM0_2:.+]] = torch.constant.int 2
+// TORCH-CHECK:       %[[PERM0_3:.+]] = torch.constant.int 3
+// TORCH-CHECK:       %[[PERM0_LIST:.+]] = torch.prim.ListConstruct %[[PERM0_0]], %[[PERM0_1]], %[[PERM0_2]], %[[PERM0_3]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %[[PERMUTE0:.+]] = torch.aten.permute %[[ARG0]], %[[PERM0_LIST]] : !torch.vtensor<[16,256,64,32],i1>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],i1>
+// TORCH-CHECK:       %[[PERM1_0:.+]] = torch.constant.int 0
+// TORCH-CHECK:       %[[PERM1_1:.+]] = torch.constant.int 1
+// TORCH-CHECK:       %[[PERM1_2:.+]] = torch.constant.int 2
+// TORCH-CHECK:       %[[PERM1_3:.+]] = torch.constant.int 3
+// TORCH-CHECK:       %[[PERM1_LIST:.+]] = torch.prim.ListConstruct %[[PERM1_0]], %[[PERM1_1]], %[[PERM1_2]], %[[PERM1_3]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %[[PERMUTE1:.+]] = torch.aten.permute %[[ARG1]], %[[PERM1_LIST]] : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %[[PERM2_0:.+]] = torch.constant.int 0
+// TORCH-CHECK:       %[[PERM2_1:.+]] = torch.constant.int 1
+// TORCH-CHECK:       %[[PERM2_2:.+]] = torch.constant.int 2
+// TORCH-CHECK:       %[[PERM2_3:.+]] = torch.constant.int 3
+// TORCH-CHECK:       %[[PERM2_LIST:.+]] = torch.prim.ListConstruct %[[PERM2_0]], %[[PERM2_1]], %[[PERM2_2]], %[[PERM2_3]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %[[PERMUTE2:.+]] = torch.aten.permute %[[ARG2]], %[[PERM2_LIST]] : !torch.vtensor<[1,256,1,1],f32>, !torch.list<int> -> !torch.vtensor<[1,256,1,1],f32>
+// TORCH-CHECK:       %[[WHERE:.+]] = torch.aten.where.self %[[PERMUTE0]], %[[PERMUTE1]], %[[PERMUTE2]] : !torch.vtensor<[16,256,64,32],i1>, !torch.vtensor<[16,256,64,32],f32>, !torch.vtensor<[1,256,1,1],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %[[PERM_OUT_0:.+]] = torch.constant.int 0
+// TORCH-CHECK:       %[[PERM_OUT_1:.+]] = torch.constant.int 1
+// TORCH-CHECK:       %[[PERM_OUT_2:.+]] = torch.constant.int 2
+// TORCH-CHECK:       %[[PERM_OUT_3:.+]] = torch.constant.int 3
+// TORCH-CHECK:       %[[PERM_OUT_LIST:.+]] = torch.prim.ListConstruct %[[PERM_OUT_0]], %[[PERM_OUT_1]], %[[PERM_OUT_2]], %[[PERM_OUT_3]] : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %[[PERM_OUT:.+]] = torch.aten.permute %[[WHERE]], %[[PERM_OUT_LIST]] : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %[[PERM_OUT]] overwrites %[[RESULT0]] : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "pointwise_utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto status = testTernaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_binary_select", "binary_select", mode,
+      PointwiseAttr::Mode::BINARY_SELECT, {16, 256, 64, 32}, {16, 256, 64, 32},
+      {1, 256, 1, 1});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/pointwise_utils.h
+++ b/tests/pointwise_utils.h
@@ -99,6 +99,52 @@ inline ErrorObject testBinaryPointwiseAsmEmitter(const std::string &graphName,
   return ok();
 }
 
+inline ErrorObject testTernaryPointwiseAsmEmitter(
+    const std::string &graphName, const std::string &opName,
+    const std::string &mode, PointwiseAttr::Mode pwMode,
+    std::vector<int64_t> in0Dims, std::vector<int64_t> in1Dims,
+    std::vector<int64_t> in2Dims) {
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName(graphName);
+  graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
+
+  // IN_0 is a boolean predicate; IN_1 and IN_2 carry the selected values.
+  auto in0StrideOrder = getContiguousStrideOrder(in0Dims.size());
+  auto in0T = graph->tensor(
+      TensorAttr()
+          .setName("arg0")
+          .setDataType(DataType::Boolean)
+          .setDim(in0Dims)
+          .setStride(generateStrideFromDim(in0Dims, in0StrideOrder)));
+  auto in1T = createTestTensor("arg1", in1Dims, graph.get());
+  auto in2T = createTestTensor("arg2", in2Dims, graph.get());
+
+  auto pointwiseAttr = PointwiseAttr().setMode(pwMode).setName(opName);
+
+  auto yT = graph->pointwise(in0T, in1T, in2T, pointwiseAttr);
+
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  if (mode == "default") {
+    FUSILLI_ASSIGN_OR_RETURN(auto generatedAsm, graph->emitAsm());
+    FUSILLI_CHECK_ERROR(checkMlirIndentation(generatedAsm));
+    std::cout << generatedAsm << std::endl;
+  }
+
+  if (mode == "stats") {
+    FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
+    FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
+                                             CachedAssetsType::Statistics));
+    std::cout << stats << std::endl;
+  }
+
+  return ok();
+}
+
 } // namespace fusilli
 
 #endif // FUSILLI_TESTS_POINTWISE_UTILS_H


### PR DESCRIPTION
Emit torch.aten.where.self for a three-input pointwise select that picks between IN_1 and IN_2 based on a boolean IN_0 predicate. Adds a ternary Graph::pointwise overload, a ternary torch emitter schema, and sample and lit tests.