### PR TITLE
Fix compile tests to avoid device initialization

### DIFF
--- a/tests/test_compile_command.cpp
+++ b/tests/test_compile_command.cpp
@@ -20,9 +20,6 @@ using namespace fusilli;
 static std::string kGraphName = "test_compile_command";
 
 TEST_CASE("CompileCommand::build with CPU backend", "[CompileCommand]") {
-  // Create test handle for CPU backend.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -43,7 +40,7 @@ TEST_CASE("CompileCommand::build with CPU backend", "[CompileCommand]") {
 
   // Build the compile command.
   CompileCommand cmd =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(Backend::CPU, input, output, statistics);
 
   // Verify the command arguments.
   const auto &args = cmd.getArgs();
@@ -101,9 +98,6 @@ TEST_CASE("CompileCommand::build with CPU backend", "[CompileCommand]") {
 
 #if defined(FUSILLI_ENABLE_AMDGPU)
 TEST_CASE("CompileCommand::build with AMDGPU backend", "[CompileCommand]") {
-  // Create test handle for AMDGPU backend.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -124,7 +118,7 @@ TEST_CASE("CompileCommand::build with AMDGPU backend", "[CompileCommand]") {
 
   // Build the compile command.
   CompileCommand cmd =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(Backend::AMDGPU, input, output, statistics);
 
   // Verify the command arguments.
   const auto &args = cmd.getArgs();
@@ -160,9 +154,6 @@ TEST_CASE("CompileCommand::build with AMDGPU backend", "[CompileCommand]") {
 #endif
 
 TEST_CASE("CompileCommand::toString format", "[CompileCommand]") {
-  // Create test handle.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -180,7 +171,7 @@ TEST_CASE("CompileCommand::toString format", "[CompileCommand]") {
 
   // Build the compile command.
   CompileCommand cmd =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(Backend::CPU, input, output, statistics);
 
   // Get string representation.
   std::string cmdStr = cmd.toString();
@@ -200,9 +191,6 @@ TEST_CASE("CompileCommand::toString format", "[CompileCommand]") {
 }
 
 TEST_CASE("CompileCommand::writeTo", "[CompileCommand]") {
-  // Create test handle.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -223,7 +211,7 @@ TEST_CASE("CompileCommand::writeTo", "[CompileCommand]") {
 
   // Build the compile command.
   CompileCommand cmd =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(kDefaultBackend, input, output, statistics);
 
   // Write to cache file.
   FUSILLI_REQUIRE_OK(cmd.writeTo(commandFile));
@@ -236,9 +224,6 @@ TEST_CASE("CompileCommand::writeTo", "[CompileCommand]") {
 }
 
 TEST_CASE("CompileCommand::getArgs", "[CompileCommand]") {
-  // Create test handle.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -256,7 +241,7 @@ TEST_CASE("CompileCommand::getArgs", "[CompileCommand]") {
 
   // Build the compile command.
   CompileCommand cmd =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(kDefaultBackend, input, output, statistics);
 
   // Get args and verify structure.
   const auto &args = cmd.getArgs();
@@ -276,9 +261,6 @@ TEST_CASE("CompileCommand::getArgs", "[CompileCommand]") {
 }
 
 TEST_CASE("CompileCommand round-trip serialization", "[CompileCommand]") {
-  // Create test handle.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
       CacheFile input,
@@ -299,12 +281,12 @@ TEST_CASE("CompileCommand round-trip serialization", "[CompileCommand]") {
 
   // Build and write command.
   CompileCommand cmd1 =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(kDefaultBackend, input, output, statistics);
   FUSILLI_REQUIRE_OK(cmd1.writeTo(commandFile));
 
   // Build another command with the same parameters.
   CompileCommand cmd2 =
-      CompileCommand::build(handle.getBackend(), input, output, statistics);
+      CompileCommand::build(kDefaultBackend, input, output, statistics);
 
   // Read the serialized command.
   FUSILLI_REQUIRE_ASSIGN(std::string serializedCmd, commandFile.read());

--- a/tests/test_compile_session.cpp
+++ b/tests/test_compile_session.cpp
@@ -91,11 +91,8 @@ TEST_CASE("CompileContext::createSession with CPU backend",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
 
-  // Create a handle for CPU backend.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
-
   // Create a session.
-  auto maybeSession = context->createSession(handle.getBackend());
+  auto maybeSession = context->createSession(Backend::CPU);
   FUSILLI_REQUIRE_OK(maybeSession);
 
   FUSILLI_REQUIRE_ASSIGN(CompileSession session, std::move(maybeSession));
@@ -111,11 +108,8 @@ TEST_CASE("CompileContext::createSession with AMDGPU backend",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
 
-  // Create a handle for AMDGPU backend.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
-
   // Create a session.
-  auto maybeSession = context->createSession(handle.getBackend());
+  auto maybeSession = context->createSession(Backend::AMDGPU);
   FUSILLI_REQUIRE_OK(maybeSession);
 
   FUSILLI_REQUIRE_ASSIGN(CompileSession session, std::move(maybeSession));
@@ -131,16 +125,13 @@ TEST_CASE("CompileContext supports multiple sessions",
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
 
-  // Create a handle.
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-
   // Create multiple sessions from the same context.
   FUSILLI_REQUIRE_ASSIGN(auto session1,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(auto session2,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(auto session3,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
 
   // All sessions should be valid.
   SUCCEED("Multiple sessions created successfully");
@@ -150,9 +141,7 @@ TEST_CASE("CompileSession::addFlag", "[CompileSession]") {
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Add a flag.
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -165,9 +154,7 @@ TEST_CASE("CompileSession::addFlags", "[CompileSession]") {
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Add multiple flags.
   std::vector<std::string> flags = {
@@ -185,9 +172,7 @@ TEST_CASE("CompileSession::compile with valid MLIR",
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -220,9 +205,7 @@ TEST_CASE("CompileSession::compile with custom flags",
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Add custom optimization flags.
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -260,9 +243,7 @@ TEST_CASE("CompileSession::compile with invalid MLIR",
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -292,9 +273,7 @@ TEST_CASE("CompileSession::compile with missing input file",
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Create cache files but don't write to input.
   FUSILLI_REQUIRE_ASSIGN(
@@ -319,9 +298,8 @@ TEST_CASE("CompileSession move semantics", "[CompileSession]") {
   // Get the shared compiler context and create sessions.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(auto session1,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
 
   // Add a flag to session1.
   FUSILLI_REQUIRE_OK(session1.addFlag("--iree-opt-level=O3"));
@@ -341,9 +319,7 @@ TEST_CASE("CompileSession::compile with AMDGPU backend",
   // Get the shared compiler context and create a session for AMDGPU.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::AMDGPU));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(Backend::AMDGPU));
 
   // Create temporary cache files.
   FUSILLI_REQUIRE_ASSIGN(
@@ -376,12 +352,11 @@ TEST_CASE("CompileSession cleanup on destruction", "[CompileSession]") {
   // Get the shared compiler context.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
   // Create a session in a nested scope.
   {
     FUSILLI_REQUIRE_ASSIGN(auto session,
-                           context->createSession(handle.getBackend()));
+                           context->createSession(kDefaultBackend));
 
     // Use the session.
     FUSILLI_REQUIRE_OK(session.addFlag("--iree-opt-level=O3"));
@@ -392,7 +367,7 @@ TEST_CASE("CompileSession cleanup on destruction", "[CompileSession]") {
   // Should be able to create a new session after the previous one was
   // destroyed.
   FUSILLI_REQUIRE_ASSIGN(auto session2,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
   FUSILLI_REQUIRE_OK(session2.addFlag("--iree-opt-level=O2"));
 
   SUCCEED("Session cleanup and recreation works correctly");
@@ -402,9 +377,7 @@ TEST_CASE("CompileSession with invalid flag", "[CompileSession][error]") {
   // Get the shared compiler context and create a session.
   FUSILLI_REQUIRE_ASSIGN(auto *context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
-  FUSILLI_REQUIRE_ASSIGN(auto session,
-                         context->createSession(handle.getBackend()));
+  FUSILLI_REQUIRE_ASSIGN(auto session, context->createSession(kDefaultBackend));
 
   // Try to add an invalid flag.
   auto result = session.addFlag("--this-is-not-a-valid-iree-flag-xyz123");
@@ -442,7 +415,6 @@ TEST_CASE("Multiple CompileContexts can coexist", "[CompileContext]") {
 // ===========================================================================
 
 TEST_CASE("CompileSession::build with CPU backend", "[CompileSession]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(Backend::CPU));
   FUSILLI_REQUIRE_ASSIGN(CacheFile input,
                          CacheFile::create(kGraphName, "input.mlir", true));
   FUSILLI_REQUIRE_ASSIGN(CacheFile output,
@@ -457,7 +429,7 @@ TEST_CASE("CompileSession::build with CPU backend", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle.getBackend(), input, output, statistics));
+      CompileSession::build(Backend::CPU, input, output, statistics));
 
   // Verify that flags were added (including statistics flags).
   const auto &args = session.getArgs();
@@ -481,7 +453,6 @@ TEST_CASE("CompileSession::build with CPU backend", "[CompileSession]") {
 }
 
 TEST_CASE("CompileSession::toString format", "[CompileSession]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CacheFile input,
                          CacheFile::create(kGraphName, "input.mlir", true));
   FUSILLI_REQUIRE_ASSIGN(CacheFile output,
@@ -496,7 +467,7 @@ TEST_CASE("CompileSession::toString format", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle.getBackend(), input, output, statistics));
+      CompileSession::build(kDefaultBackend, input, output, statistics));
 
   std::string cmdStr = session.toString();
 
@@ -507,7 +478,6 @@ TEST_CASE("CompileSession::toString format", "[CompileSession]") {
 }
 
 TEST_CASE("CompileSession::writeTo", "[CompileSession]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CacheFile input,
                          CacheFile::create(kGraphName, "input.mlir", true));
   FUSILLI_REQUIRE_ASSIGN(CacheFile output,
@@ -524,7 +494,7 @@ TEST_CASE("CompileSession::writeTo", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle.getBackend(), input, output, statistics));
+      CompileSession::build(kDefaultBackend, input, output, statistics));
 
   FUSILLI_REQUIRE_OK(session.writeTo(commandFile));
 
@@ -534,7 +504,6 @@ TEST_CASE("CompileSession::writeTo", "[CompileSession]") {
 }
 
 TEST_CASE("CompileSession::execute with valid MLIR", "[CompileSession]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CacheFile input,
                          CacheFile::create(kGraphName, "input.mlir", true));
   FUSILLI_REQUIRE_ASSIGN(CacheFile output,
@@ -552,7 +521,7 @@ TEST_CASE("CompileSession::execute with valid MLIR", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle.getBackend(), input, output, statistics));
+      CompileSession::build(kDefaultBackend, input, output, statistics));
 
   // Execute compilation.
   FUSILLI_REQUIRE_OK(session.execute());
@@ -567,7 +536,6 @@ TEST_CASE("CompileSession::execute with valid MLIR", "[CompileSession]") {
 }
 
 TEST_CASE("CompileSession::getArgs", "[CompileSession]") {
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CacheFile input,
                          CacheFile::create(kGraphName, "input.mlir", true));
   FUSILLI_REQUIRE_ASSIGN(CacheFile output,
@@ -582,7 +550,7 @@ TEST_CASE("CompileSession::getArgs", "[CompileSession]") {
 
   FUSILLI_REQUIRE_ASSIGN(
       CompileSession session,
-      CompileSession::build(handle.getBackend(), input, output, statistics));
+      CompileSession::build(kDefaultBackend, input, output, statistics));
 
   const auto &args = session.getArgs();
 
@@ -600,9 +568,8 @@ TEST_CASE("CompileSession::addFlag with tuning spec path",
   // Verify tuning spec path flag is accepted by C API.
   FUSILLI_REQUIRE_ASSIGN(CompileContext * context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CompileSession session,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
 
   ErrorObject result =
       session.addFlag("--iree-codegen-tuning-spec-path=" +
@@ -622,9 +589,8 @@ TEST_CASE("CompileSession::compile with tuning spec",
   // End-to-end compilation with tuning spec via C API.
   FUSILLI_REQUIRE_ASSIGN(CompileContext * context, CompileContext::create());
   REQUIRE(context != nullptr);
-  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_ASSIGN(CompileSession session,
-                         context->createSession(handle.getBackend()));
+                         context->createSession(kDefaultBackend));
 
   FUSILLI_REQUIRE_OK(session.addFlag("--iree-codegen-tuning-spec-path=" +
                                      getTestTuningSpecPath().generic_string()));


### PR DESCRIPTION
Leftover cleanup from https://github.com/iree-org/fusilli/pull/377.

Avoids creating runtime handles in compile-only command and session tests so AMDGPU-enabled builds do not initialize the HIP HAL just to format or build compiler invocations.

The tests now pass the intended backend directly: explicit CPU and AMDGPU cases stay explicit, while cases that previously used the default handle backend use `kDefaultBackend` without initializing a runtime device.