### PR TITLE
Add explicit AOT compile/load APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,58 @@ software effectively.
 
 ![Fusilli](docs/fusilli.png)
 
+## JIT and AOT support
+
+Fusilli's default API is built for the JIT usecase:
+
+```cpp
+graph.compile(handle);
+graph.execute(handle, variantPack, workspace);
+```
+
+`Graph::compile(handle)` compiles for `handle.getBackend()` and immediately loads
+the resulting artifact into runtime state owned by that `Graph`. The compiled
+artifacts are cached in-process and tied to the lifetime of the `Graph` instance.
+Here `Graph::compile` is just an implementation detail that goes hand-in-hand
+with `Graph::execute` (in the same process and using the same device handle).
+
+For AOT-style callers we recognize that the compilation may happen in a separate
+process, or without access to the specific execution device. To support the AOT
+usecase, Fusilli exposes alternate APIs with explicit artifact save/load steps:
+
+```cpp
+// Compile doesn't require a device handle
+auto vmfbPath = graph.compileToArtifact(backend);
+// Copy or serialize the VMFB here if it must outlive this compile-side graph.
+
+Graph runtimeGraph;
+// Rebuild and validate the same logical graph.
+runtimeGraph.loadFromArtifact(handle, vmfbPath);
+runtimeGraph.execute(handle, variantPack, workspace);
+```
+
+Important constraints for multi-backend AOT compilation:
+
+- Compiled artifacts are backend-specific. An artifact produced for one backend
+  must be loaded and executed with a handle for the same backend. `execute()`
+  rejects handles whose backend does not match the currently loaded artifact's
+  backend.
+- `compileToArtifact()` does not load or unload runtime state. If a `Graph`
+  already has an artifact loaded, compiling another artifact leaves the loaded
+  artifact executable until `loadFromArtifact()` replaces it.
+- A `Graph` owns one loaded runtime state at a time. Loading another artifact
+  replaces the previous VM context, function and workspace size.
+- If compiling artifacts for multiple backends from one `Graph`, copy or
+  serialize each returned VMFB before compiling the next backend. Fusilli's
+  in-process cache owns only the current compile-side artifact and is not a
+  persistent cache contract.
+- To keep multiple backend artifacts loaded concurrently, use one validated
+  `Graph` instance per backend. To switch backends on the same `Graph`, call
+  `loadFromArtifact(handleForSelectedBackend, artifactForSelectedBackend)`
+  before `execute()`.
+
+AOT samples are under `samples/aot/`, everything else in `samples/` uses the JIT API.
+
 ## Developer Guide
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ usecase, Fusilli exposes alternate APIs with explicit artifact save/load steps:
 
 ```cpp
 // Compile doesn't require a device handle
-auto vmfbPath = graph.compileToArtifact(backend);
-// Copy or serialize the VMFB here if it must outlive this compile-side graph.
+auto vmfbBytes = graph.compileToArtifact(backend);
+// Keep, copy, or serialize the VMFB bytes for later execution.
 
 Graph runtimeGraph;
 // Rebuild and validate the same logical graph.
-runtimeGraph.loadFromArtifact(handle, vmfbPath);
+runtimeGraph.loadFromArtifact(handle, vmfbBytes);
 runtimeGraph.execute(handle, variantPack, workspace);
 ```
 
@@ -71,10 +71,10 @@ Important constraints for multi-backend AOT compilation:
   artifact executable until `loadFromArtifact()` replaces it.
 - A `Graph` owns one loaded runtime state at a time. Loading another artifact
   replaces the previous VM context, function and workspace size.
