### PR TITLE
Add TANH_BWD pointwise op

### DIFF
--- a/include/fusilli/attributes/pointwise_attributes.h
+++ b/include/fusilli/attributes/pointwise_attributes.h
@@ -70,7 +70,7 @@ namespace fusilli {
   /* OP(SWISH_BWD) */                                                          \
   OP(SWISH_FWD)                                                                \
   OP(TAN)                                                                      \
-  /* OP(TANH_BWD) */                                                           \
+  OP(TANH_BWD)                                                                 \
   OP(TANH_FWD)
 
 class PointwiseAttr : public AttributesCRTP<PointwiseAttr> {
@@ -193,6 +193,7 @@ inline const std::unordered_map<PointwiseAttr::Mode, int>
         {PointwiseAttr::Mode::SUB, 2},
         {PointwiseAttr::Mode::SWISH_FWD, 1},
         {PointwiseAttr::Mode::TAN, 1},
+        {PointwiseAttr::Mode::TANH_BWD, 2},
         {PointwiseAttr::Mode::TANH_FWD, 1}};
 
 } // namespace fusilli

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1831,7 +1831,6 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {9}
 )";
 
-
   constexpr std::string_view kIdentitySchema = R"(
     {0}
     %none_{7} = torch.constant.none
@@ -2000,7 +1999,6 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        permuteOUT0                 /* {9} */
     );
   }
-
 
   default:
     assert(false && "Unsupported pointwise mode");

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -1823,6 +1823,15 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
     {7}
 )";
 
+  constexpr std::string_view kTanhBwdSchema = R"(
+    {0}
+    {1}
+    %tanh_bwd_y_{6} = torch.aten.tanh {2} : {3} -> {3}
+    {4} = torch.aten.tanh_backward {7}, %tanh_bwd_y_{6} : {8}, {3} -> {5}
+    {9}
+)";
+
+
   constexpr std::string_view kIdentitySchema = R"(
     {0}
     %none_{7} = torch.constant.none
@@ -1977,6 +1986,21 @@ inline std::string PointwiseNode::emitNodePreAsm() const {
                        getOperandTypesAsm()          /* {9} */
     );
   }
+
+  case PointwiseAttr::Mode::TANH_BWD: {
+    return std::format(kTanhBwdSchema, permuteIN0, /* {0} */
+                       permuteIN1,                 /* {1} */
+                       getInputNameAsm(1),         /* {2} */
+                       getInputTypeAsm(1),         /* {3} */
+                       getResultNamesAsm(),        /* {4} */
+                       getResultTypesAsm(),        /* {5} */
+                       getName(),                  /* {6} */
+                       getInputNameAsm(0),         /* {7} */
+                       getInputTypeAsm(0),         /* {8} */
+                       permuteOUT0                 /* {9} */
+    );
+  }
+
 
   default:
     assert(false && "Unsupported pointwise mode");

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -39,12 +39,13 @@ add_fusilli_samples(
 add_fusilli_samples(
   PREFIX fusilli_pointwise_samples
   SRCS
+    pointwise/pointwise_add_transposed.cpp
     pointwise/pointwise_binary_ops.cpp
     pointwise/pointwise_binary_cmp_ops.cpp
+    pointwise/pointwise_scalar_mul.cpp
+    pointwise/pointwise_tanh_bwd.cpp
     pointwise/pointwise_ternary_ops.cpp
     pointwise/pointwise_unary_ops.cpp
-    pointwise/pointwise_add_transposed.cpp
-    pointwise/pointwise_scalar_mul.cpp
   DEPS
     libfusilli
     libutils

--- a/samples/pointwise/pointwise_tanh_bwd.cpp
+++ b/samples/pointwise/pointwise_tanh_bwd.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+TEST_CASE("Pointwise TANH_BWD op", "[pointwise][graph]") {
+  const auto dim = std::vector<int64_t>{2, 16, 64, 64};
+
+  auto buildNewGraph = [&](Handle &handle) {
+    // Create graph
+    auto graph = std::make_shared<Graph>();
+    graph->setName("pointwise_tanh_bwd");
+    graph->setIODataType(DataType::Half).setComputeDataType(DataType::Half);
+
+    // Initialize input tensors: dy (grad_output) and x (forward input).
+    auto dyT = graph->tensor(TensorAttr().setName("dy").setDim(dim).setStride(
+        generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()))));
+    auto xT = graph->tensor(TensorAttr().setName("x").setDim(dim).setStride(
+        generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()))));
+
+    // Create Pointwise TANH_BWD op
+    auto pointwiseAttr =
+        PointwiseAttr().setMode(PointwiseAttr::Mode::TANH_BWD);
+    auto dxT = graph->pointwise(dyT, xT, pointwiseAttr);
+
+    dxT->setName("result").setOutput(true);
+
+    // Validate, infer missing properties
+    FUSILLI_REQUIRE_OK(graph->validate());
+
+    // Compile
+    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+    return std::make_tuple(graph, dyT, xT, dxT);
+  };
+
+  // Create handle for the target backend.
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  // Build graph for the given handle (device), validate and compile it.
+  auto [graph, dyT, xT, dxT] = buildNewGraph(handle);
+
+  // Input values.
+  const half dy = half(2.0f);
+  const half x = half(0.5f);
+
+  // Allocate input buffers.
+  FUSILLI_REQUIRE_ASSIGN(
+      auto dyBuf, allocateBufferOfType(handle, dyT, DataType::Half, dy));
+  FUSILLI_REQUIRE_ASSIGN(auto xBuf, allocateBufferOfType(handle, xT,
+                                                         DataType::Half, x));
+
+  // Allocate output buffer.
+  FUSILLI_REQUIRE_ASSIGN(
+      auto dxBuf, allocateBufferOfType(handle, dxT, DataType::Half, 0.0f));
+
+  // Create variant pack.
+  const std::unordered_map<std::shared_ptr<TensorAttr>,
+                           std::shared_ptr<Buffer>>
+      variantPack = {
+          {dyT, dyBuf},
+          {xT, xBuf},
+          {dxT, dxBuf},
+      };
+
+  // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+
+  // Execute graph once.
+  FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+  // Calculate reference value: y = tanh(x); dx = dy * (1 - y*y)
+  const double xD = static_cast<double>(x);
+  const double dyD = static_cast<double>(dy);
+  const double yD = std::tanh(xD);
+  const half expected = half(dyD * (1.0 - yD * yD));
+
+  // Read output buffer.
+  std::vector<half> result;
+  FUSILLI_REQUIRE_OK(dxBuf->read(handle, result));
+
+  auto isClose = [](half lhs, half rhs) -> bool {
+    const double lhsD = static_cast<double>(lhs);
+    const double rhsD = static_cast<double>(rhs);
+    const double absTol = 1e-3;
+    const double relTol = 1e-3;
+    return std::abs(lhsD - rhsD) <= absTol + relTol * std::abs(rhsD);
+  };
+
+  for (auto val : result) {
+    REQUIRE(isClose(val, expected));
+  }
+
+  // Execute graph a few times and re-check.
+  constexpr size_t numIters = 1;
+  for (size_t i = 0; i < numIters; ++i)
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+  result.clear();
+  FUSILLI_REQUIRE_OK(dxBuf->read(handle, result));
+  for (auto val : result)
+    REQUIRE(isClose(val, expected));
+}

