### PR TITLE
[1/N Dynamic Shapes]: Defer workspace size queries until execute for access to runtime input shapes

### DIFF
--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -235,8 +235,10 @@ static ErrorObject benchmarkConvFprop(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph a few times.
   for (size_t i = 0; i < iter; ++i)
@@ -366,8 +368,10 @@ static ErrorObject benchmarkConvWGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph a few times.
   for (size_t i = 0; i < iter; ++i)
@@ -497,8 +501,10 @@ static ErrorObject benchmarkConvDGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph a few times.
   for (size_t i = 0; i < iter; ++i)
@@ -593,8 +599,10 @@ static ErrorObject benchmarkLayerNormFwd(const LayerNormOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph `iter` times.
   for (size_t i = 0; i < iter; ++i)
@@ -722,8 +730,10 @@ static ErrorObject benchmarkSdpaFwd(const SdpaOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph `iter` times.
   for (size_t i = 0; i < iter; ++i)
@@ -851,8 +861,10 @@ static ErrorObject benchmarkMatmul(const MatmulOptions &opts, DataType aType,
   }
 
   // Allocate workspace buffer if needed.
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                           graph.getWorkspaceSize(variantPack));
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
-                           allocateWorkspace(handle, graph.getWorkspaceSize()));
+                           allocateWorkspace(handle, workspaceSize));
 
   // Execute graph `iter` times.
   for (size_t i = 0; i < iter; ++i)