-- If compiling artifacts for multiple backends from one `Graph`, copy or
-  serialize each returned VMFB before compiling the next backend. Fusilli's
-  in-process cache owns only the current compile-side artifact and is not a
-  persistent cache contract.
+- If compiling artifacts for multiple backends from one `Graph`, keep or
+  serialize each returned VMFB byte buffer before compiling the next backend.
+  Fusilli's in-process cache owns only the current compile-side artifact and is
+  not a persistent cache contract.
 - To keep multiple backend artifacts loaded concurrently, use one validated
   `Graph` instance per backend. To switch backends on the same `Graph`, call
   `loadFromArtifact(handleForSelectedBackend, artifactForSelectedBackend)`

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -395,6 +395,15 @@ Graph::execute(const Handle &handle,
   if (!kBackendExecuteAsync.contains(handle.getBackend())) // C++20
     return ErrorObject(ErrorCode::InternalError,
                        "Graph::execute got an unknown backend");
+  FUSILLI_RETURN_ERROR_IF(!loadedBackend_.has_value(), ErrorCode::NotCompiled,
+                          "Graph::execute requires a successful compile() first"
+                          " (loaded backend not set)");
+  FUSILLI_RETURN_ERROR_IF(handle.getBackend() != *loadedBackend_,
+                          ErrorCode::InvalidArgument,
+                          "Graph::execute got a handle for backend " +
+                              kBackendToStr.at(handle.getBackend()) +
+                              ", but the loaded artifact uses backend " +
+                              kBackendToStr.at(*loadedBackend_));
   bool executeAsync = kBackendExecuteAsync.at(handle.getBackend());
 
   iree_allocator_t allocator = iree_allocator_system();

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -44,7 +44,6 @@
 #include <iree/hal/api.h>
 #include <iree/hal/drivers/hip/api.h>
 #include <iree/hal/drivers/init.h>
-#include <iree/io/file_contents.h>
 #include <iree/modules/hal/module.h>
 #include <iree/vm/api.h>
 #include <iree/vm/bytecode/module.h>
@@ -240,8 +239,7 @@ inline ErrorObject Handle::createAMDGPUDevice(int deviceId, uintptr_t stream) {
 //===----------------------------------------------------------------------===//
 
 // Create IREE VM context for this graph and load the compiled artifact.
-inline ErrorObject Graph::createVmContext(const Handle &handle,
-                                          const std::string &vmfbPath) {
+inline ErrorObject Graph::createVmContext(const Handle &handle) {
   // Create a context even if one was created earlier, since the handle
   // (hence device) might have changed and we might be re-compiling the graph
   // for the new device.
@@ -268,25 +266,16 @@ inline ErrorObject Graph::createVmContext(const Handle &handle,
     FUSILLI_CHECK_ERROR(status);
   }
 
-  // Read the VMFB file and create a bytecode module from it.
+  // Create a bytecode module from the graph-owned VMFB bytes.
   FUSILLI_LOG_LABEL_ENDL("INFO: Loading bytecode module into IREE VM context");
   {
-    iree_io_file_contents_t *fileContents = nullptr;
-    FUSILLI_CHECK_ERROR(iree_io_file_contents_read(
-        iree_make_cstring_view(vmfbPath.c_str()), allocator, &fileContents));
-
     iree_vm_module_t *bytecodeModule = nullptr;
     iree_status_t status = iree_vm_bytecode_module_create(
         handle.getInstance(), IREE_VM_BYTECODE_MODULE_FLAG_NONE,
-        fileContents->const_buffer,
-        iree_io_file_contents_deallocator(fileContents), allocator,
-        &bytecodeModule);
-    if (!iree_status_is_ok(status)) {
-      iree_io_file_contents_free(fileContents);
-      FUSILLI_CHECK_ERROR(status);
-    }
-    // File contents ownership transferred to bytecode module on success
-    // so there's no `iree_io_file_contents_free` on the success path.
+        iree_make_const_byte_span(loadedArtifactBytes_.data(),
+                                  loadedArtifactBytes_.size()),
+        iree_allocator_null(), allocator, &bytecodeModule);
+    FUSILLI_CHECK_ERROR(status);
 
     status =
         iree_vm_context_register_modules(vmContext_.get(),

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -174,7 +174,8 @@ public:
   //
   // A `Graph` owns one loaded runtime state at a time. Loading a new artifact
   // replaces any previously loaded VM context, function, workspace size, and VM
-  // input list capacity. To keep multiple backends loaded concurrently, use one
+  // input list capacity. If loading fails, the `Graph` is left without loaded
+  // runtime state. To keep multiple backends loaded concurrently, use one
   // `Graph` instance per backend artifact. To switch backends on one `Graph`,
   // call `loadFromArtifact()` with the selected backend artifact before
   // `execute()`.
@@ -304,8 +305,7 @@ public:
   Graph &operator=(const Graph &) = delete;
   Graph(Graph &&) noexcept = default;
   Graph &operator=(Graph &&) noexcept = default;
-  // The VM context may retain references into loadedArtifactBytes_.
-  ~Graph() { clearRuntimeState(); }
+  ~Graph() = default;
 
   // Getters and setters for graph context.
   const std::string &getName() const override final {
@@ -465,11 +465,8 @@ private:
   ErrorObject createVmContext(const Handle &handle);
 
   void clearRuntimeState() {
-    // Teardown order matters: the IREE bytecode module owned by vmContext_ may
-    // retain references into loadedArtifactBytes_, so release vmContext_ before
-    // clearing the backing VMFB bytes.
-    vmContext_.reset();
     vmFunction_.reset();
+    vmContext_.reset();
     workspaceSize_.reset();
     loadedBackend_.reset();
     loadedArtifactBytes_.clear();
@@ -694,10 +691,14 @@ private:
   // This is set after `validate()` is run at least once successfully.
   bool isValidated_ = false;
 
-  // Required workspace buffer size in bytes. Set during createVmContext()
-  // by querying the iree.abi.transients.size.constant attribute.
-  // std::nullopt indicates the graph has not been compiled yet.
-  std::optional<size_t> workspaceSize_;
+  // Bytes backing the currently loaded VMFB artifact. IREE's bytecode module
+  // may retain references to this archive, so keep it alive for as long as the
+  // VM context is alive.
+  //
+  // Keep this declared before vmContext_: members destruct in reverse
+  // declaration order, and the context must be released before the backing VMFB
+  // bytes.
+  std::vector<uint8_t> loadedArtifactBytes_;
 
   // IREE VM context lifetime managed by the `Graph` object
   // (deleted when the `Graph` object goes out of scope).
@@ -707,6 +708,11 @@ private:
   // Avoids repeated function lookup on every execute() call.
   std::optional<iree_vm_function_t> vmFunction_;
 
+  // Required workspace buffer size in bytes. Set during createVmContext()
+  // by querying the iree.abi.transients.size.constant attribute.
+  // std::nullopt indicates the graph has not been compiled yet.
+  std::optional<size_t> workspaceSize_;
+
   // Pre-computed VM input list capacity for iree_vm_list_create().
   // Set during createVmContext() to avoid recomputing on every execute().
   iree_host_size_t vmInputListCapacity_ = 0;
@@ -714,11 +720,6 @@ private:
   // Backend for the currently loaded runtime state. `execute()` requires a
   // handle for this backend because VMFB artifacts are backend-specific.
   std::optional<Backend> loadedBackend_;
-
-  // Bytes backing the currently loaded VMFB artifact. IREE's bytecode module
-  // may retain references to this archive, so keep it alive for as long as the
-  // VM context is alive.
-  std::vector<uint8_t> loadedArtifactBytes_;
 
   // Compile-side cache set by `getCompiledArtifact()`. The AOT
   // `loadFromArtifact()` API uses caller-provided VMFB bytes directly and does

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -111,13 +111,43 @@ public:
     return ok();
   }
 
-  // Compiles the graph using IREE compiler and sets up the IREE VM
-  // context for future g->execute calls.
+  // Compiles the graph using IREE compiler and sets up the IREE VM context for
+  // future g->execute calls. This is the default JIT convenience API.
+  //
+  // This is equivalent to:
+  //   compileToArtifact(handle.getBackend(), remove)
+  //   loadFromArtifact(handle, artifactPath)
+  //
+  // The compiled artifact is backend-specific and is immediately loaded using
+  // the same backend from `handle`.
   //
   // Set `remove = true` to remove compilation artifacts (cache files) when
   // this `Graph` instance goes out of scope.
   ErrorObject compile(const Handle &handle, bool remove = false) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiling Graph");
+    FUSILLI_ASSIGN_OR_RETURN(auto vmfbPath,
+                             compileToArtifact(handle.getBackend(), remove));
+    return loadFromArtifact(handle, vmfbPath);
+  }
+
+  // Compiles the graph using IREE compiler to produce a backend-specific VMFB
+  // artifact. This does not create any runtime state; call
+  // `loadFromArtifact()` before executing.
+  //
+  // If callers need artifacts for multiple backends, they should copy or
+  // serialize each returned VMFB path before compiling the next backend.
+  // Fusilli owns only the in-process `cache_` for the most recent compile-side
+  // artifact; it does not provide persistent artifact storage or invalidation.
+  //
+  // Compiling a new artifact does not load or unload runtime state. If this
+  // `Graph` already has an artifact loaded, that artifact remains executable
+  // until a later `loadFromArtifact()` replaces it.
+  //
+  // Set `remove = true` to remove compilation artifacts (cache files) when
+  // this `Graph` instance goes out of scope.
+  ErrorOr<std::filesystem::path> compileToArtifact(Backend backend,
+                                                   bool remove = false) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Compiling Graph to artifact");
     FUSILLI_RETURN_ERROR_IF(!isValidated_, ErrorCode::NotValidated,
                             "Graph must be validated before being compiled");
 
@@ -125,15 +155,46 @@ public:
     FUSILLI_ASSIGN_OR_RETURN(std::string generatedAsm, emitAsm());
 
     // Compile using IREE compiler or reuse cached artifact.
-    FUSILLI_ASSIGN_OR_RETURN(auto vmfbPath,
-                             getCompiledArtifact(handle, generatedAsm, remove));
+    FUSILLI_ASSIGN_OR_RETURN(
+        auto vmfbPath, getCompiledArtifact(backend, generatedAsm, remove));
 
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiled Graph cached at \"" +
                            vmfbPath.string() + "\"");
 
-    // Create per-graph IREE VM context and load the compiled artifact.
-    FUSILLI_CHECK_ERROR(createVmContext(handle, vmfbPath.string()));
+    return ok(vmfbPath);
+  }
 
+  // Loads a compiled VMFB artifact onto the device owned by `handle`, creating
+  // per-graph runtime state and querying workspace size. This does not require
+  // the artifact to have been produced by this `Graph` instance.
+  //
+  // The artifact must be compatible with `handle.getBackend()`. A VMFB compiled
+  // for one backend is not a portable artifact for another backend.
+  //
+  // A `Graph` owns one loaded runtime state at a time. Loading a new artifact
+  // replaces any previously loaded VM context, function, workspace size, and VM
+  // input list capacity. To keep multiple backends loaded concurrently, use one
+  // `Graph` instance per backend artifact. To switch backends on one `Graph`,
+  // call `loadFromArtifact()` with the selected backend artifact before
+  // `execute()`.
+  ErrorObject loadFromArtifact(const Handle &handle,
+                               const std::filesystem::path &vmfbPath) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Loading compiled artifact into VM context");
+    FUSILLI_RETURN_ERROR_IF(
+        !isValidated_, ErrorCode::NotValidated,
+        "Graph must be validated before loading a compiled artifact");
+    // Loading replaces the currently executable artifact. Clear first so a
+    // failed load cannot leave execute() using stale runtime state from an
+    // older artifact.
+    clearRuntimeState();
+    ErrorObject status = createVmContext(handle, vmfbPath.string());
+    if (isError(status)) {
+      // createVmContext may have partially populated runtime state before
+      // failing; leave the graph in a clean "not loaded" state.
+      clearRuntimeState();
+      return status;
+    }
+    loadedBackend_ = handle.getBackend();
     return ok();
   }
 
@@ -354,11 +415,11 @@ public:
   // TODO(#13): Make this private. It is public for now to aid testing and
   // debuggability, however the intended user facing API is `Graph::compile()`.
   ErrorOr<std::filesystem::path>
-  getCompiledArtifact(const Handle &handle, const std::string &generatedAsm,
+  getCompiledArtifact(Backend backend, const std::string &generatedAsm,
                       bool remove, std::optional<bool> *reCompiled = nullptr) {
     // Check for cache hit.
     FUSILLI_ASSIGN_OR_RETURN(bool cacheValid,
-                             validateCache(handle, generatedAsm));
+                             validateCache(backend, generatedAsm));
     if (cacheValid) {
       if (reCompiled)
         *reCompiled = false;
@@ -367,7 +428,7 @@ public:
     // (Re)generate cache.
     FUSILLI_ASSIGN_OR_RETURN(
         auto generatedCache,
-        generateCompiledArtifact(handle, generatedAsm, remove));
+        generateCompiledArtifact(backend, generatedAsm, remove));
     cache_ = std::move(generatedCache);
     if (reCompiled)
       *reCompiled = true;
@@ -400,6 +461,14 @@ private:
   ErrorObject createVmContext(const Handle &handle,
                               const std::string &vmfbPath);
 
+  void clearRuntimeState() {
+    workspaceSize_.reset();
+    loadedBackend_.reset();
+    vmContext_.reset();
+    vmFunction_.reset();
+    vmInputListCapacity_ = 0;
+  }
+
   // Queries the required transient/workspace buffer size from the compiled
   // module. Returns the size in bytes, or 0 if no transients are needed.
   // Returns an error if the module requires dynamic transient sizes.
@@ -410,8 +479,8 @@ private:
   // `remove = true` to remove cache files when returned `CachedAssets` lifetime
   // ends.
   ErrorOr<CachedAssets>
-  generateCompiledArtifact(const Handle &handle,
-                           const std::string &generatedAsm, bool remove) {
+  generateCompiledArtifact(Backend backend, const std::string &generatedAsm,
+                           bool remove) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Generating compiled artifacts");
 
     // Create cache files.
@@ -448,7 +517,7 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd = CompileCommand::build(
-          handle.getBackend(), cache.input, cache.output, cache.statistics);
+          backend, cache.input, cache.output, cache.statistics);
       FUSILLI_CHECK_ERROR(cmd.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (CLI)");
       FUSILLI_LOG_ENDL(cmd.toString());
@@ -456,8 +525,8 @@ private:
     } else {
       // Use CompileSession (C API) - DEFAULT.
       FUSILLI_ASSIGN_OR_RETURN(CompileSession session,
-                               CompileSession::build(handle.getBackend(),
-                                                     cache.input, cache.output,
+                               CompileSession::build(backend, cache.input,
+                                                     cache.output,
                                                      cache.statistics));
       FUSILLI_CHECK_ERROR(session.writeTo(cache.command));
       FUSILLI_LOG_LABEL_ENDL("INFO: iree-compile command (C API)");
@@ -473,8 +542,8 @@ private:
   //  - Graph name (and therefore cache path) has changed
   //  - Generated assembly differs
   //  - Compile commands have changed
-  //  - Handle/backend (and therefore compile command) has changed
-  ErrorOr<bool> validateCache(const Handle &handle,
+  //  - Backend (and therefore compile command) has changed
+  ErrorOr<bool> validateCache(Backend backend,
                               const std::string &generatedAsm) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Validating cache");
 
@@ -544,13 +613,13 @@ private:
     if (checkCompileBackendEnv()) {
       // Use CompileCommand (CLI).
       CompileCommand cmd =
-          CompileCommand::build(handle.getBackend(), input, output, statistics);
+          CompileCommand::build(backend, input, output, statistics);
       cmdString = cmd.toString();
     } else {
       // Use CompileSession (C API) - DEFAULT.
-      FUSILLI_ASSIGN_OR_RETURN(auto session,
-                               CompileSession::build(handle.getBackend(), input,
-                                                     output, statistics));
+      FUSILLI_ASSIGN_OR_RETURN(
+          auto session,
+          CompileSession::build(backend, input, output, statistics));
       cmdString = session.toString();
     }
 
@@ -635,7 +704,13 @@ private:
   // Set during createVmContext() to avoid recomputing on every execute().
   iree_host_size_t vmInputListCapacity_ = 0;
 
-  // Cache set by `getCompiledArtifact()`.
+  // Backend for the currently loaded runtime state. `execute()` requires a
+  // handle for this backend because VMFB artifacts are backend-specific.
+  std::optional<Backend> loadedBackend_;
+
+  // Compile-side cache set by `getCompiledArtifact()`. This is used as the
+  // JIT cache. The AOT `loadFromArtifact()` API uses caller-provided VMFB
+  // paths directly and does not consult this cache.
   //
   // Note: new instances should always re-generate cache even if the results
   // could be read from the file system. Old results may have been generated

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -52,6 +52,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <span>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -116,7 +117,7 @@ public:
   //
   // This is equivalent to:
   //   compileToArtifact(handle.getBackend(), remove)
-  //   loadFromArtifact(handle, artifactPath)
+  //   loadFromArtifact(handle, vmfbBytes)
   //
   // The compiled artifact is backend-specific and is immediately loaded using
   // the same backend from `handle`.
@@ -125,17 +126,17 @@ public:
   // this `Graph` instance goes out of scope.
   ErrorObject compile(const Handle &handle, bool remove = false) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiling Graph");
-    FUSILLI_ASSIGN_OR_RETURN(auto vmfbPath,
+    FUSILLI_ASSIGN_OR_RETURN(auto vmfbBytes,
                              compileToArtifact(handle.getBackend(), remove));
-    return loadFromArtifact(handle, vmfbPath);
+    return loadFromArtifact(handle, vmfbBytes);
   }
 
   // Compiles the graph using IREE compiler to produce a backend-specific VMFB
   // artifact. This does not create any runtime state; call
   // `loadFromArtifact()` before executing.
   //
-  // If callers need artifacts for multiple backends, they should copy or
-  // serialize each returned VMFB path before compiling the next backend.
+  // If callers need artifacts for multiple backends, they should keep or
+  // serialize each returned VMFB byte buffer before compiling the next backend.
   // Fusilli owns only the in-process `cache_` for the most recent compile-side
   // artifact; it does not provide persistent artifact storage or invalidation.
   //
@@ -145,8 +146,8 @@ public:
   //
   // Set `remove = true` to remove compilation artifacts (cache files) when
   // this `Graph` instance goes out of scope.
-  ErrorOr<std::filesystem::path> compileToArtifact(Backend backend,
-                                                   bool remove = false) {
+  ErrorOr<std::vector<uint8_t>> compileToArtifact(Backend backend,
+                                                  bool remove = false) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiling Graph to artifact");
     FUSILLI_RETURN_ERROR_IF(!isValidated_, ErrorCode::NotValidated,
                             "Graph must be validated before being compiled");
@@ -161,7 +162,7 @@ public:
     FUSILLI_LOG_LABEL_ENDL("INFO: Compiled Graph cached at \"" +
                            vmfbPath.string() + "\"");
 
-    return ok(vmfbPath);
+    return readFileBytes(vmfbPath);
   }
 
   // Loads a compiled VMFB artifact onto the device owned by `handle`, creating
@@ -178,16 +179,18 @@ public:
   // call `loadFromArtifact()` with the selected backend artifact before
   // `execute()`.
   ErrorObject loadFromArtifact(const Handle &handle,
-                               const std::filesystem::path &vmfbPath) {
+                               std::span<const uint8_t> vmfbBytes) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Loading compiled artifact into VM context");
     FUSILLI_RETURN_ERROR_IF(
         !isValidated_, ErrorCode::NotValidated,
         "Graph must be validated before loading a compiled artifact");
+    std::vector<uint8_t> artifactBytes(vmfbBytes.begin(), vmfbBytes.end());
     // Loading replaces the currently executable artifact. Clear first so a
     // failed load cannot leave execute() using stale runtime state from an
     // older artifact.
     clearRuntimeState();
-    ErrorObject status = createVmContext(handle, vmfbPath.string());
+    loadedArtifactBytes_ = std::move(artifactBytes);
+    ErrorObject status = createVmContext(handle);
     if (isError(status)) {
       // createVmContext may have partially populated runtime state before
       // failing; leave the graph in a clean "not loaded" state.
@@ -296,12 +299,13 @@ public:
                                    std::shared_ptr<Buffer>> &variantPack,
           const std::shared_ptr<Buffer> &workspace) const;
 
-  // Delete copy constructors, keep default move constructor and destructor.
+  // Delete copy constructors and keep default move operations.
   Graph(const Graph &) = delete;
   Graph &operator=(const Graph &) = delete;
   Graph(Graph &&) noexcept = default;
   Graph &operator=(Graph &&) noexcept = default;
-  ~Graph() = default;
+  // The VM context may retain references into loadedArtifactBytes_.
+  ~Graph() { clearRuntimeState(); }
 
   // Getters and setters for graph context.
   const std::string &getName() const override final {
@@ -458,14 +462,17 @@ public:
 
 private:
   // Definition in `fusilli/backend/runtime.h`.
-  ErrorObject createVmContext(const Handle &handle,
-                              const std::string &vmfbPath);
+  ErrorObject createVmContext(const Handle &handle);
 
   void clearRuntimeState() {
-    workspaceSize_.reset();
-    loadedBackend_.reset();
+    // Teardown order matters: the IREE bytecode module owned by vmContext_ may
+    // retain references into loadedArtifactBytes_, so release vmContext_ before
+    // clearing the backing VMFB bytes.
     vmContext_.reset();
     vmFunction_.reset();
+    workspaceSize_.reset();
+    loadedBackend_.reset();
+    loadedArtifactBytes_.clear();
     vmInputListCapacity_ = 0;
   }
 
@@ -708,9 +715,14 @@ private:
   // handle for this backend because VMFB artifacts are backend-specific.
   std::optional<Backend> loadedBackend_;
 
-  // Compile-side cache set by `getCompiledArtifact()`. This is used as the
-  // JIT cache. The AOT `loadFromArtifact()` API uses caller-provided VMFB
-  // paths directly and does not consult this cache.
+  // Bytes backing the currently loaded VMFB artifact. IREE's bytecode module
+  // may retain references to this archive, so keep it alive for as long as the
+  // VM context is alive.
+  std::vector<uint8_t> loadedArtifactBytes_;
+
+  // Compile-side cache set by `getCompiledArtifact()`. The AOT
+  // `loadFromArtifact()` API uses caller-provided VMFB bytes directly and does
+  // not consult this cache.
   //
   // Note: new instances should always re-generate cache even if the results
   // could be read from the file system. Old results may have been generated

--- a/include/fusilli/support/cache.h
+++ b/include/fusilli/support/cache.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #if defined(FUSILLI_PLATFORM_WINDOWS)
 #include <KnownFolders.h>
@@ -247,6 +248,26 @@ private:
   // Whether to remove the file on destruction or not.
   bool remove_;
 };
+
+inline ErrorOr<std::vector<uint8_t>>
+readFileBytes(const std::filesystem::path &path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  FUSILLI_RETURN_ERROR_IF(!file.is_open(), ErrorCode::FileSystemFailure,
+                          "Failed to open file: " + path.string());
+
+  const std::streamsize size = file.tellg();
+  FUSILLI_RETURN_ERROR_IF(size < 0, ErrorCode::FileSystemFailure,
+                          "Failed to get file size: " + path.string());
+
+  file.seekg(0, std::ios::beg);
+  std::vector<uint8_t> buffer(static_cast<size_t>(size));
+  if (size > 0)
+    file.read(reinterpret_cast<char *>(buffer.data()), size);
+  FUSILLI_RETURN_ERROR_IF(!file.good(), ErrorCode::FileSystemFailure,
+                          "Failed to read file: " + path.string());
+
+  return ok(std::move(buffer));
+}
 
 // CleanupCacheDirectory removes a sub-directory from the main cache directory
 // if it's empty. When used as a base class, C++ destructor ordering (explained

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -128,6 +128,16 @@ add_fusilli_samples(
     Catch2::Catch2WithMain
 )
 
+add_fusilli_samples(
+  PREFIX fusilli_aot_samples
+  SRCS
+    aot/single_backend.cpp
+    aot/multi_backend.cpp
+  DEPS
+    libfusilli
+    libutils
+    Catch2::Catch2WithMain
+)
 
 
 add_fusilli_samples(

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -1,0 +1,138 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+namespace {
+
+struct PointwiseGraph {
+  std::shared_ptr<Graph> graph;
+  std::shared_ptr<TensorAttr> x0;
+  std::shared_ptr<TensorAttr> x1;
+  std::shared_ptr<TensorAttr> y;
+};
+
+PointwiseGraph buildPointwiseAddGraph(const std::string &graphName) {
+  const std::vector<int64_t> dims = {4};
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName(graphName);
+  graph->setIODataType(DataType::Int32).setComputeDataType(DataType::Int32);
+
+  auto x0T =
+      graph->tensor(TensorAttr().setName("lhs").setDim(dims).setStride({1}));
+  auto x1T =
+      graph->tensor(TensorAttr().setName("rhs").setDim(dims).setStride({1}));
+
+  auto pointwiseAttr = PointwiseAttr().setMode(PointwiseAttr::Mode::ADD);
+  auto yT = graph->pointwise(x0T, x1T, pointwiseAttr);
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+  return {graph, x0T, x1T, yT};
+}
+
+void executeAndCheck(Handle &handle, PointwiseGraph &ctx) {
+  FUSILLI_REQUIRE_ASSIGN(
+      auto x0Buf, allocateBufferOfType(handle, ctx.x0, DataType::Int32, 2));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto x1Buf, allocateBufferOfType(handle, ctx.x1, DataType::Int32, 3));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Int32, 0));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {
+          {ctx.x0, x0Buf},
+          {ctx.x1, x1Buf},
+          {ctx.y, yBuf},
+      };
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+
+  FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
+
+  std::vector<int> result;
+  FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+  for (auto val : result)
+    REQUIRE(val == 5);
+}
+
+void compileAndCopyArtifact(Graph &graph, Backend backend,
+                            const std::filesystem::path &callerOwnedArtifact) {
+  FUSILLI_REQUIRE_ASSIGN(auto compiledArtifact,
+                         graph.compileToArtifact(backend, /*remove=*/true));
+
+  REQUIRE(std::filesystem::exists(compiledArtifact));
+  REQUIRE(!graph.getWorkspaceSize().has_value());
+
+  std::error_code err;
+  std::filesystem::copy_file(compiledArtifact, callerOwnedArtifact,
+                             std::filesystem::copy_options::overwrite_existing,
+                             err);
+  REQUIRE(!err);
+}
+
+void loadAndExecuteArtifact(Backend backend,
+                            const std::filesystem::path &callerOwnedArtifact,
+                            const std::string &graphName) {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(backend));
+
+  auto runtimeGraph = buildPointwiseAddGraph(graphName);
+  FUSILLI_REQUIRE_OK(
+      runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifact));
+
+  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
+  executeAndCheck(handle, runtimeGraph);
+}
+
+} // namespace
+
+TEST_CASE("AOT multi-backend artifacts can be selected per execution backend",
+          "[aot][graph]") {
+  const auto artifactDir = std::filesystem::temp_directory_path();
+  const auto cpuArtifact = artifactDir / "fusilli_aot_multi_backend_cpu.vmfb";
+  auto cleanupCpu = ScopeExit([&] { std::filesystem::remove(cpuArtifact); });
+
+#if defined(FUSILLI_ENABLE_AMDGPU)
+  const auto gpuArtifact =
+      artifactDir / "fusilli_aot_multi_backend_amdgpu.vmfb";
+  auto cleanupGpu = ScopeExit([&] { std::filesystem::remove(gpuArtifact); });
+#endif
+
+  // Compile by backend only. Handles and devices are created later, matching an
+  // AOT flow where compilation and execution happen on different machines.
+  auto compileGraph = buildPointwiseAddGraph("aot_multi_backend_compile_graph");
+  compileAndCopyArtifact(*compileGraph.graph, Backend::CPU, cpuArtifact);
+
+#if defined(FUSILLI_ENABLE_AMDGPU)
+  compileAndCopyArtifact(*compileGraph.graph, Backend::AMDGPU, gpuArtifact);
+#endif
+
+  REQUIRE(std::filesystem::exists(cpuArtifact));
+  loadAndExecuteArtifact(Backend::CPU, cpuArtifact,
+                         "aot_multi_backend_runtime_cpu_graph");
+
+#if defined(FUSILLI_ENABLE_AMDGPU)
+  REQUIRE(std::filesystem::exists(gpuArtifact));
+  loadAndExecuteArtifact(Backend::AMDGPU, gpuArtifact,
+                         "aot_multi_backend_runtime_amdgpu_graph");
+#endif
+}

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -11,10 +11,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <string>
-#include <system_error>
 #include <unordered_map>
 #include <vector>
 
@@ -49,25 +47,49 @@ PointwiseGraph buildPointwiseAddGraph(const std::string &graphName) {
   return {graph, x0T, x1T, yT};
 }
 
-void executeAndCheck(Handle &handle, PointwiseGraph &ctx) {
+std::vector<uint8_t> compileArtifact(Backend backend) {
+  auto compileGraph = buildPointwiseAddGraph("aot_multi_backend_compile_graph");
   FUSILLI_REQUIRE_ASSIGN(
-      auto x0Buf, allocateBufferOfType(handle, ctx.x0, DataType::Int32, 2));
+      auto compiledArtifactBytes,
+      compileGraph.graph->compileToArtifact(backend, /*remove=*/true));
+
+  REQUIRE(!compiledArtifactBytes.empty());
+  REQUIRE(!compileGraph.graph->getWorkspaceSize().has_value());
+  return compiledArtifactBytes;
+}
+
+void loadAndExecuteArtifact(Backend backend,
+                            const std::vector<uint8_t> &vmfbBytes,
+                            const std::string &graphName) {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(backend));
+
+  auto runtimeGraph = buildPointwiseAddGraph(graphName);
+  FUSILLI_REQUIRE_OK(runtimeGraph.graph->loadFromArtifact(handle, vmfbBytes));
+
+  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
+
   FUSILLI_REQUIRE_ASSIGN(
-      auto x1Buf, allocateBufferOfType(handle, ctx.x1, DataType::Int32, 3));
+      auto x0Buf,
+      allocateBufferOfType(handle, runtimeGraph.x0, DataType::Int32, 2));
   FUSILLI_REQUIRE_ASSIGN(
-      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Int32, 0));
+      auto x1Buf,
+      allocateBufferOfType(handle, runtimeGraph.x1, DataType::Int32, 3));
+  FUSILLI_REQUIRE_ASSIGN(auto yBuf, allocateBufferOfType(handle, runtimeGraph.y,
+                                                         DataType::Int32, 0));
 
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {
-          {ctx.x0, x0Buf},
-          {ctx.x1, x1Buf},
-          {ctx.y, yBuf},
+          {runtimeGraph.x0, x0Buf},
+          {runtimeGraph.x1, x1Buf},
+          {runtimeGraph.y, yBuf},
       };
 
   FUSILLI_REQUIRE_ASSIGN(
-      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+      auto workspace,
+      allocateWorkspace(handle, runtimeGraph.graph->getWorkspaceSize()));
 