--- a/samples/pointwise/pointwise_tanh_bwd.cpp
+++ b/samples/pointwise/pointwise_tanh_bwd.cpp
@@ -36,8 +36,7 @@ TEST_CASE("Pointwise TANH_BWD op", "[pointwise][graph]") {
         generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()))));
 
     // Create Pointwise TANH_BWD op
-    auto pointwiseAttr =
-        PointwiseAttr().setMode(PointwiseAttr::Mode::TANH_BWD);
+    auto pointwiseAttr = PointwiseAttr().setMode(PointwiseAttr::Mode::TANH_BWD);
     auto dxT = graph->pointwise(dyT, xT, pointwiseAttr);
 
     dxT->setName("result").setOutput(true);
@@ -62,18 +61,17 @@ TEST_CASE("Pointwise TANH_BWD op", "[pointwise][graph]") {
   const half x = half(0.5f);
 
   // Allocate input buffers.
-  FUSILLI_REQUIRE_ASSIGN(
-      auto dyBuf, allocateBufferOfType(handle, dyT, DataType::Half, dy));
-  FUSILLI_REQUIRE_ASSIGN(auto xBuf, allocateBufferOfType(handle, xT,
-                                                         DataType::Half, x));
+  FUSILLI_REQUIRE_ASSIGN(auto dyBuf,
+                         allocateBufferOfType(handle, dyT, DataType::Half, dy));
+  FUSILLI_REQUIRE_ASSIGN(auto xBuf,
+                         allocateBufferOfType(handle, xT, DataType::Half, x));
 
   // Allocate output buffer.
   FUSILLI_REQUIRE_ASSIGN(
       auto dxBuf, allocateBufferOfType(handle, dxT, DataType::Half, 0.0f));
 
   // Create variant pack.
-  const std::unordered_map<std::shared_ptr<TensorAttr>,
-                           std::shared_ptr<Buffer>>
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {
           {dyT, dyBuf},
           {xT, xBuf},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,7 @@ add_fusilli_lit_tests(
     lit/test_pointwise_asm_emitter_swish_fwd.cpp
     lit/test_pointwise_asm_emitter_tan.cpp
     lit/test_pointwise_asm_emitter_tanh.cpp
+    lit/test_pointwise_asm_emitter_tanh_bwd.cpp
     lit/test_pointwise_asm_emitter_sub.cpp
     lit/test_conv_wgrad_asm_emitter_nhwc_krsc.cpp
     lit/test_conv_wgrad_asm_emitter_nhwc_krsc_grouped.cpp

--- a/tests/lit/test_pointwise_asm_emitter_tanh_bwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_tanh_bwd.cpp
@@ -1,0 +1,69 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
+// RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
+
+// clang-format off
+//
+// TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0: !torch.vtensor<[16,256,64,32],f32>, %arg1: !torch.vtensor<[16,256,64,32],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:       %permute_IN_0_val_0_pointwise_tanh_bwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_0_val_1_pointwise_tanh_bwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_0_val_2_pointwise_tanh_bwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_0_val_3_pointwise_tanh_bwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_0_pointwise_tanh_bwd = torch.prim.ListConstruct %permute_IN_0_val_0_pointwise_tanh_bwd, %permute_IN_0_val_1_pointwise_tanh_bwd, %permute_IN_0_val_2_pointwise_tanh_bwd, %permute_IN_0_val_3_pointwise_tanh_bwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg0_pointwise_tanh_bwd_perm = torch.aten.permute %arg0, %permute_IN_0_pointwise_tanh_bwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_IN_1_val_0_pointwise_tanh_bwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_IN_1_val_1_pointwise_tanh_bwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_IN_1_val_2_pointwise_tanh_bwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_IN_1_val_3_pointwise_tanh_bwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_IN_1_pointwise_tanh_bwd = torch.prim.ListConstruct %permute_IN_1_val_0_pointwise_tanh_bwd, %permute_IN_1_val_1_pointwise_tanh_bwd, %permute_IN_1_val_2_pointwise_tanh_bwd, %permute_IN_1_val_3_pointwise_tanh_bwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %arg1_pointwise_tanh_bwd_perm = torch.aten.permute %arg1, %permute_IN_1_pointwise_tanh_bwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %tanh_bwd_y_pointwise_tanh_bwd = torch.aten.tanh %arg1_pointwise_tanh_bwd_perm : !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %result_pointwise_tanh_bwd_perm = torch.aten.tanh_backward %arg0_pointwise_tanh_bwd_perm, %tanh_bwd_y_pointwise_tanh_bwd : !torch.vtensor<[16,256,64,32],f32>, !torch.vtensor<[16,256,64,32],f32> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       %permute_OUT_0_val_0_pointwise_tanh_bwd = torch.constant.int 0
+// TORCH-CHECK:       %permute_OUT_0_val_1_pointwise_tanh_bwd = torch.constant.int 1
+// TORCH-CHECK:       %permute_OUT_0_val_2_pointwise_tanh_bwd = torch.constant.int 2
+// TORCH-CHECK:       %permute_OUT_0_val_3_pointwise_tanh_bwd = torch.constant.int 3
+// TORCH-CHECK:       %permute_OUT_0_pointwise_tanh_bwd = torch.prim.ListConstruct %permute_OUT_0_val_0_pointwise_tanh_bwd, %permute_OUT_0_val_1_pointwise_tanh_bwd, %permute_OUT_0_val_2_pointwise_tanh_bwd, %permute_OUT_0_val_3_pointwise_tanh_bwd : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %result = torch.aten.permute %result_pointwise_tanh_bwd_perm, %permute_OUT_0_pointwise_tanh_bwd : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
+// TORCH-CHECK:       return
+// TORCH-CHECK:     }
+// TORCH-CHECK:   }
+//
+// AMDGPU-STATS-CHECK: "transient-memory-size": 0
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "transient-memory-size": 0
+// CPU-STATS-CHECK: "dispatch-count": 1
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "pointwise_utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main(int argc, char **argv) {
+  std::string mode = (argc > 1) ? argv[1] : "default";
+
+  auto pointwiseAttr = PointwiseAttr()
+                           .setMode(PointwiseAttr::Mode::TANH_BWD)
+                           .setName("pointwise_tanh_bwd");
+  auto status = testBinaryPointwiseAsmEmitter(
+      "pointwise_asm_emitter_tanh_bwd", mode, pointwiseAttr,
+      {16, 256, 64, 32}, {16, 256, 64, 32});
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit/test_pointwise_asm_emitter_tanh_bwd.cpp
+++ b/tests/lit/test_pointwise_asm_emitter_tanh_bwd.cpp
@@ -59,8 +59,8 @@ int main(int argc, char **argv) {
                            .setMode(PointwiseAttr::Mode::TANH_BWD)
                            .setName("pointwise_tanh_bwd");
   auto status = testBinaryPointwiseAsmEmitter(
-      "pointwise_asm_emitter_tanh_bwd", mode, pointwiseAttr,
-      {16, 256, 64, 32}, {16, 256, 64, 32});
+      "pointwise_asm_emitter_tanh_bwd", mode, pointwiseAttr, {16, 256, 64, 32},
+      {16, 256, 64, 32});
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;


### PR DESCRIPTION
Emit torch.aten.tanh_backward by first computing tanh(x), then applying the backward formula dy * (1 - tanh(x)^2). Adds emitter case, sample test, and minimal lit test.

Signed-off-by: Rob Suderman <rob.suderman@gmail.com>