--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -235,8 +235,7 @@ static ErrorObject benchmarkConvFprop(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -368,8 +367,7 @@ static ErrorObject benchmarkConvWGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -501,8 +499,7 @@ static ErrorObject benchmarkConvDGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -599,8 +596,7 @@ static ErrorObject benchmarkLayerNormFwd(const LayerNormOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -730,8 +726,7 @@ static ErrorObject benchmarkSdpaFwd(const SdpaOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -861,8 +856,7 @@ static ErrorObject benchmarkMatmul(const MatmulOptions &opts, DataType aType,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                           graph.getWorkspaceSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -311,11 +311,23 @@ inline ErrorObject Graph::createVmContext(const Handle &handle) {
   if (executeAsync)
     vmInputListCapacity_ += 2;
 
-  // Query the required workspace size from the compiled module.
-  FUSILLI_LOG_LABEL_ENDL("INFO: Querying workspace size from compiled module");
-  FUSILLI_ASSIGN_OR_RETURN(workspaceSize_, queryTransientSize());
-
   return ok();
+}
+
+inline ErrorOr<std::optional<size_t>>
+Graph::getWorkspaceSize(const VariantPack &variantPack) const {
+  if (vmContext_ == nullptr)
+    return ok(std::optional<size_t>());
+
+  if (!workspaceSize_.has_value()) {
+    FUSILLI_LOG_LABEL_ENDL(
+        "INFO: Querying workspace size from compiled module");
+    FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
+                             queryTransientSize(variantPack));
+    workspaceSize_ = workspaceSize;
+  }
+
+  return ok(workspaceSize_);
 }
 
 // Queries the required transient/workspace buffer size from the compiled
@@ -324,7 +336,10 @@ inline ErrorObject Graph::createVmContext(const Handle &handle) {
 // for the constant workspace size case, or an "iree.abi.transients.size"
 // function for the data-dependent workspace size case. Only the former is
 // supported by Fusilli at the moment.
-inline ErrorOr<size_t> Graph::queryTransientSize() {
+inline ErrorOr<size_t>
+Graph::queryTransientSize(const VariantPack &variantPack) const {
+  (void)variantPack;
+
   // Always resolve the async function for attribute queries. The
   // iree.abi.transients.size.constant attribute is stored in the
   // iree.reflection dict on the @main$async entry point. The sync wrapper
@@ -369,9 +384,7 @@ inline ErrorOr<size_t> Graph::queryTransientSize() {
 // The `workspace` parameter provides transient storage for intermediate values
 // when required by the compiled module.
 inline ErrorObject
-Graph::execute(const Handle &handle,
-               const std::unordered_map<std::shared_ptr<TensorAttr>,
-                                        std::shared_ptr<Buffer>> &variantPack,
+Graph::execute(const Handle &handle, const VariantPack &variantPack,
                const std::shared_ptr<Buffer> &workspace) const {
   FUSILLI_LOG_LABEL_ENDL("INFO: Executing Graph");
   FUSILLI_RETURN_ERROR_IF(vmContext_ == nullptr, ErrorCode::NotCompiled,
@@ -394,6 +407,7 @@ Graph::execute(const Handle &handle,
                               ", but the loaded artifact uses backend " +
                               kBackendToStr.at(*loadedBackend_));
   bool executeAsync = kBackendExecuteAsync.at(handle.getBackend());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, getWorkspaceSize(variantPack));
 
   iree_allocator_t allocator = iree_allocator_system();
 
@@ -448,18 +462,18 @@ Graph::execute(const Handle &handle,
   // adds a !hal.buffer argument to the generated function signature, even when
   // no transient storage is needed (size = 0). We must always push a buffer
   // (or null ref when size = 0) to satisfy the function signature.
-  if (workspaceSize_.value_or(0) > 0) {
+  if (workspaceSize.value_or(0) > 0) {
     FUSILLI_RETURN_ERROR_IF(
         workspace == nullptr, ErrorCode::InvalidArgument,
         "Workspace buffer required but not provided (size=" +
-            std::to_string(*workspaceSize_) + " bytes)");
+            std::to_string(*workspaceSize) + " bytes)");
     iree_hal_buffer_t *halBuffer = iree_hal_buffer_view_buffer(*workspace);
     FUSILLI_RETURN_ERROR_IF(
-        iree_hal_buffer_byte_length(halBuffer) < *workspaceSize_,
+        iree_hal_buffer_byte_length(halBuffer) < *workspaceSize,
         ErrorCode::InvalidArgument,
         "Workspace buffer too small: provided " +
             std::to_string(iree_hal_buffer_byte_length(halBuffer)) +
-            " bytes, required " + std::to_string(*workspaceSize_) + " bytes");
+            " bytes, required " + std::to_string(*workspaceSize) + " bytes");
     iree_vm_ref_t bufferRef = iree_hal_buffer_retain_ref(halBuffer);
     FUSILLI_CHECK_ERROR(
         iree_vm_list_push_ref_move(inputList.get(), &bufferRef));

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -377,7 +377,9 @@ inline ErrorOr<size_t> Graph::queryTransientSize() const {
 // The `workspace` parameter provides transient storage for intermediate values
 // when required by the compiled module.
 inline ErrorObject
-Graph::execute(const Handle &handle, const VariantPack &variantPack,
+Graph::execute(const Handle &handle,
+               const std::unordered_map<std::shared_ptr<TensorAttr>,
+                                        std::shared_ptr<Buffer>> &variantPack,
                const std::shared_ptr<Buffer> &workspace) const {
   FUSILLI_LOG_LABEL_ENDL("INFO: Executing Graph");
   FUSILLI_RETURN_ERROR_IF(vmContext_ == nullptr, ErrorCode::NotCompiled,

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -314,7 +314,7 @@ inline ErrorObject Graph::createVmContext(const Handle &handle) {
   return ok();
 }
 
-inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSize() const {
+inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSize() {
   if (vmContext_ == nullptr)
     return ok(std::optional<size_t>());
 

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -320,7 +320,8 @@ Graph::getWorkspaceSize(const VariantPack &variantPack) const {
     return ok(std::optional<size_t>());
 
   FUSILLI_LOG_LABEL_ENDL("INFO: Querying workspace size from compiled module");
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, queryTransientSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(size_t workspaceSize,
+                           queryTransientSize(variantPack));
   if (!workspaceSize_.has_value() || workspaceSize > *workspaceSize_)
     workspaceSize_ = workspaceSize;
 
@@ -404,7 +405,10 @@ Graph::execute(const Handle &handle, const VariantPack &variantPack,
                               ", but the loaded artifact uses backend " +
                               kBackendToStr.at(*loadedBackend_));
   bool executeAsync = kBackendExecuteAsync.at(handle.getBackend());
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, getWorkspaceSize(variantPack));
+  FUSILLI_RETURN_ERROR_IF(
+      !workspaceSize_.has_value(), ErrorCode::InvalidArgument,
+      "Graph::execute requires getWorkspaceSize() to be called before "
+      "workspace allocation and execution");
 
   iree_allocator_t allocator = iree_allocator_system();
 
@@ -459,18 +463,18 @@ Graph::execute(const Handle &handle, const VariantPack &variantPack,
   // adds a !hal.buffer argument to the generated function signature, even when
   // no transient storage is needed (size = 0). We must always push a buffer
   // (or null ref when size = 0) to satisfy the function signature.
-  if (workspaceSize.value_or(0) > 0) {
+  if (*workspaceSize_ > 0) {
     FUSILLI_RETURN_ERROR_IF(
         workspace == nullptr, ErrorCode::InvalidArgument,
         "Workspace buffer required but not provided (size=" +
-            std::to_string(*workspaceSize) + " bytes)");
+            std::to_string(*workspaceSize_) + " bytes)");
     iree_hal_buffer_t *halBuffer = iree_hal_buffer_view_buffer(*workspace);
     FUSILLI_RETURN_ERROR_IF(
-        iree_hal_buffer_byte_length(halBuffer) < *workspaceSize,
+        iree_hal_buffer_byte_length(halBuffer) < *workspaceSize_,
         ErrorCode::InvalidArgument,
         "Workspace buffer too small: provided " +
             std::to_string(iree_hal_buffer_byte_length(halBuffer)) +
-            " bytes, required " + std::to_string(*workspaceSize) + " bytes");
+            " bytes, required " + std::to_string(*workspaceSize_) + " bytes");
     iree_vm_ref_t bufferRef = iree_hal_buffer_retain_ref(halBuffer);
     FUSILLI_CHECK_ERROR(
         iree_vm_list_push_ref_move(inputList.get(), &bufferRef));

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -319,13 +319,10 @@ Graph::getWorkspaceSize(const VariantPack &variantPack) const {
   if (vmContext_ == nullptr)
     return ok(std::optional<size_t>());
 
-  if (!workspaceSize_.has_value()) {
-    FUSILLI_LOG_LABEL_ENDL(
-        "INFO: Querying workspace size from compiled module");
-    FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize,
-                             queryTransientSize(variantPack));
+  FUSILLI_LOG_LABEL_ENDL("INFO: Querying workspace size from compiled module");
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, queryTransientSize(variantPack));
+  if (!workspaceSize_.has_value() || workspaceSize > *workspaceSize_)
     workspaceSize_ = workspaceSize;
-  }
 
   return ok(workspaceSize_);
 }

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -314,14 +314,12 @@ inline ErrorObject Graph::createVmContext(const Handle &handle) {
   return ok();
 }
 
-inline ErrorOr<std::optional<size_t>>
-Graph::getWorkspaceSize(const VariantPack &variantPack) const {
+inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSize() const {
   if (vmContext_ == nullptr)
     return ok(std::optional<size_t>());
 
   FUSILLI_LOG_LABEL_ENDL("INFO: Querying workspace size from compiled module");
-  FUSILLI_ASSIGN_OR_RETURN(size_t workspaceSize,
-                           queryTransientSize(variantPack));
+  FUSILLI_ASSIGN_OR_RETURN(size_t workspaceSize, queryTransientSize());
   if (!workspaceSize_.has_value() || workspaceSize > *workspaceSize_)
     workspaceSize_ = workspaceSize;
 
@@ -334,10 +332,7 @@ Graph::getWorkspaceSize(const VariantPack &variantPack) const {
 // for the constant workspace size case, or an "iree.abi.transients.size"
 // function for the data-dependent workspace size case. Only the former is
 // supported by Fusilli at the moment.
-inline ErrorOr<size_t>
-Graph::queryTransientSize(const VariantPack &variantPack) const {
-  (void)variantPack;
-
+inline ErrorOr<size_t> Graph::queryTransientSize() const {
   // Always resolve the async function for attribute queries. The
   // iree.abi.transients.size.constant attribute is stored in the
   // iree.reflection dict on the @main$async entry point. The sync wrapper

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -74,9 +74,6 @@ inline bool checkCompileBackendEnv() {
 
 class Graph : public INode {
 public:
-  using VariantPack =
-      std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>;
-
   Graph() : INode(Context{}) {}
 
   // Validates the graph for correctness and infers missing properties.
@@ -299,8 +296,11 @@ public:
   //       workspace = std::make_shared<Buffer>(std::move(wsBuf));
   //     }
   //     graph.execute(handle, variantPack, workspace);
-  ErrorObject execute(const Handle &handle, const VariantPack &variantPack,
-                      const std::shared_ptr<Buffer> &workspace) const;
+  ErrorObject
+  execute(const Handle &handle,
+          const std::unordered_map<std::shared_ptr<TensorAttr>,
+                                   std::shared_ptr<Buffer>> &variantPack,
+          const std::shared_ptr<Buffer> &workspace) const;
 
   // Delete copy constructors and keep default move operations.
   Graph(const Graph &) = delete;

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -282,16 +282,16 @@ public:
   //     doSomethingWith(hostData);
   //
   // Workspace Buffer Usage:
-  //   After calling compile(), query getWorkspaceSize(variantPack) to determine
+  //   After calling compile(), query getWorkspaceSize() to determine
   //   if a workspace buffer is needed. If size > 0, allocate using
   //   Buffer::allocateRaw() and pass it to execute(). Calling
-  //   getWorkspaceSize(variantPack) before execute() is required, and the same
+  //   getWorkspaceSize() before execute() is required, and the same
   //   workspace buffer can be reused across multiple execute() calls.
   //
   //   Example:
   //     graph.compile(handle);
   //     FUSILLI_ASSIGN_OR_RETURN(auto wsSize,
-  //                              graph.getWorkspaceSize(variantPack));
+  //                              graph.getWorkspaceSize());
   //     std::shared_ptr<Buffer> workspace = nullptr;
   //     if (wsSize.value_or(0) > 0) {
   //       FUSILLI_ASSIGN_OR_RETURN(auto wsBuf,
@@ -390,13 +390,11 @@ public:
   customOp(std::vector<std::shared_ptr<TensorAttr>> inputs,
            CustomOpAttr &customOpAttr);
 
-  // Query required workspace buffer size for the concrete runtime variant pack.
-  // Returns std::nullopt if no runtime artifact is loaded, 0 if no workspace is
-  // needed, or the maximum required size in bytes seen across queried variant
-  // packs for the currently loaded runtime state. Dynamic workspace sizes are
-  // not supported yet and return an error.
-  ErrorOr<std::optional<size_t>>
-  getWorkspaceSize(const VariantPack &variantPack) const;
+  // Query required workspace buffer size. Returns std::nullopt if no runtime
+  // artifact is loaded, 0 if no workspace is needed, or the maximum required
+  // size in bytes seen for the currently loaded runtime state. Dynamic
+  // workspace sizes are not supported yet and return an error.
+  ErrorOr<std::optional<size_t>> getWorkspaceSize() const;
 
   // ASM emitter driver method.
   //
@@ -479,11 +477,10 @@ private:
   }
 
   // Queries the required transient/workspace buffer size from the compiled
-  // module for the concrete runtime variant pack. Returns the size in bytes, or
-  // 0 if no transients are needed. Returns an error if the module requires
-  // dynamic transient sizes.
+  // module. Returns the size in bytes, or 0 if no transients are needed.
+  // Returns an error if the module requires dynamic transient sizes.
   // Definition in `fusilli/backend/runtime.h`.
-  ErrorOr<size_t> queryTransientSize(const VariantPack &variantPack) const;
+  ErrorOr<size_t> queryTransientSize() const;
 
   // Create compiled artifacts from graph writing results to the cache. Set
   // `remove = true` to remove cache files when returned `CachedAssets` lifetime

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -74,6 +74,9 @@ inline bool checkCompileBackendEnv() {
 
 class Graph : public INode {
 public:
+  using VariantPack =
+      std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>;
+
   Graph() : INode(Context{}) {}
 
   // Validates the graph for correctness and infers missing properties.
@@ -166,19 +169,19 @@ public:
   }
 
   // Loads a compiled VMFB artifact onto the device owned by `handle`, creating
-  // per-graph runtime state and querying workspace size. This does not require
-  // the artifact to have been produced by this `Graph` instance.
+  // per-graph runtime state. This does not require the artifact to have been
+  // produced by this `Graph` instance.
   //
   // The artifact must be compatible with `handle.getBackend()`. A VMFB compiled
   // for one backend is not a portable artifact for another backend.
   //
   // A `Graph` owns one loaded runtime state at a time. Loading a new artifact
-  // replaces any previously loaded VM context, function, workspace size, and VM
-  // input list capacity. If loading fails, the `Graph` is left without loaded
-  // runtime state. To keep multiple backends loaded concurrently, use one
-  // `Graph` instance per backend artifact. To switch backends on one `Graph`,
-  // call `loadFromArtifact()` with the selected backend artifact before
-  // `execute()`.
+  // replaces any previously loaded VM context, function, workspace query cache,
+  // and VM input list capacity. If loading fails, the `Graph` is left without
+  // loaded runtime state. To keep multiple backends loaded concurrently, use
+  // one `Graph` instance per backend artifact. To switch backends on one
+  // `Graph`, call `loadFromArtifact()` with the selected backend artifact
+  // before `execute()`.
   ErrorObject loadFromArtifact(const Handle &handle,
                                std::span<const uint8_t> vmfbBytes) {
     FUSILLI_LOG_LABEL_ENDL("INFO: Loading compiled artifact into VM context");
@@ -286,7 +289,8 @@ public:
   //
   //   Example:
   //     graph.compile(handle);
-  //     auto wsSize = graph.getWorkspaceSize();
+  //     FUSILLI_ASSIGN_OR_RETURN(auto wsSize,
+  //                              graph.getWorkspaceSize(variantPack));
   //     std::shared_ptr<Buffer> workspace = nullptr;
   //     if (wsSize.value_or(0) > 0) {
   //       FUSILLI_ASSIGN_OR_RETURN(auto wsBuf,
@@ -294,11 +298,8 @@ public:
   //       workspace = std::make_shared<Buffer>(std::move(wsBuf));
   //     }
   //     graph.execute(handle, variantPack, workspace);
-  ErrorObject
-  execute(const Handle &handle,
-          const std::unordered_map<std::shared_ptr<TensorAttr>,
-                                   std::shared_ptr<Buffer>> &variantPack,
-          const std::shared_ptr<Buffer> &workspace) const;
+  ErrorObject execute(const Handle &handle, const VariantPack &variantPack,
+                      const std::shared_ptr<Buffer> &workspace) const;
 
   // Delete copy constructors and keep default move operations.
   Graph(const Graph &) = delete;
@@ -388,10 +389,12 @@ public:
   customOp(std::vector<std::shared_ptr<TensorAttr>> inputs,
            CustomOpAttr &customOpAttr);
 
-  // Query required workspace buffer size.
-  // Returns std::nullopt if not compiled, 0 if no workspace needed,
-  // or the required size in bytes.
-  std::optional<size_t> getWorkspaceSize() const { return workspaceSize_; }
+  // Query required workspace buffer size for the concrete runtime variant pack.
+  // Returns std::nullopt if no runtime artifact is loaded, 0 if no workspace is
+  // needed, or the required size in bytes. Dynamic workspace sizes are not
+  // supported yet and return an error.
+  ErrorOr<std::optional<size_t>>
+  getWorkspaceSize(const VariantPack &variantPack) const;
 
   // ASM emitter driver method.
   //
@@ -474,10 +477,11 @@ private:
   }
 
   // Queries the required transient/workspace buffer size from the compiled
-  // module. Returns the size in bytes, or 0 if no transients are needed.
-  // Returns an error if the module requires dynamic transient sizes.
+  // module for the concrete runtime variant pack. Returns the size in bytes, or
+  // 0 if no transients are needed. Returns an error if the module requires
+  // dynamic transient sizes.
   // Definition in `fusilli/backend/runtime.h`.
-  ErrorOr<size_t> queryTransientSize();
+  ErrorOr<size_t> queryTransientSize(const VariantPack &variantPack) const;
 
   // Create compiled artifacts from graph writing results to the cache. Set
   // `remove = true` to remove cache files when returned `CachedAssets` lifetime
@@ -708,10 +712,10 @@ private:
   // Avoids repeated function lookup on every execute() call.
   std::optional<iree_vm_function_t> vmFunction_;
 
-  // Required workspace buffer size in bytes. Set during createVmContext()
-  // by querying the iree.abi.transients.size.constant attribute.
-  // std::nullopt indicates the graph has not been compiled yet.
-  std::optional<size_t> workspaceSize_;
+  // Required workspace buffer size in bytes. Cached by getWorkspaceSize().
+  // std::nullopt indicates the workspace size has not been queried for the
+  // currently loaded runtime state.
+  mutable std::optional<size_t> workspaceSize_;
 
   // Pre-computed VM input list capacity for iree_vm_list_create().
   // Set during createVmContext() to avoid recomputing on every execute().

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -282,10 +282,11 @@ public:
   //     doSomethingWith(hostData);
   //
   // Workspace Buffer Usage:
-  //   After calling compile(), query getWorkspaceSize() to determine if a
-  //   workspace buffer is needed. If size > 0, allocate using
-  //   Buffer::allocateRaw() and pass it to execute(). The same workspace
-  //   buffer can be reused across multiple execute() calls.
+  //   After calling compile(), query getWorkspaceSize(variantPack) to determine
+  //   if a workspace buffer is needed. If size > 0, allocate using
+  //   Buffer::allocateRaw() and pass it to execute(). Calling
+  //   getWorkspaceSize(variantPack) before execute() is required, and the same
+  //   workspace buffer can be reused across multiple execute() calls.
   //
   //   Example:
   //     graph.compile(handle);

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -394,7 +394,7 @@ public:
   // artifact is loaded, 0 if no workspace is needed, or the maximum required
   // size in bytes seen for the currently loaded runtime state. Dynamic
   // workspace sizes are not supported yet and return an error.
-  ErrorOr<std::optional<size_t>> getWorkspaceSize() const;
+  ErrorOr<std::optional<size_t>> getWorkspaceSize();
 
   // ASM emitter driver method.
   //
@@ -714,7 +714,7 @@ private:
   // Maximum required workspace buffer size in bytes seen by getWorkspaceSize().
   // std::nullopt indicates the workspace size has not been queried for the
   // currently loaded runtime state.
-  mutable std::optional<size_t> workspaceSize_;
+  std::optional<size_t> workspaceSize_;
 
   // Pre-computed VM input list capacity for iree_vm_list_create().
   // Set during createVmContext() to avoid recomputing on every execute().

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -391,8 +391,9 @@ public:
 
   // Query required workspace buffer size for the concrete runtime variant pack.
   // Returns std::nullopt if no runtime artifact is loaded, 0 if no workspace is
-  // needed, or the required size in bytes. Dynamic workspace sizes are not
-  // supported yet and return an error.
+  // needed, or the maximum required size in bytes seen across queried variant
+  // packs for the currently loaded runtime state. Dynamic workspace sizes are
+  // not supported yet and return an error.
   ErrorOr<std::optional<size_t>>
   getWorkspaceSize(const VariantPack &variantPack) const;
 
@@ -712,7 +713,7 @@ private:
   // Avoids repeated function lookup on every execute() call.
   std::optional<iree_vm_function_t> vmFunction_;
 
-  // Required workspace buffer size in bytes. Cached by getWorkspaceSize().
+  // Maximum required workspace buffer size in bytes seen by getWorkspaceSize().
   // std::nullopt indicates the workspace size has not been queried for the
   // currently loaded runtime state.
   mutable std::optional<size_t> workspaceSize_;

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -53,8 +53,11 @@ std::vector<uint8_t> compileArtifact(Backend backend) {
       auto compiledArtifactBytes,
       compileGraph.graph->compileToArtifact(backend, /*remove=*/true));
 
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         compileGraph.graph->getWorkspaceSize(variantPack));
   REQUIRE(!compiledArtifactBytes.empty());
-  REQUIRE(!compileGraph.graph->getWorkspaceSize().has_value());
+  REQUIRE(!workspaceSize.has_value());
   return compiledArtifactBytes;
 }
 
@@ -65,8 +68,6 @@ void loadAndExecuteArtifact(Backend backend,
 
   auto runtimeGraph = buildPointwiseAddGraph(graphName);
   FUSILLI_REQUIRE_OK(runtimeGraph.graph->loadFromArtifact(handle, vmfbBytes));
-
-  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
 
   FUSILLI_REQUIRE_ASSIGN(
       auto x0Buf,
@@ -84,9 +85,12 @@ void loadAndExecuteArtifact(Backend backend,
           {runtimeGraph.y, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(
-      auto workspace,
-      allocateWorkspace(handle, runtimeGraph.graph->getWorkspaceSize()));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         runtimeGraph.graph->getWorkspaceSize(variantPack));
+  REQUIRE(workspaceSize.has_value());
+
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(
       runtimeGraph.graph->execute(handle, variantPack, workspace));

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -82,7 +82,7 @@ void loadAndExecuteArtifact(Backend backend,
       };
 
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         runtimeGraph.graph->getWorkspaceSize(variantPack));
+                         runtimeGraph.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 
   FUSILLI_REQUIRE_ASSIGN(auto workspace,

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -53,11 +53,7 @@ std::vector<uint8_t> compileArtifact(Backend backend) {
       auto compiledArtifactBytes,
       compileGraph.graph->compileToArtifact(backend, /*remove=*/true));
 
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         compileGraph.graph->getWorkspaceSize(variantPack));
   REQUIRE(!compiledArtifactBytes.empty());
-  REQUIRE(!workspaceSize.has_value());
   return compiledArtifactBytes;
 }
 

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -94,7 +94,7 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
       };
 
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         runtimeGraph.graph->getWorkspaceSize(variantPack));
+                         runtimeGraph.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 
   FUSILLI_REQUIRE_ASSIGN(auto workspace,

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -63,8 +63,11 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
         callerOwnedArtifactBytes,
         compileGraph.graph->compileToArtifact(kDefaultBackend,
                                               /*remove=*/true));
+    Graph::VariantPack variantPack;
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           compileGraph.graph->getWorkspaceSize(variantPack));
     REQUIRE(!callerOwnedArtifactBytes.empty());
-    REQUIRE(!compileGraph.graph->getWorkspaceSize().has_value());
+    REQUIRE(!workspaceSize.has_value());
   }
 
   // Caller code may serialize and de-serialize the compiled artifacts here.
@@ -77,8 +80,6 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
       buildPointwiseAddGraph("aot_single_backend_runtime_graph");
   FUSILLI_REQUIRE_OK(
       runtimeGraph.graph->loadFromArtifact(handle, callerOwnedArtifactBytes));
-
-  REQUIRE(runtimeGraph.graph->getWorkspaceSize().has_value());
 
   FUSILLI_REQUIRE_ASSIGN(
       auto x0Buf,
@@ -96,9 +97,12 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
           {runtimeGraph.y, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(
-      auto workspace,
-      allocateWorkspace(handle, runtimeGraph.graph->getWorkspaceSize()));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         runtimeGraph.graph->getWorkspaceSize(variantPack));
+  REQUIRE(workspaceSize.has_value());
+
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(
       runtimeGraph.graph->execute(handle, variantPack, workspace));

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -63,11 +63,7 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
         callerOwnedArtifactBytes,
         compileGraph.graph->compileToArtifact(kDefaultBackend,
                                               /*remove=*/true));
-    Graph::VariantPack variantPack;
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           compileGraph.graph->getWorkspaceSize(variantPack));
     REQUIRE(!callerOwnedArtifactBytes.empty());
-    REQUIRE(!workspaceSize.has_value());
   }
 
   // Caller code may serialize and de-serialize the compiled artifacts here.

--- a/samples/batchnorm/batchnorm_infer_nchw.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw.cpp
@@ -86,8 +86,10 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; no scale/bias",
           {yT, yBuf},
       };
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/batchnorm/batchnorm_infer_nchw.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw.cpp
@@ -86,8 +86,7 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; no scale/bias",
           {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
@@ -91,8 +91,7 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
@@ -91,8 +91,10 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
@@ -92,8 +92,7 @@ TEST_CASE("Batch normalization; inference mode; NHWC layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
@@ -92,8 +92,10 @@ TEST_CASE("Batch normalization; inference mode; NHWC layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/batchnorm/batchnorm_train_nchw.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw.cpp
@@ -85,8 +85,10 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; no scale/bias",
           {sivT, sivBuf},
       };
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/batchnorm/batchnorm_train_nchw.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw.cpp
@@ -85,8 +85,7 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; no scale/bias",
           {sivT, sivBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
@@ -92,8 +92,10 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; scale, bias",
           {yT, yBuf}, {smT, smBuf}, {sivT, sivBuf},
       };
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
@@ -92,8 +92,7 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; scale, bias",
           {yT, yBuf}, {smT, smBuf}, {sivT, sivBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_dgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc.cpp
@@ -85,8 +85,10 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -191,8 +193,10 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_dgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc.cpp
@@ -85,8 +85,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -193,8 +192,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
@@ -86,8 +86,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding;"
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
@@ -86,8 +86,10 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding;"
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
@@ -100,8 +100,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
@@ -100,8 +100,10 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -83,8 +83,7 @@ TEST_CASE("Convolution fprop; X (NCHW), W (KCRS); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -83,8 +83,10 @@ TEST_CASE("Convolution fprop; X (NCHW), W (KCRS); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
@@ -83,8 +83,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
@@ -83,8 +83,10 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -81,8 +81,10 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -81,8 +81,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
@@ -81,8 +81,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 3x3 conv; same padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
@@ -81,8 +81,10 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 3x3 conv; same padding",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_with_bias.cpp
+++ b/samples/convolution/conv_fprop_with_bias.cpp
@@ -93,8 +93,10 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_with_bias.cpp
+++ b/samples/convolution/conv_fprop_with_bias.cpp
@@ -93,8 +93,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_with_relu.cpp
+++ b/samples/convolution/conv_fprop_with_relu.cpp
@@ -85,8 +85,10 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; relu",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_with_relu.cpp
+++ b/samples/convolution/conv_fprop_with_relu.cpp
@@ -85,8 +85,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; relu",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_with_relu_and_bias.cpp
@@ -98,8 +98,10 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_fprop_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_with_relu_and_bias.cpp
@@ -98,8 +98,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc.cpp
@@ -85,8 +85,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -194,8 +193,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc.cpp
@@ -85,8 +85,10 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -192,8 +194,10 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
@@ -84,8 +84,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; grouped",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
@@ -84,8 +84,10 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; grouped",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
@@ -88,8 +88,10 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
@@ -88,8 +88,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/custom_op/custom_op_add.cpp
+++ b/samples/custom_op/custom_op_add.cpp
@@ -87,8 +87,10 @@ TEST_CASE("Custom op: compose built-in pointwise add with custom negate",
                              std::shared_ptr<Buffer>>
         variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/custom_op/custom_op_add.cpp
+++ b/samples/custom_op/custom_op_add.cpp
@@ -87,8 +87,7 @@ TEST_CASE("Custom op: compose built-in pointwise add with custom negate",
                              std::shared_ptr<Buffer>>
         variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nchw.cpp
+++ b/samples/layernorm/layernorm_infer_nchw.cpp
@@ -79,8 +79,7 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nchw.cpp
+++ b/samples/layernorm/layernorm_infer_nchw.cpp
@@ -79,8 +79,10 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
@@ -90,8 +90,10 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
@@ -90,8 +90,7 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
@@ -90,8 +90,10 @@ TEST_CASE("Layer normalization; inference mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
@@ -90,8 +90,7 @@ TEST_CASE("Layer normalization; inference mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nchw.cpp
+++ b/samples/layernorm/layernorm_train_nchw.cpp
@@ -87,8 +87,10 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/layernorm/layernorm_train_nchw.cpp
+++ b/samples/layernorm/layernorm_train_nchw.cpp
@@ -87,8 +87,7 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
@@ -94,8 +94,10 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
@@ -94,8 +94,7 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
@@ -94,8 +94,7 @@ TEST_CASE("Layer normalization; training mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
@@ -94,8 +94,10 @@ TEST_CASE("Layer normalization; training mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/matmul/matmul_basic.cpp
+++ b/samples/matmul/matmul_basic.cpp
@@ -75,8 +75,10 @@ TEST_CASE("Matrix multiplication; A (M, K), B (K, N); basic matmul",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -152,8 +154,10 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/matmul/matmul_basic.cpp
+++ b/samples/matmul/matmul_basic.cpp
@@ -75,8 +75,7 @@ TEST_CASE("Matrix multiplication; A (M, K), B (K, N); basic matmul",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -154,8 +153,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_basic_with_bias.cpp
+++ b/samples/matmul/matmul_basic_with_bias.cpp
@@ -93,8 +93,10 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B (K, N), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -188,8 +190,10 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B^T (N, K), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/matmul/matmul_basic_with_bias.cpp
+++ b/samples/matmul/matmul_basic_with_bias.cpp
@@ -93,8 +93,7 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B (K, N), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -190,8 +189,7 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B^T (N, K), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_batched.cpp
+++ b/samples/matmul/matmul_batched.cpp
@@ -83,8 +83,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -167,8 +166,7 @@ TEST_CASE("Batched matrix multiplication with broadcast; A (B, M, K), B (1, K, "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_batched.cpp
+++ b/samples/matmul/matmul_batched.cpp
@@ -83,8 +83,10 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -165,8 +167,10 @@ TEST_CASE("Batched matrix multiplication with broadcast; A (B, M, K), B (1, K, "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/matmul/matmul_batched_with_bias.cpp
+++ b/samples/matmul/matmul_batched_with_bias.cpp
@@ -100,8 +100,7 @@ TEST_CASE("Batched matrix multiplication with bias; A (B, M, K), B (B, K, N), "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -204,8 +203,7 @@ TEST_CASE("Batched matrix multiplication with broadcast and bias; A (B, M, K), "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_batched_with_bias.cpp
+++ b/samples/matmul/matmul_batched_with_bias.cpp
@@ -100,8 +100,10 @@ TEST_CASE("Batched matrix multiplication with bias; A (B, M, K), B (B, K, N), "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -202,8 +204,10 @@ TEST_CASE("Batched matrix multiplication with broadcast and bias; A (B, M, K), "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/matmul/matmul_int4_fp16.cpp
+++ b/samples/matmul/matmul_int4_fp16.cpp
@@ -67,8 +67,10 @@ TEST_CASE("Int4 x fp16 matmul", "[matmul][int4]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{aT, aBuf}, {bT, bBuf}, {cT, cBuf}};
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/matmul/matmul_int4_fp16.cpp
+++ b/samples/matmul/matmul_int4_fp16.cpp
@@ -67,8 +67,7 @@ TEST_CASE("Int4 x fp16 matmul", "[matmul][int4]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{aT, aBuf}, {bT, bBuf}, {cT, cBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -98,8 +98,7 @@ TEST_CASE("Pointwise add with transposed operand", "[pointwise][graph]") {
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -98,8 +98,10 @@ TEST_CASE("Pointwise add with transposed operand", "[pointwise][graph]") {
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -80,98 +80,100 @@ TEST_CASE("Pointwise binary compare ops", "[pointwise][graph]") {
     return std::make_tuple(graph, x0T, x1T, yT);
   };
 
-  auto testDtype = [&]<typename T>(
-                       Handle &handle, DataType dt,
-                       const std::vector<std::pair<T, T>> &valuePairs) {
-    auto [graph, x0T, x1T, yT] = buildNewGraph(handle, dt);
+  auto testDtype =
+      [&]<typename T>(Handle &handle, DataType dt,
+                      const std::vector<std::pair<T, T>> &valuePairs) {
+        auto [graph, x0T, x1T, yT] = buildNewGraph(handle, dt);
 
-    for (auto [x0, x1] : valuePairs) {
-      // Allocate input buffers.
-      FUSILLI_REQUIRE_ASSIGN(auto x0Buf,
-                             allocateBufferOfType(handle, x0T, dt, x0));
-      FUSILLI_REQUIRE_ASSIGN(auto x1Buf,
-                             allocateBufferOfType(handle, x1T, dt, x1));
+        for (auto [x0, x1] : valuePairs) {
+          // Allocate input buffers.
+          FUSILLI_REQUIRE_ASSIGN(auto x0Buf,
+                                 allocateBufferOfType(handle, x0T, dt, x0));
+          FUSILLI_REQUIRE_ASSIGN(auto x1Buf,
+                                 allocateBufferOfType(handle, x1T, dt, x1));
 
-      // Allocate output buffer.
-      DataType yDt = DataType::Boolean;
-      FUSILLI_REQUIRE_ASSIGN(auto yBuf,
-                             allocateBufferOfType(handle, yT, yDt, false));
+          // Allocate output buffer.
+          DataType yDt = DataType::Boolean;
+          FUSILLI_REQUIRE_ASSIGN(auto yBuf,
+                                 allocateBufferOfType(handle, yT, yDt, false));
 
-      // Create variant pack.
-      const std::unordered_map<std::shared_ptr<TensorAttr>,
-                               std::shared_ptr<Buffer>>
-          variantPack = {
-              {x0T, x0Buf},
-              {x1T, x1Buf},
-              {yT, yBuf},
-          };
+          // Create variant pack.
+          const std::unordered_map<std::shared_ptr<TensorAttr>,
+                                   std::shared_ptr<Buffer>>
+              variantPack = {
+                  {x0T, x0Buf},
+                  {x1T, x1Buf},
+                  {yT, yBuf},
+              };
 
-      // Allocate workspace buffer if needed.
-      FUSILLI_REQUIRE_ASSIGN(
-          auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+          // Allocate workspace buffer if needed.
+          FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                                 graph->getWorkspaceSize(variantPack));
+          FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                                 allocateWorkspace(handle, workspaceSize));
 
-      // Execute graph once.
-      FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+          // Execute graph once.
+          FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 
-      // Calculate reference value
-      bool y = 0;
-      switch (mode) {
-      case PointwiseAttr::Mode::CMP_EQ: {
-        y = (x0 == x1);
-        break;
-      }
-      case PointwiseAttr::Mode::CMP_LT: {
-        y = (x0 < x1);
-        break;
-      }
-      case PointwiseAttr::Mode::CMP_LE: {
-        y = (x0 <= x1);
-        break;
-      }
-      case PointwiseAttr::Mode::CMP_GT: {
-        y = (x0 > x1);
-        break;
-      }
-      case PointwiseAttr::Mode::CMP_GE: {
-        y = (x0 >= x1);
-        break;
-      }
-      case PointwiseAttr::Mode::CMP_NEQ: {
-        y = (x0 != x1);
-        break;
-      }
-      case PointwiseAttr::Mode::LOGICAL_AND: {
-        y = (x0 != T(0)) && (x1 != T(0));
-        break;
-      }
-      case PointwiseAttr::Mode::LOGICAL_OR: {
-        y = (x0 != T(0)) || (x1 != T(0));
-        break;
-      }
-      default:
-        FAIL("Unsupported pointwise mode: "
-             << PointwiseAttr::kModeToStr.at(mode));
-      }
+          // Calculate reference value
+          bool y = 0;
+          switch (mode) {
+          case PointwiseAttr::Mode::CMP_EQ: {
+            y = (x0 == x1);
+            break;
+          }
+          case PointwiseAttr::Mode::CMP_LT: {
+            y = (x0 < x1);
+            break;
+          }
+          case PointwiseAttr::Mode::CMP_LE: {
+            y = (x0 <= x1);
+            break;
+          }
+          case PointwiseAttr::Mode::CMP_GT: {
+            y = (x0 > x1);
+            break;
+          }
+          case PointwiseAttr::Mode::CMP_GE: {
+            y = (x0 >= x1);
+            break;
+          }
+          case PointwiseAttr::Mode::CMP_NEQ: {
+            y = (x0 != x1);
+            break;
+          }
+          case PointwiseAttr::Mode::LOGICAL_AND: {
+            y = (x0 != T(0)) && (x1 != T(0));
+            break;
+          }
+          case PointwiseAttr::Mode::LOGICAL_OR: {
+            y = (x0 != T(0)) || (x1 != T(0));
+            break;
+          }
+          default:
+            FAIL("Unsupported pointwise mode: "
+                 << PointwiseAttr::kModeToStr.at(mode));
+          }
 
-      // Read output buffers.
-      std::vector<uint8_t> result;
-      FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
-      for (auto val : result) {
-        REQUIRE(val == y);
-      }
+          // Read output buffers.
+          std::vector<uint8_t> result;
+          FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+          for (auto val : result) {
+            REQUIRE(val == y);
+          }
 
-      // Execute graph a few times.
-      constexpr size_t numIters = 1;
-      for (size_t i = 0; i < numIters; ++i)
-        FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+          // Execute graph a few times.
+          constexpr size_t numIters = 1;
+          for (size_t i = 0; i < numIters; ++i)
+            FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 
-      // Repeat output buffer checks.
-      result.clear();
-      FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
-      for (auto val : result)
-        REQUIRE(val == y);
-    }
-  };
+          // Repeat output buffer checks.
+          result.clear();
+          FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+          for (auto val : result)
+            REQUIRE(val == y);
+        }
+      };
 
   // Create handle for the target backend.
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -107,8 +107,7 @@ TEST_CASE("Pointwise binary compare ops", "[pointwise][graph]") {
               };
 
           // Allocate workspace buffer if needed.
-          FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                                 graph->getWorkspaceSize(variantPack));
+          FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
           FUSILLI_REQUIRE_ASSIGN(auto workspace,
                                  allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -108,8 +108,10 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once.
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -108,8 +108,7 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_bwd.cpp
+++ b/samples/pointwise/pointwise_bwd.cpp
@@ -100,8 +100,10 @@ TEST_CASE("Pointwise backward ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once.
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/pointwise/pointwise_bwd.cpp
+++ b/samples/pointwise/pointwise_bwd.cpp
@@ -100,8 +100,7 @@ TEST_CASE("Pointwise backward ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_scalar_mul.cpp
+++ b/samples/pointwise/pointwise_scalar_mul.cpp
@@ -64,8 +64,10 @@ TEST_CASE("Pointwise MUL with scalar operand", "[pointwise][scalar][graph]") {
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
 

--- a/samples/pointwise/pointwise_scalar_mul.cpp
+++ b/samples/pointwise/pointwise_scalar_mul.cpp
@@ -64,8 +64,7 @@ TEST_CASE("Pointwise MUL with scalar operand", "[pointwise][scalar][graph]") {
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_ternary_ops.cpp
+++ b/samples/pointwise/pointwise_ternary_ops.cpp
@@ -112,8 +112,7 @@ TEST_CASE("Pointwise ternary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_ternary_ops.cpp
+++ b/samples/pointwise/pointwise_ternary_ops.cpp
@@ -112,8 +112,10 @@ TEST_CASE("Pointwise ternary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once.
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/pointwise/pointwise_unary_logical_ops.cpp
+++ b/samples/pointwise/pointwise_unary_logical_ops.cpp
@@ -78,8 +78,10 @@ TEST_CASE("Pointwise unary logical ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once.
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/pointwise/pointwise_unary_logical_ops.cpp
+++ b/samples/pointwise/pointwise_unary_logical_ops.cpp
@@ -78,8 +78,7 @@ TEST_CASE("Pointwise unary logical ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -158,8 +158,7 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -158,8 +158,10 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once.
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -97,8 +97,10 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(
-        auto workspace, allocateWorkspace(handle, graph->getWorkspaceSize()));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
 
     // Execute graph once
     FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -97,8 +97,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSize(variantPack));
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nchw.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw.cpp
@@ -78,8 +78,10 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; no scale",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/rmsnorm/rmsnorm_infer_nchw.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw.cpp
@@ -78,8 +78,7 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; no scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
@@ -88,8 +88,10 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
@@ -88,8 +88,7 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
@@ -88,8 +88,7 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
@@ -88,8 +88,10 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -210,8 +210,10 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
     variantPack[ctx.maskT] = maskBuf;
   }
 
-  FUSILLI_REQUIRE_ASSIGN(
-      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
 

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -210,8 +210,7 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
     variantPack[ctx.maskT] = maskBuf;
   }
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
+++ b/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
@@ -97,8 +97,10 @@ TEST_CASE("Convolution fprop with hip stream; X (NCHW), W (KCRS); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph.getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph.getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph once.
   FUSILLI_REQUIRE_OK(graph.execute(handle, variantPack, workspace));

--- a/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
+++ b/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
@@ -97,8 +97,7 @@ TEST_CASE("Convolution fprop with hip stream; X (NCHW), W (KCRS); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/tests/test_custom_op.cpp
+++ b/tests/test_custom_op.cpp
@@ -137,7 +137,7 @@ TEST_CASE("CustomOp compile + execute round-trip", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));
@@ -206,7 +206,7 @@ TEST_CASE("CustomOp composition: built-in op -> custom op", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));

--- a/tests/test_custom_op.cpp
+++ b/tests/test_custom_op.cpp
@@ -137,8 +137,9 @@ TEST_CASE("CustomOp compile + execute round-trip", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, g.getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));
 
   std::vector<float> result;
@@ -205,8 +206,9 @@ TEST_CASE("CustomOp composition: built-in op -> custom op", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, g.getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));
 
   std::vector<float> result;

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -210,8 +210,10 @@ static void executeAndCheckGraph(Handle &handle, ExecutableGraph &ctx) {
           {ctx.y, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(
-      auto workspace, allocateWorkspace(handle, ctx.graph->getWorkspaceSize()));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, workspaceSize));
 
   FUSILLI_REQUIRE_OK(ctx.graph->execute(handle, variantPack, workspace));
 
@@ -376,8 +378,10 @@ TEST_CASE("Graph `compileToArtifact` produces artifact without loading runtime",
   FUSILLI_REQUIRE_ASSIGN(auto artifactBytes,
                          g.compileToArtifact(kDefaultBackend, /*remove=*/true));
 
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
   REQUIRE(!artifactBytes.empty());
-  REQUIRE(!g.getWorkspaceSize().has_value());
+  REQUIRE(!workspaceSize.has_value());
 }
 
 TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
@@ -390,7 +394,10 @@ TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
 
-  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
+  REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
 }
 
@@ -413,8 +420,11 @@ TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
       auto compileOnlyArtifactBytes,
       ctx.graph->compileToArtifact(compileOnlyBackend, /*remove=*/true));
 
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
   REQUIRE(!compileOnlyArtifactBytes.empty());
-  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+  REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
 }
 
@@ -431,7 +441,10 @@ TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
     FUSILLI_REQUIRE_OK(consumer.graph->loadFromArtifact(handle, artifactBytes));
   }
 
-  REQUIRE(consumer.graph->getWorkspaceSize().has_value());
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         consumer.graph->getWorkspaceSize(variantPack));
+  REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, consumer);
 }
 
@@ -444,12 +457,17 @@ TEST_CASE("Graph failed `loadFromArtifact` clears loaded runtime state",
       auto artifactBytes,
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
-  REQUIRE(ctx.graph->getWorkspaceSize().has_value());
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto loadedWorkspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
+  REQUIRE(loadedWorkspaceSize.has_value());
 
   const std::vector<uint8_t> invalidArtifactBytes = {0xde, 0xad, 0xbe, 0xef};
   auto status = ctx.graph->loadFromArtifact(handle, invalidArtifactBytes);
   REQUIRE(isError(status));
-  REQUIRE(!ctx.graph->getWorkspaceSize().has_value());
+  FUSILLI_REQUIRE_ASSIGN(auto clearedWorkspaceSize,
+                         ctx.graph->getWorkspaceSize(variantPack));
+  REQUIRE(!clearedWorkspaceSize.has_value());
 }
 
 #if defined(FUSILLI_ENABLE_AMDGPU)
@@ -585,8 +603,10 @@ TEST_CASE("Graph `execute`", "[graph]") {
       };
 
   // Query and allocate workspace buffer if needed.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                         graph->getWorkspaceSize(variantPack));
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
-                         allocateWorkspace(handle, graph->getWorkspaceSize()));
+                         allocateWorkspace(handle, workspaceSize));
 
   // Execute graph.
   FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
@@ -653,9 +673,11 @@ TEST_CASE("collectModuleScopeAsm gathers declarations from nested sub-nodes",
 TEST_CASE("Graph `getWorkspaceSize` returns nullopt before compilation",
           "[graph]") {
   Graph g = testGraph(/*validate=*/true);
+  Graph::VariantPack variantPack;
 
   // Before compilation, workspace size should be nullopt.
-  REQUIRE(!g.getWorkspaceSize().has_value());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
+  REQUIRE(!workspaceSize.has_value());
 }
 
 TEST_CASE("Graph `getWorkspaceSize` after compilation", "[graph]") {
@@ -669,7 +691,8 @@ TEST_CASE("Graph `getWorkspaceSize` after compilation", "[graph]") {
   // After compilation, getWorkspaceSize returns the queried transient size.
   // It should have a value (not nullopt). The actual size is
   // implementation-dependent.
-  auto workspaceSize = g.getWorkspaceSize();
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
   REQUIRE(workspaceSize.has_value());
 }
 
@@ -681,9 +704,10 @@ TEST_CASE("Graph `getWorkspaceSize` consistency across multiple queries",
   FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
 
   // Multiple queries should return the same value.
-  auto size1 = g.getWorkspaceSize();
-  auto size2 = g.getWorkspaceSize();
-  auto size3 = g.getWorkspaceSize();
+  Graph::VariantPack variantPack;
+  FUSILLI_REQUIRE_ASSIGN(auto size1, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto size2, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto size3, g.getWorkspaceSize(variantPack));
 
   REQUIRE(size1.has_value());
   REQUIRE(size1 == size2);

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -401,6 +401,32 @@ TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
   executeAndCheckGraph(handle, ctx);
 }
 
+TEST_CASE("Graph `execute` requires prior workspace size query", "[graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto ctx = makeTestExecutableGraph("execute_requires_workspace_query");
+  FUSILLI_REQUIRE_OK(ctx.graph->compile(handle, /*remove=*/true));
+
+  FUSILLI_REQUIRE_ASSIGN(
+      auto xBuf, allocateBufferOfType(handle, ctx.x, DataType::Half, 1.0f));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto wBuf, allocateBufferOfType(handle, ctx.w, DataType::Half, 1.0f));
+  FUSILLI_REQUIRE_ASSIGN(
+      auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Half, 0.0f));
+
+  const Graph::VariantPack variantPack = {
+      {ctx.x, xBuf},
+      {ctx.w, wBuf},
+      {ctx.y, yBuf},
+  };
+
+  auto status = ctx.graph->execute(handle, variantPack, /*workspace=*/nullptr);
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidArgument);
+  REQUIRE(status.getMessage() ==
+          "Graph::execute requires getWorkspaceSize() to be called before "
+          "workspace allocation and execution");
+}
+
 TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
           "[graph]") {
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -407,11 +407,12 @@ TEST_CASE("Graph `execute` requires prior workspace size query", "[graph]") {
   FUSILLI_REQUIRE_ASSIGN(
       auto yBuf, allocateBufferOfType(handle, ctx.y, DataType::Half, 0.0f));
 
-  const Graph::VariantPack variantPack = {
-      {ctx.x, xBuf},
-      {ctx.w, wBuf},
-      {ctx.y, yBuf},
-  };
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {
+          {ctx.x, xBuf},
+          {ctx.w, wBuf},
+          {ctx.y, yBuf},
+      };
 
   auto status = ctx.graph->execute(handle, variantPack, /*workspace=*/nullptr);
   REQUIRE(isError(status));

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -378,10 +378,7 @@ TEST_CASE("Graph `compileToArtifact` produces artifact without loading runtime",
   FUSILLI_REQUIRE_ASSIGN(auto artifactBytes,
                          g.compileToArtifact(kDefaultBackend, /*remove=*/true));
 
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
   REQUIRE(!artifactBytes.empty());
-  REQUIRE(!workspaceSize.has_value());
 }
 
 TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -210,8 +210,7 @@ static void executeAndCheckGraph(Handle &handle, ExecutableGraph &ctx) {
           {ctx.y, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -391,9 +390,7 @@ TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
 
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
 }
@@ -443,9 +440,7 @@ TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
       auto compileOnlyArtifactBytes,
       ctx.graph->compileToArtifact(compileOnlyBackend, /*remove=*/true));
 
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   REQUIRE(!compileOnlyArtifactBytes.empty());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
@@ -464,9 +459,8 @@ TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
     FUSILLI_REQUIRE_OK(consumer.graph->loadFromArtifact(handle, artifactBytes));
   }
 
-  Graph::VariantPack variantPack;
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         consumer.graph->getWorkspaceSize(variantPack));
+                         consumer.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, consumer);
 }
@@ -480,16 +474,15 @@ TEST_CASE("Graph failed `loadFromArtifact` clears loaded runtime state",
       auto artifactBytes,
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
-  Graph::VariantPack variantPack;
   FUSILLI_REQUIRE_ASSIGN(auto loadedWorkspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+                         ctx.graph->getWorkspaceSize());
   REQUIRE(loadedWorkspaceSize.has_value());
 
   const std::vector<uint8_t> invalidArtifactBytes = {0xde, 0xad, 0xbe, 0xef};
   auto status = ctx.graph->loadFromArtifact(handle, invalidArtifactBytes);
   REQUIRE(isError(status));
   FUSILLI_REQUIRE_ASSIGN(auto clearedWorkspaceSize,
-                         ctx.graph->getWorkspaceSize(variantPack));
+                         ctx.graph->getWorkspaceSize());
   REQUIRE(!clearedWorkspaceSize.has_value());
 }
 
@@ -626,8 +619,7 @@ TEST_CASE("Graph `execute`", "[graph]") {
       };
 
   // Query and allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         graph->getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -696,10 +688,9 @@ TEST_CASE("collectModuleScopeAsm gathers declarations from nested sub-nodes",
 TEST_CASE("Graph `getWorkspaceSize` returns nullopt before compilation",
           "[graph]") {
   Graph g = testGraph(/*validate=*/true);
-  Graph::VariantPack variantPack;
 
   // Before compilation, workspace size should be nullopt.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   REQUIRE(!workspaceSize.has_value());
 }
 
@@ -714,8 +705,7 @@ TEST_CASE("Graph `getWorkspaceSize` after compilation", "[graph]") {
   // After compilation, getWorkspaceSize returns the queried transient size.
   // It should have a value (not nullopt). The actual size is
   // implementation-dependent.
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 }
 
@@ -727,10 +717,9 @@ TEST_CASE("Graph `getWorkspaceSize` consistency across multiple queries",
   FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
 
   // Multiple queries should return the same value.
-  Graph::VariantPack variantPack;
-  FUSILLI_REQUIRE_ASSIGN(auto size1, g.getWorkspaceSize(variantPack));
-  FUSILLI_REQUIRE_ASSIGN(auto size2, g.getWorkspaceSize(variantPack));
-  FUSILLI_REQUIRE_ASSIGN(auto size3, g.getWorkspaceSize(variantPack));
+  FUSILLI_REQUIRE_ASSIGN(auto size1, g.getWorkspaceSize());
+  FUSILLI_REQUIRE_ASSIGN(auto size2, g.getWorkspaceSize());
+  FUSILLI_REQUIRE_ASSIGN(auto size3, g.getWorkspaceSize());
 
   REQUIRE(size1.has_value());
   REQUIRE(size1 == size2);


### PR DESCRIPTION
For the static case, workspace size was a constant and independent of the runtime input sizes so it was OK to query and cache it during VM context creation. However for the dynamic case it is dependent on the runtime input shapes. 

This PR moves workspace-size querying out of VM context creation and into the explicit `getWorkspaceSize()` call. This keeps compile/load from querying transient size and makes `execute()` require callers to query workspace size before allocating and passing a workspace buffer.

For this PR, `getWorkspaceSize()` remains independent of runtime inputs: it queries the currently supported constant transient size, stores the maximum queried size on the graph, and returns `std::nullopt` when no runtime artifact is loaded. Variant-pack/handle-dependent dynamic workspace sizing is intentionally deferred until the dynamic size function path is added.

Updates samples, benchmarks, and tests to call `getWorkspaceSize()` before `allocateWorkspace(...)` and then pass the resulting workspace to `execute()`. Also covers the AOT compile/load path.