-  FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
+  FUSILLI_REQUIRE_OK(
+      runtimeGraph.graph->execute(handle, variantPack, workspace));
 
   std::vector<int> result;
   FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
@@ -75,63 +97,26 @@ void executeAndCheck(Handle &handle, PointwiseGraph &ctx) {
     REQUIRE(val == 5);
 }
 
-void compileAndCopyArtifact(Graph &graph, Backend backend,
-                            const std::filesystem::path &callerOwnedArtifact) {
-  FUSILLI_REQUIRE_ASSIGN(auto compiledArtifact,
-                         graph.compileToArtifact(backend, /*remove=*/true));
-
-  REQUIRE(std::filesystem::exists(compiledArtifact));
-  REQUIRE(!graph.getWorkspaceSize().has_value());
-
-  std::error_code err;
-  std::filesystem::copy_file(compiledArtifact, callerOwnedArtifact,
-                             std::filesystem::copy_options::overwrite_existing,
-                             err);
-  REQUIRE(!err);
-}
-
-void loadAndExecuteArtifact(Backend backend,
-                            const std::filesystem::path &callerOwnedArtifact,
-                            const std::string &graphName) {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(backend));
-
-  auto runtimeGraph = buildPointwiseAddGraph(graphName);
-  FUSILLI_REQUIRE_OK(
-      runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifact));
-
-  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
-  executeAndCheck(handle, runtimeGraph);
-}
-
 } // namespace
 
 TEST_CASE("AOT multi-backend artifacts can be selected per execution backend",
           "[aot][graph]") {
-  const auto artifactDir = std::filesystem::temp_directory_path();
-  const auto cpuArtifact = artifactDir / "fusilli_aot_multi_backend_cpu.vmfb";
-  auto cleanupCpu = ScopeExit([&] { std::filesystem::remove(cpuArtifact); });
-
-#if defined(FUSILLI_ENABLE_AMDGPU)
-  const auto gpuArtifact =
-      artifactDir / "fusilli_aot_multi_backend_amdgpu.vmfb";
-  auto cleanupGpu = ScopeExit([&] { std::filesystem::remove(gpuArtifact); });
-#endif
-
+  // Compile Phase:
   // Compile by backend only. Handles and devices are created later, matching an
   // AOT flow where compilation and execution happen on different machines.
-  auto compileGraph = buildPointwiseAddGraph("aot_multi_backend_compile_graph");
-  compileAndCopyArtifact(*compileGraph.graph, Backend::CPU, cpuArtifact);
-
+  auto cpuArtifact = compileArtifact(Backend::CPU);
 #if defined(FUSILLI_ENABLE_AMDGPU)
-  compileAndCopyArtifact(*compileGraph.graph, Backend::AMDGPU, gpuArtifact);
+  auto gpuArtifact = compileArtifact(Backend::AMDGPU);
 #endif
 
-  REQUIRE(std::filesystem::exists(cpuArtifact));
+  // Caller code may serialize and de-serialize the compiled artifacts here.
+  // <serialize / de-serialize>
+
+  // Execute Phase:
+  // Load needs handles / devices and the compiled artifact (bytes)
   loadAndExecuteArtifact(Backend::CPU, cpuArtifact,
                          "aot_multi_backend_runtime_cpu_graph");
-
 #if defined(FUSILLI_ENABLE_AMDGPU)
-  REQUIRE(std::filesystem::exists(gpuArtifact));
   loadAndExecuteArtifact(Backend::AMDGPU, gpuArtifact,
                          "aot_multi_backend_runtime_amdgpu_graph");
 #endif

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -11,10 +11,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <string>
-#include <system_error>
 #include <unordered_map>
 #include <vector>
 
@@ -49,76 +47,64 @@ PointwiseGraph buildPointwiseAddGraph(const std::string &graphName) {
   return {graph, x0T, x1T, yT};
 }
 
-void executeAndCheck(Handle &handle, PointwiseGraph &ctx) {
+} // namespace
+
+TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
+          "[aot][graph]") {
+
+  // Compile Phase:
+  std::vector<uint8_t> callerOwnedArtifactBytes;
+  {
+    // With `remove=true`, Fusilli may remove compile-side cache files when the
+    // compile graph is destroyed. The returned bytes are caller-owned.
+    auto compileGraph =
+        buildPointwiseAddGraph("aot_single_backend_compile_graph");
+    FUSILLI_REQUIRE_ASSIGN(
+        callerOwnedArtifactBytes,
+        compileGraph.graph->compileToArtifact(kDefaultBackend,
+                                              /*remove=*/true));
+    REQUIRE(!callerOwnedArtifactBytes.empty());
+    REQUIRE(!compileGraph.graph->getWorkspaceSize().has_value());
+  }
+
+  // Caller code may serialize and de-serialize the compiled artifacts here.
+  // <serialize / de-serialize>
+
+  // Execute Phase:
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  auto runtimeGraph =
+      buildPointwiseAddGraph("aot_single_backend_runtime_graph");
+  FUSILLI_REQUIRE_OK(
+      runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifactBytes));
+
+  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
+
   FUSILLI_REQUIRE_ASSIGN(
-      auto x0Buf, allocateBufferOfType(handle, ctx.x0, DataType::Int32, 2));
+      auto x0Buf,
+      allocateBufferOfType(handle, runtimeGraph.x0, DataType::Int32, 2));
   FUSILLI_REQUIRE_ASSIGN(
-      auto x1Buf, allocateBufferOfType(handle, ctx.x1, DataType::Int32, 3));
-  FUSILLI_REQUIRE_ASSIGN(
-      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Int32, 0));
+      auto x1Buf,
+      allocateBufferOfType(handle, runtimeGraph.x1, DataType::Int32, 3));
+  FUSILLI_REQUIRE_ASSIGN(auto yBuf, allocateBufferOfType(handle, runtimeGraph.y,
+                                                         DataType::Int32, 0));
 
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {
-          {ctx.x0, x0Buf},
-          {ctx.x1, x1Buf},
-          {ctx.y, yBuf},
+          {runtimeGraph.x0, x0Buf},
+          {runtimeGraph.x1, x1Buf},
+          {runtimeGraph.y, yBuf},
       };
 
   FUSILLI_REQUIRE_ASSIGN(
-      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+      auto workspace,
+      allocateWorkspace(handle, runtimeGraph.graph->getWorkspaceSize()));
 
-  FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
+  FUSILLI_REQUIRE_OK(
+      runtimeGraph.graph->execute(handle, variantPack, workspace));
 
   std::vector<int> result;
   FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
   for (auto val : result)
     REQUIRE(val == 5);
-}
-
-void compileAndCopyArtifact(Graph &graph, Backend backend,
-                            const std::filesystem::path &callerOwnedArtifact) {
-  FUSILLI_REQUIRE_ASSIGN(auto compiledArtifact,
-                         graph.compileToArtifact(backend, /*remove=*/true));
-
-  REQUIRE(std::filesystem::exists(compiledArtifact));
-  REQUIRE(!graph.getWorkspaceSize().has_value());
-
-  std::error_code err;
-  std::filesystem::copy_file(compiledArtifact, callerOwnedArtifact,
-                             std::filesystem::copy_options::overwrite_existing,
-                             err);
-  REQUIRE(!err);
-}
-
-} // namespace
-
-TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
-          "[aot][graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
-  const std::filesystem::path callerOwnedArtifact =
-      std::filesystem::temp_directory_path() /
-      "fusilli_aot_single_backend_sample.vmfb";
-  auto cleanup =
-      ScopeExit([&] { std::filesystem::remove(callerOwnedArtifact); });
-
-  {
-    // With `remove=true`, Fusilli removes the compile-side cache files when
-    // the compile graph is destroyed. Copy the VMFB into caller-owned storage
-    // before leaving this scope.
-    auto compileGraph =
-        buildPointwiseAddGraph("aot_single_backend_compile_graph");
-    compileAndCopyArtifact(*compileGraph.graph, handle.getBackend(),
-                           callerOwnedArtifact);
-  }
-
-  REQUIRE(std::filesystem::exists(callerOwnedArtifact));
-
-  auto runtimeGraph =
-      buildPointwiseAddGraph("aot_single_backend_runtime_graph");
-  FUSILLI_REQUIRE_OK(
-      runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifact));
-
-  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
-  executeAndCheck(handle, runtimeGraph);
 }

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+namespace {
+
+struct PointwiseGraph {
+  std::shared_ptr<Graph> graph;
+  std::shared_ptr<TensorAttr> x0;
+  std::shared_ptr<TensorAttr> x1;
+  std::shared_ptr<TensorAttr> y;
+};
+
+PointwiseGraph buildPointwiseAddGraph(const std::string &graphName) {
+  const std::vector<int64_t> dims = {4};
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName(graphName);
+  graph->setIODataType(DataType::Int32).setComputeDataType(DataType::Int32);
+
+  auto x0T =
+      graph->tensor(TensorAttr().setName("lhs").setDim(dims).setStride({1}));
+  auto x1T =
+      graph->tensor(TensorAttr().setName("rhs").setDim(dims).setStride({1}));
+
+  auto pointwiseAttr = PointwiseAttr().setMode(PointwiseAttr::Mode::ADD);
+  auto yT = graph->pointwise(x0T, x1T, pointwiseAttr);
+  yT->setName("result").setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+  return {graph, x0T, x1T, yT};
+}
+
+void executeAndCheck(Handle &handle, PointwiseGraph &ctx) {
+  FUSILLI_REQUIRE_ASSIGN(
+      auto x0Buf, allocateBufferOfType(handle, ctx.x0, DataType::Int32, 2));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto x1Buf, allocateBufferOfType(handle, ctx.x1, DataType::Int32, 3));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Int32, 0));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {
+          {ctx.x0, x0Buf},
+          {ctx.x1, x1Buf},
+          {ctx.y, yBuf},
+      };
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+
+  FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
+
+  std::vector<int> result;
+  FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+  for (auto val : result)
+    REQUIRE(val == 5);
+}
+
+void compileAndCopyArtifact(Graph &graph, Backend backend,
+                            const std::filesystem::path &callerOwnedArtifact) {
+  FUSILLI_REQUIRE_ASSIGN(auto compiledArtifact,
+                         graph.compileToArtifact(backend, /*remove=*/true));
+
+  REQUIRE(std::filesystem::exists(compiledArtifact));
+  REQUIRE(!graph.getWorkspaceSize().has_value());
+
+  std::error_code err;
+  std::filesystem::copy_file(compiledArtifact, callerOwnedArtifact,
+                             std::filesystem::copy_options::overwrite_existing,
+                             err);
+  REQUIRE(!err);
+}
+
+} // namespace
+
+TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
+          "[aot][graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  const std::filesystem::path callerOwnedArtifact =
+      std::filesystem::temp_directory_path() /
+      "fusilli_aot_single_backend_sample.vmfb";
+  auto cleanup =
+      ScopeExit([&] { std::filesystem::remove(callerOwnedArtifact); });
+
+  {
+    // With `remove=true`, Fusilli removes the compile-side cache files when
+    // the compile graph is destroyed. Copy the VMFB into caller-owned storage
+    // before leaving this scope.
+    auto compileGraph =
+        buildPointwiseAddGraph("aot_single_backend_compile_graph");
+    compileAndCopyArtifact(*compileGraph.graph, handle.getBackend(),
+                           callerOwnedArtifact);
+  }
+
+  REQUIRE(std::filesystem::exists(callerOwnedArtifact));
+
+  auto runtimeGraph =
+      buildPointwiseAddGraph("aot_single_backend_runtime_graph");
+  FUSILLI_REQUIRE_OK(
+      runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifact));
+
+  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
+  executeAndCheck(handle, runtimeGraph);
+}

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -373,10 +373,10 @@ TEST_CASE("Graph `compileToArtifact` produces artifact without loading runtime",
           "[graph]") {
   Graph g = testGraph(/*validate=*/true);
 
-  FUSILLI_REQUIRE_ASSIGN(auto artifactPath,
+  FUSILLI_REQUIRE_ASSIGN(auto artifactBytes,
                          g.compileToArtifact(kDefaultBackend, /*remove=*/true));
 
-  REQUIRE(std::filesystem::exists(artifactPath));
+  REQUIRE(!artifactBytes.empty());
   REQUIRE(!g.getWorkspaceSize().has_value());
 }
 
@@ -386,9 +386,9 @@ TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
   auto ctx = makeTestExecutableGraph("aot_artifact_round_trip");
 
   FUSILLI_REQUIRE_ASSIGN(
-      auto artifactPath,
+      auto artifactBytes,
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
-  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactPath));
+  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
 
   REQUIRE(ctx.graph->getWorkspaceSize().has_value());
   executeAndCheckGraph(handle, ctx);
@@ -400,9 +400,9 @@ TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
   auto ctx = makeTestExecutableGraph("aot_artifact_compile_after_load");
 
   FUSILLI_REQUIRE_ASSIGN(
-      auto loadedArtifact,
+      auto loadedArtifactBytes,
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
-  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, loadedArtifact));
+  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, loadedArtifactBytes));
 
   Backend compileOnlyBackend = handle.getBackend();
 #if defined(FUSILLI_ENABLE_AMDGPU)
@@ -410,10 +410,10 @@ TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
       handle.getBackend() == Backend::AMDGPU ? Backend::CPU : Backend::AMDGPU;
 #endif
   FUSILLI_REQUIRE_ASSIGN(
-      auto compileOnlyArtifact,
+      auto compileOnlyArtifactBytes,
       ctx.graph->compileToArtifact(compileOnlyBackend, /*remove=*/true));
 
-  REQUIRE(std::filesystem::exists(compileOnlyArtifact));
+  REQUIRE(!compileOnlyArtifactBytes.empty());
   REQUIRE(ctx.graph->getWorkspaceSize().has_value());
   executeAndCheckGraph(handle, ctx);
 }
@@ -425,10 +425,10 @@ TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
 
   {
     auto producer = makeTestExecutableGraph("aot_artifact_producer");
-    FUSILLI_REQUIRE_ASSIGN(auto artifactPath,
+    FUSILLI_REQUIRE_ASSIGN(auto artifactBytes,
                            producer.graph->compileToArtifact(
                                handle.getBackend(), /*remove=*/true));
-    FUSILLI_REQUIRE_OK(consumer.graph->loadFromArtifact(handle, artifactPath));
+    FUSILLI_REQUIRE_OK(consumer.graph->loadFromArtifact(handle, artifactBytes));
   }
 
   REQUIRE(consumer.graph->getWorkspaceSize().has_value());
@@ -443,9 +443,9 @@ TEST_CASE("Graph `execute` rejects a handle with a different backend",
   Graph g = testGraph(/*validate=*/true);
 
   FUSILLI_REQUIRE_ASSIGN(
-      auto artifactPath,
+      auto artifactBytes,
       g.compileToArtifact(cpuHandle.getBackend(), /*remove=*/true));
-  FUSILLI_REQUIRE_OK(g.loadFromArtifact(cpuHandle, artifactPath));
+  FUSILLI_REQUIRE_OK(g.loadFromArtifact(cpuHandle, artifactBytes));
 
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack;

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -435,6 +435,23 @@ TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
   executeAndCheckGraph(handle, consumer);
 }
 
+TEST_CASE("Graph failed `loadFromArtifact` clears loaded runtime state",
+          "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto ctx = makeTestExecutableGraph("aot_artifact_failed_reload");
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto artifactBytes,
+      ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
+  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+
+  const std::vector<uint8_t> invalidArtifactBytes = {0xde, 0xad, 0xbe, 0xef};
+  auto status = ctx.graph->loadFromArtifact(handle, invalidArtifactBytes);
+  REQUIRE(isError(status));
+  REQUIRE(!ctx.graph->getWorkspaceSize().has_value());
+}
+
 #if defined(FUSILLI_ENABLE_AMDGPU)
 TEST_CASE("Graph `execute` rejects a handle with a different backend",
           "[graph]") {

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using namespace fusilli;
@@ -156,6 +157,70 @@ static Graph testGraph(bool validate) {
   return g;
 };
 
+struct ExecutableGraph {
+  std::shared_ptr<Graph> graph;
+  std::shared_ptr<TensorAttr> x;
+  std::shared_ptr<TensorAttr> w;
+  std::shared_ptr<TensorAttr> y;
+};
+
+static ExecutableGraph makeTestExecutableGraph(const std::string &graphName) {
+  int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName(graphName);
+  graph->setIODataType(DataType::Half).setComputeDataType(DataType::Float);
+
+  auto xT = graph->tensor(TensorAttr()
+                              .setName("image")
+                              .setDim({n, c, h, w})
+                              .setStride({c * h * w, h * w, w, 1}));
+
+  auto wT = graph->tensor(TensorAttr()
+                              .setName("filter")
+                              .setDim({k, c, r, s})
+                              .setStride({c * r * s, r * s, s, 1}));
+
+  auto convAttr = ConvFPropAttr()
+                      .setPadding({0, 0})
+                      .setStride({1, 1})
+                      .setDilation({1, 1})
+                      .setName("conv_fprop");
+
+  auto yT = graph->convFProp(xT, wT, convAttr);
+  yT->setDim({n, k, h, w}).setStride({k * h * w, h * w, w, 1});
+  yT->setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+  return {std::move(graph), std::move(xT), std::move(wT), std::move(yT)};
+}
+
+static void executeAndCheckGraph(Handle &handle, ExecutableGraph &ctx) {
+  FUSILLI_REQUIRE_ASSIGN(
+      auto xBuf, allocateBufferOfType(handle, ctx.x, DataType::Half, 1.0f));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto wBuf, allocateBufferOfType(handle, ctx.w, DataType::Half, 1.0f));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Half, 0.0f));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {
+          {ctx.x, xBuf},
+          {ctx.w, wBuf},
+          {ctx.y, yBuf},
+      };
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+
+  FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
+
+  std::vector<half> result;
+  FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+  for (auto val : result)
+    REQUIRE(val == half(128.0f));
+}
+
 TEST_CASE("Graph asm_emitter requires validation to be run first", "[graph]") {
   Graph g = testGraph(/*validate=*/false);
 
@@ -175,40 +240,35 @@ TEST_CASE("Graph asm_emitter requires validation to be run first", "[graph]") {
 
 TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
           "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle cpuHandle, Handle::create(Backend::CPU));
-#if defined(FUSILLI_ENABLE_AMDGPU)
-  FUSILLI_REQUIRE_ASSIGN(Handle gpuHandle, Handle::create(Backend::AMDGPU));
-#endif
-
   Graph g = testGraph(/*validate=*/true);
 
   FUSILLI_REQUIRE_ASSIGN(std::string generatedAsm, g.emitAsm());
 
   // Cache should be empty, compilation artifacts should be generated.
   std::optional<bool> reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
   // Cache should hit, no compilation should be required.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
 
 #if defined(FUSILLI_ENABLE_AMDGPU)
-  // Cache should miss based on different handle / device / compile command.
+  // Cache should miss based on different backend / compile command.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(gpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::AMDGPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
-  // Cache should hit with a re-run on the different handle.
+  // Cache should hit with a re-run on the different backend.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(gpuHandle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::AMDGPU, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
@@ -216,14 +276,14 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
 
   // Cache should miss because of different generated asm.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 
   // Cache should hit with the same generated asm.
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(!reCompiled.value());
@@ -231,7 +291,7 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
   // Cache should miss because graph name change.
   g.setName("new_graph_name");
   reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(cpuHandle, generatedAsm + " ",
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(Backend::CPU, generatedAsm + " ",
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
@@ -240,8 +300,6 @@ TEST_CASE("Graph `getCompiledArtifact` cache generation and invalidation",
 TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
           "other/previous Graph instances",
           "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   std::string generatedAsm;
   {
     Graph g = testGraph(/*validate=*/true);
@@ -250,14 +308,14 @@ TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
 
     // Cache should be empty.
     std::optional<bool> reCompiled = std::nullopt;
-    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                              /*remove=*/false, &reCompiled));
     REQUIRE(reCompiled.has_value());
     REQUIRE(reCompiled.value());
 
     // Cache should hit with the same generated asm.
     reCompiled = std::nullopt;
-    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+    FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                              /*remove=*/false, &reCompiled));
     REQUIRE(reCompiled.has_value());
     REQUIRE(!reCompiled.value());
@@ -274,20 +332,19 @@ TEST_CASE("Graph `getCompiledArtifact` should not read cached items from "
 
   // Nonetheless a new instance should regenerate cache.
   std::optional<bool> reCompiled = std::nullopt;
-  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(handle, generatedAsm,
+  FUSILLI_REQUIRE_OK(g.getCompiledArtifact(kDefaultBackend, generatedAsm,
                                            /*remove=*/true, &reCompiled));
   REQUIRE(reCompiled.has_value());
   REQUIRE(reCompiled.value());
 }
 
 TEST_CASE("Graph `getCompiledArtifact` invalid input IR", "[graph]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   std::string graphName;
   {
     Graph g;
     g.setName("invalid_input_ir");
     ErrorObject err =
-        g.getCompiledArtifact(handle, "invalid mlir", /*remove=*/true);
+        g.getCompiledArtifact(kDefaultBackend, "invalid mlir", /*remove=*/true);
     REQUIRE(isError(err));
     REQUIRE(err.getCode() == ErrorCode::CompileFailure);
     // Error message varies between subprocess and C API backends.
@@ -311,6 +368,95 @@ TEST_CASE("Graph `compile` method fails without validation", "[graph]") {
   REQUIRE(status.getMessage() ==
           "Graph must be validated before being compiled");
 }
+
+TEST_CASE("Graph `compileToArtifact` produces artifact without loading runtime",
+          "[graph]") {
+  Graph g = testGraph(/*validate=*/true);
+
+  FUSILLI_REQUIRE_ASSIGN(auto artifactPath,
+                         g.compileToArtifact(kDefaultBackend, /*remove=*/true));
+
+  REQUIRE(std::filesystem::exists(artifactPath));
+  REQUIRE(!g.getWorkspaceSize().has_value());
+}
+
+TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
+          "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto ctx = makeTestExecutableGraph("aot_artifact_round_trip");
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto artifactPath,
+      ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactPath));
+
+  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+  executeAndCheckGraph(handle, ctx);
+}
+
+TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
+          "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto ctx = makeTestExecutableGraph("aot_artifact_compile_after_load");
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto loadedArtifact,
+      ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, loadedArtifact));
+
+  Backend compileOnlyBackend = handle.getBackend();
+#if defined(FUSILLI_ENABLE_AMDGPU)
+  compileOnlyBackend =
+      handle.getBackend() == Backend::AMDGPU ? Backend::CPU : Backend::AMDGPU;
+#endif
+  FUSILLI_REQUIRE_ASSIGN(
+      auto compileOnlyArtifact,
+      ctx.graph->compileToArtifact(compileOnlyBackend, /*remove=*/true));
+
+  REQUIRE(std::filesystem::exists(compileOnlyArtifact));
+  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+  executeAndCheckGraph(handle, ctx);
+}
+
+TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
+          "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto consumer = makeTestExecutableGraph("aot_artifact_consumer");
+
+  {
+    auto producer = makeTestExecutableGraph("aot_artifact_producer");
+    FUSILLI_REQUIRE_ASSIGN(auto artifactPath,
+                           producer.graph->compileToArtifact(
+                               handle.getBackend(), /*remove=*/true));
+    FUSILLI_REQUIRE_OK(consumer.graph->loadFromArtifact(handle, artifactPath));
+  }
+
+  REQUIRE(consumer.graph->getWorkspaceSize().has_value());
+  executeAndCheckGraph(handle, consumer);
+}
+
+#if defined(FUSILLI_ENABLE_AMDGPU)
+TEST_CASE("Graph `execute` rejects a handle with a different backend",
+          "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle cpuHandle, Handle::create(Backend::CPU));
+  FUSILLI_REQUIRE_ASSIGN(Handle gpuHandle, Handle::create(Backend::AMDGPU));
+  Graph g = testGraph(/*validate=*/true);
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto artifactPath,
+      g.compileToArtifact(cpuHandle.getBackend(), /*remove=*/true));
+  FUSILLI_REQUIRE_OK(g.loadFromArtifact(cpuHandle, artifactPath));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack;
+  auto status = g.execute(gpuHandle, variantPack, /*workspace=*/nullptr);
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidArgument);
+  REQUIRE(status.getMessage() ==
+          "Graph::execute got a handle for backend AMDGPU, but the loaded "
+          "artifact uses backend CPU");
+}
+#endif
 
 TEST_CASE("Graph `compile` recompilations with changed handle", "[graph]") {
   // This test constructs a single graph but compiles it with different


### PR DESCRIPTION
Adds explicit AOT compile/load APIs so callers can compile backend-specific VMFBs separately from runtime loading while keeping `Graph::compile(handle)` as the JIT convenience path over `compileToArtifact(handle.getBackend())` + `loadFromArtifact(handle, vmfbBytes)`.

Summary:
- Updates `Graph::compileToArtifact(Backend)` to return caller-owned raw VMFB bytes. Internally it still uses the compile-side artifact path from `getCompiledArtifact()` and reads the VMFB before returning.
- Updates `Graph::loadFromArtifact(Handle, bytes)` to load from an in-memory VMFB buffer instead of a filesystem path.
- Keeps loaded VMFB bytes alive for the lifetime of the IREE VM context and explicitly tears down runtime state before clearing those bytes.
- Updates the AOT single-backend and multi-backend samples to pass artifacts between compile and execute phases with in-memory `std::vector<uint8_t>` buffers instead of temporary filesystem paths.
- Documents AOT constraints: VMFBs are backend-specific, compile-side cache ownership is not a persistent artifact contract, and callers should keep or serialize byte buffers they need to use later.
- Adds focused graph tests covering compile-only artifacts, load/execute round trips, runtime-state replacement, artifact lifetime across graph instances, and backend mismatch errors.