### PR TITLE
[2/N Dynamic Shapes]: Support dynamic dims for single-dispatch (zero-workspace) graphs

### DIFF
--- a/include/fusilli/attributes/custom_op_attributes.h
+++ b/include/fusilli/attributes/custom_op_attributes.h
@@ -43,9 +43,9 @@ public:
   // `func.call` the emitter generates:
   //
   //   Name:    @<setName()>
-  //   Inputs:  static logical value tensor types
+  //   Inputs:  logical value tensor types
   //              (e.g., !torch.vtensor<[4,8],f32>)
-  //   Outputs: static logical value tensor types
+  //   Outputs: logical value tensor types
   //
   // The following placeholders are resolved at emission time by
   // `CustomOpNode::resolveMlirPlaceholders()` and can be used to build a
@@ -57,8 +57,9 @@ public:
   //   {IN0_TYPE}   — input 0's full tensor type
   //                   (e.g., "!torch.vtensor<[4,8],f32>")
   //   {OUT0_TYPE}  — output 0's full tensor type
-  //   {IN0_DIM0}   — input 0's logical dimension 0 (e.g., "4")
-  //   {OUT0_DIM0}  — output 0's logical dimension 0
+  //   {IN0_DIM0}   — input 0's logical dimension 0 (e.g., "4", or "?" when
+  //                   that dimension is dynamic)
+  //   {OUT0_DIM0}  — output 0's logical dimension 0 (same dynamic behavior)
   //
   // All indices are 0-based and generalize to any input/output/dimension
   // count (e.g., {IN2_TYPE}, {OUT1_DIM3}).

--- a/include/fusilli/attributes/tensor_attributes.h
+++ b/include/fusilli/attributes/tensor_attributes.h
@@ -68,6 +68,21 @@
 // tensors; output tensors with broadcast strides are rejected during node
 // validation.
 //
+// Dynamic dimensions are recorded separately from `dim_`. The `dim_` entries
+// remain representative extents used by shape inference, stride inference, and
+// validation; MLIR emission overlays the dynamic annotations as `?`, and
+// runtime tensors may provide different concrete extents for those positions.
+//
+// For tensors with dynamic dimensions, `stride_` is also a representative
+// dense-layout pattern rather than a complete runtime stride vector. It is used
+// to derive the logical <-> physical permutation that Fusilli emits as tensor
+// transposes around torch dialect ops. Runtime strides whose running products
+// depend on dynamic extents are therefore dynamic too. This is currently
+// supported only for dense layout permutations. Broadcast strides and
+// representative unit dimensions are rejected on dynamic tensors because both
+// are layout-insensitive in the representative stride pattern but may become
+// layout-significant at runtime.
+//
 // Invalid stride configurations (e.g., strides that don't correspond to any
 // valid permutation) or strides unsupported by a specific operation will result
 // in an error during validation.
@@ -386,6 +401,11 @@ public:
               std::to_string(dynamicDim) +
               " with stride 0 (broadcast stride), which "
               "is not supported");
+      FUSILLI_RETURN_ERROR_IF(
+          dim_[dynamicDim] == 1, ErrorCode::InvalidAttribute,
+          "Tensor '" + name_ + "' has dynamic dim at index " +
+              std::to_string(dynamicDim) +
+              " with representative size 1, which is not supported");
     }
 
     FUSILLI_RETURN_ERROR_IF(

--- a/include/fusilli/attributes/tensor_attributes.h
+++ b/include/fusilli/attributes/tensor_attributes.h
@@ -117,10 +117,12 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <numeric>
 #include <optional>
 #include <ranges>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -371,6 +373,27 @@ public:
         dim_.size() != stride_.size(), ErrorCode::InvalidAttribute,
         "Tensor '" + name_ +
             "' uses dim and stride of different dimensionality");
+
+    for (size_t dynamicDim : dynamicDims_) {
+      FUSILLI_RETURN_ERROR_IF(
+          dynamicDim >= dim_.size(), ErrorCode::InvalidAttribute,
+          "Tensor '" + name_ + "' has dynamic dim index " +
+              std::to_string(dynamicDim) + " out of range for rank " +
+              std::to_string(dim_.size()));
+      FUSILLI_RETURN_ERROR_IF(
+          stride_[dynamicDim] == 0, ErrorCode::InvalidAttribute,
+          "Tensor '" + name_ + "' has dynamic dim at index " +
+              std::to_string(dynamicDim) +
+              " with stride 0 (broadcast stride), which "
+              "is not supported");
+    }
+
+    FUSILLI_RETURN_ERROR_IF(
+        hasBroadcastDims() && hasDynamicDims(), ErrorCode::InvalidAttribute,
+        "Tensor '" + name_ +
+            "' has dynamic dimensions on a tensor with broadcast strides, "
+            "which is not supported");
+
     FUSILLI_RETURN_ERROR_IF(
         !hasValidPhysicalRepresentation(), ErrorCode::InvalidAttribute,
         "Tensor '" + name_ +
@@ -466,6 +489,28 @@ public:
     return *this;
   }
 
+  TensorAttr &setDynamicDim(size_t index) {
+    dynamicDims_.push_back(index);
+    canonicalizeDynamicDims();
+    return *this;
+  }
+
+  TensorAttr &setDynamicDims(std::span<const size_t> indices) {
+    dynamicDims_.assign(indices.begin(), indices.end());
+    canonicalizeDynamicDims();
+    return *this;
+  }
+
+  TensorAttr &setDynamicDims(std::initializer_list<size_t> indices) {
+    return setDynamicDims(
+        std::span<const size_t>(indices.begin(), indices.size()));
+  }
+
+  TensorAttr &clearDynamicDims() {
+    dynamicDims_.clear();
+    return *this;
+  }
+
   TensorAttr &setStride(const std::vector<int64_t> &stride) {
     stride_ = stride;
     return *this;
@@ -495,6 +540,14 @@ public:
   const std::vector<int64_t> &getDim() const { return dim_; }
 
   const std::vector<int64_t> &getStride() const { return stride_; }
+
+  bool isDynamicDim(size_t index) const {
+    return std::binary_search(dynamicDims_.begin(), dynamicDims_.end(), index);
+  }
+
+  bool hasDynamicDims() const { return !dynamicDims_.empty(); }
+
+  const std::vector<size_t> &getDynamicDims() const { return dynamicDims_; }
 
   int64_t getVolume() const {
     int64_t volume = 1;
@@ -714,6 +767,7 @@ private:
   DataType dataType_ = DataType::NotSet;
   std::vector<int64_t> dim_ = {};
   std::vector<int64_t> stride_ = {};
+  std::vector<size_t> dynamicDims_ = {};
 
   // Intermediate tensors that are not inputs/outputs are virtual
   // and not stored/read as they appear internal to the kernel.
@@ -726,6 +780,12 @@ private:
   // so they should not be in the variant pack.
   bool isScalar_ = false;
   std::optional<scalar_t> scalarValue_;
+
+  void canonicalizeDynamicDims() {
+    std::sort(dynamicDims_.begin(), dynamicDims_.end());
+    dynamicDims_.erase(std::unique(dynamicDims_.begin(), dynamicDims_.end()),
+                       dynamicDims_.end());
+  }
 };
 
 // Sorting function for deterministic lookups on TensorAttr containers

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -89,7 +89,7 @@ public:
   //   {FUNC_NAME}                    — node name
   //   {IN<i>_DTYPE}/{OUT<i>_DTYPE}   — element type (e.g., "f32")
   //   {IN<i>_TYPE}/{OUT<i>_TYPE}     — full value tensor type
-  //   {IN<i>_DIM<j>}/{OUT<i>_DIM<j>} — representative logical dimension
+  //   {IN<i>_DIM<j>}/{OUT<i>_DIM<j>} — logical dimension, or `?` when dynamic
   //
   // Definition in asm_emitter.h (needs getTensorTypeAsm()).
   std::string resolveMlirPlaceholders() const;

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -89,7 +89,7 @@ public:
   //   {FUNC_NAME}                    — node name
   //   {IN<i>_DTYPE}/{OUT<i>_DTYPE}   — element type (e.g., "f32")
   //   {IN<i>_TYPE}/{OUT<i>_TYPE}     — full value tensor type
-  //   {IN<i>_DIM<j>}/{OUT<i>_DIM<j>} — single logical dimension
+  //   {IN<i>_DIM<j>}/{OUT<i>_DIM<j>} — representative logical dimension
   //
   // Definition in asm_emitter.h (needs getTensorTypeAsm()).
   std::string resolveMlirPlaceholders() const;

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2495,7 +2495,7 @@ inline std::string CustomOpNode::resolveMlirPlaceholders() const {
     const auto &dims = inputs[i]->getDim();
     for (size_t d = 0; d < dims.size(); ++d)
       replaceAll(mlir, "{IN" + iStr + "_DIM" + std::to_string(d) + "}",
-                 std::to_string(dims[d]));
+                 inputs[i]->isDynamicDim(d) ? "?" : std::to_string(dims[d]));
   }
   for (size_t i = 0; i < outputs.size(); ++i) {
     std::string iStr = std::to_string(i);
@@ -2507,7 +2507,7 @@ inline std::string CustomOpNode::resolveMlirPlaceholders() const {
     const auto &dims = outputs[i]->getDim();
     for (size_t d = 0; d < dims.size(); ++d)
       replaceAll(mlir, "{OUT" + iStr + "_DIM" + std::to_string(d) + "}",
-                 std::to_string(dims[d]));
+                 outputs[i]->isDynamicDim(d) ? "?" : std::to_string(dims[d]));
   }
   return mlir;
 }

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -48,6 +48,7 @@
 #include <cstdint>
 #include <format> // C++20
 #include <memory>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -336,6 +337,32 @@ inline std::string getScalarItemOpsAsm(const std::string &prefix,
 //                       /*useLogicalDims=*/false)
 //        --> "!torch.tensor<[2,4,3],f32>"
 //
+// Dynamic dims are tracked by logical dimension index. For example, marking
+// logical dim 2 (sequence length) dynamic:
+//
+//    TensorAttr dynT;
+//    dynT.setName("tensor")
+//      .setDataType(DataType::Float)
+//      .setDim({2, 3, 4}) // batch, channels, sequence length
+//      .setStride({12, 1, 3})
+//      .setDynamicDims({2})
+//
+//    dynT.getTensorTypeAsm(/*isValueTensor=*/true,
+//                            /*useLogicalDims=*/true)
+//        --> "!torch.vtensor<[2,3,?],f32>"
+//
+//    dynT.getTensorTypeAsm(/*isValueTensor=*/false,
+//                            /*useLogicalDims=*/true)
+//        --> "!torch.tensor<[2,3,?],f32>"
+//
+//    dynT.getTensorTypeAsm(/*isValueTensor=*/true,
+//                            /*useLogicalDims=*/false)
+//        --> "!torch.vtensor<[2,?,3],f32>"
+//
+//    dynT.getTensorTypeAsm(/*isValueTensor=*/false,
+//                            /*useLogicalDims=*/false)
+//        --> "!torch.tensor<[2,?,3],f32>"
+//
 // Scalars (dim={1}, stride={1}) also work through this path:
 //
 //    TensorAttr s(2.0f);
@@ -355,10 +382,24 @@ inline std::string TensorAttr::getTensorTypeAsm(bool isValueTensor,
   oss << (isValueTensor ? "!torch.vtensor<[" : "!torch.tensor<[");
 
   std::vector<int64_t> dims = useLogicalDims ? getDim() : getPhysicalDim();
+  std::vector<int64_t> logicalDimIndices(dims.size());
+  if (useLogicalDims)
+    std::iota(logicalDimIndices.begin(), logicalDimIndices.end(), 0);
+  else
+    logicalDimIndices = getLogicalToPhysicalPermuteOrder();
+  std::vector<size_t> dimPositions(dims.size());
+  std::iota(dimPositions.begin(), dimPositions.end(), 0);
 
   interleave(
-      dims.begin(), dims.end(),
-      [&](int64_t dim) { oss << std::to_string(dim); },
+      dimPositions.begin(), dimPositions.end(),
+      [&](size_t dimPosition) {
+        int64_t logicalDimIndex = logicalDimIndices[dimPosition];
+        if (isDynamicDim(static_cast<size_t>(logicalDimIndex))) {
+          oss << "?";
+          return;
+        }
+        oss << std::to_string(dims[dimPosition]);
+      },
       // between_fn:
       [&] { oss << ","; });
   oss << "],";

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -123,11 +123,20 @@ add_fusilli_samples(
     dynamic_shapes/conv_fprop_dynamic_batch.cpp
     dynamic_shapes/custom_op_dynamic_batch.cpp
     dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+    dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
   DEPS
     libfusilli
     libutils
     Catch2::Catch2WithMain
 )
+
+if(FUSILLI_SYSTEMS_AMDGPU)
+  # TODO: Remove this xfail once dynamic sequence SDPA works for GPU
+  set_tests_properties(
+    fusilli_dynamic_shape_samples_sdpa_basic_dynamic_sequence PROPERTIES
+    WILL_FAIL TRUE
+  )
+endif()
 
 add_fusilli_samples(
   PREFIX fusilli_custom_op_samples

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -118,6 +118,18 @@ add_fusilli_samples(
 )
 
 add_fusilli_samples(
+  PREFIX fusilli_dynamic_shape_samples
+  SRCS
+    dynamic_shapes/conv_fprop_dynamic_batch.cpp
+    dynamic_shapes/custom_op_dynamic_batch.cpp
+    dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+  DEPS
+    libfusilli
+    libutils
+    Catch2::Catch2WithMain
+)
+
+add_fusilli_samples(
   PREFIX fusilli_custom_op_samples
   SRCS
     custom_op/custom_op_add.cpp

--- a/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
@@ -81,7 +81,8 @@ TEST_CASE("Dynamic batch convolution fprop with zero workspace",
                              std::shared_ptr<Buffer>>
         variantPack = {{xT, xBuf}, {wT, wBuf}, {yT, yBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSizeOrError());
     REQUIRE(workspaceSize == 0);
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace fusilli;
+
+TEST_CASE("Dynamic batch convolution fprop with zero workspace",
+          "[dynamic][conv][graph]") {
+  const int64_t n = 4, c = 4, h = 4, w = 4, k = 4, r = 1, s = 1;
+  const std::vector<int64_t> runtimeNs = {1, 2, n};
+
+  auto buildNewGraph = [=](const Handle &handle) {
+    auto graph = std::make_shared<Graph>();
+    graph->setName("dynamic_conv_fprop_nchw_kcrs_1x1_nopad");
+    graph->setIODataType(DataType::Half).setComputeDataType(DataType::Float);
+
+    auto xT = graph->tensor(TensorAttr()
+                                .setName("image")
+                                .setDim({n, c, h, w})
+                                .setDynamicDims({0})
+                                .setStride({c * h * w, h * w, w, 1}));
+
+    auto wT = graph->tensor(TensorAttr()
+                                .setName("filter")
+                                .setDim({k, c, r, s})
+                                .setStride({c * r * s, r * s, s, 1}));
+
+    auto convAttr = ConvFPropAttr()
+                        .setPadding({0, 0})
+                        .setStride({1, 1})
+                        .setDilation({1, 1})
+                        .setName("conv_fprop");
+
+    auto yT = graph->convFProp(xT, wT, convAttr);
+    yT->setDynamicDims({0}).setOutput(true);
+
+    FUSILLI_REQUIRE_OK(graph->validate());
+    FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+    return std::make_tuple(graph, xT, wT, yT);
+  };
+
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  auto [graph, xT, wT, yT] = buildNewGraph(handle);
+
+  for (auto runtimeN : runtimeNs) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Running runtimeN=" << runtimeN);
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto xRawBuf,
+        Buffer::allocate(handle, castToSizeT({runtimeN, c, h, w}),
+                         std::vector<half>(runtimeN * c * h * w, half(1.0f))));
+    auto xBuf = std::make_shared<Buffer>(std::move(xRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto wBuf, allocateBufferOfType(handle, wT, DataType::Half, 1.0f));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto yRawBuf,
+        Buffer::allocate(handle, castToSizeT({runtimeN, k, h, w}),
+                         std::vector<half>(runtimeN * k * h * w, half(0.0f))));
+    auto yBuf = std::make_shared<Buffer>(std::move(yRawBuf));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {{xT, xBuf}, {wT, wBuf}, {yT, yBuf}};
+
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    REQUIRE(workspaceSize == 0);
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
+
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    std::vector<half> result;
+    FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+    REQUIRE(result.size() == static_cast<size_t>(runtimeN * k * h * w));
+    for (auto val : result)
+      REQUIRE(val == half(4.0f));
+  }
+}

--- a/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
@@ -105,7 +105,8 @@ TEST_CASE("Dynamic batch custom add with zero workspace",
                              std::shared_ptr<Buffer>>
         variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSizeOrError());
     REQUIRE(workspaceSize == 0);
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace fusilli;
+
+static std::string getCustomAddMlir() {
+  return R"(
+  func.func private @{FUNC_NAME}(%arg0: {IN0_TYPE},
+                                   %arg1: {IN1_TYPE})
+                                   -> {OUT0_TYPE} {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : {IN0_TYPE}, {IN1_TYPE}, !torch.int
+        -> {OUT0_TYPE}
+    return %0 : {OUT0_TYPE}
+  }
+)";
+}
+
+TEST_CASE("Dynamic batch custom add with zero workspace",
+          "[dynamic][custom_op][graph]") {
+  const int64_t n = 4, c = 8;
+  const std::vector<int64_t> runtimeNs = {1, 2, n};
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName("dynamic_custom_add")
+      .setIODataType(DataType::Float)
+      .setIntermediateDataType(DataType::Float);
+
+  auto aT = graph->tensor(TensorAttr()
+                              .setName("a")
+                              .setDim({n, c})
+                              .setDynamicDims({0})
+                              .setStride({c, 1})
+                              .setDataType(DataType::Float));
+  auto bT = graph->tensor(TensorAttr()
+                              .setName("b")
+                              .setDim({n, c})
+                              .setDynamicDims({0})
+                              .setStride({c, 1})
+                              .setDataType(DataType::Float));
+
+  CustomOpAttr addAttr;
+  addAttr.setName("my_dynamic_add")
+      .setMlir(getCustomAddMlir())
+      .setNumOutputs(1);
+
+  auto outs = graph->customOp({aT, bT}, addAttr);
+  outs[0]
+      ->setDim({n, c})
+      .setDynamicDims({0})
+      .setStride({c, 1})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+  for (auto runtimeN : runtimeNs) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Running runtimeN=" << runtimeN);
+
+    std::vector<float> aData(runtimeN * c);
+    std::vector<float> bData(runtimeN * c);
+    for (int64_t i = 0; i < runtimeN * c; ++i) {
+      aData[i] = static_cast<float>(i);
+      bData[i] = static_cast<float>(100 + i);
+    }
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto aRawBuf,
+        Buffer::allocate(handle, castToSizeT({runtimeN, c}), aData));
+    auto aBuf = std::make_shared<Buffer>(std::move(aRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto bRawBuf,
+        Buffer::allocate(handle, castToSizeT({runtimeN, c}), bData));
+    auto bBuf = std::make_shared<Buffer>(std::move(bRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto outRawBuf,
+        Buffer::allocate(handle, castToSizeT({runtimeN, c}),
+                         std::vector<float>(runtimeN * c, 0.0f)));
+    auto outBuf = std::make_shared<Buffer>(std::move(outRawBuf));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
+
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    REQUIRE(workspaceSize == 0);
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
+
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    std::vector<float> result;
+    FUSILLI_REQUIRE_OK(outBuf->read(handle, result));
+    REQUIRE(result.size() == static_cast<size_t>(runtimeN * c));
+    for (size_t i = 0; i < result.size(); ++i)
+      REQUIRE(result[i] == aData[i] + bData[i]);
+  }
+}

--- a/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
@@ -70,7 +70,7 @@ void executeDynamicReduction(Handle &handle, ReductionAttr::Mode mode,
   // instead of iree.abi.transients.size.constant for dynamic batch. Fusilli
   // rejects that dynamic workspace query until runtime size functions are
   // supported.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
   REQUIRE(workspaceSize.value_or(0) > 0);
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
@@ -1,0 +1,118 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+namespace {
+
+template <typename T>
+void executeDynamicReduction(Handle &handle, ReductionAttr::Mode mode,
+                             DataType dt, T initValue) {
+  const std::vector<int64_t> xDims = {2, 16, 8, 8};
+  const std::vector<int64_t> yDims = {2, 16, 1, 1};
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName("dynamic_reduction_" + ReductionAttr::kModeToStr.at(mode));
+  graph->setIODataType(dt).setComputeDataType(dt);
+
+  auto xT = graph->tensor(
+      TensorAttr().setName("x").setDim(xDims).setDynamicDims({0}).setStride(
+          generateStrideFromDim(xDims,
+                                getContiguousStrideOrder(xDims.size()))));
+
+  auto reductionAttr = ReductionAttr().setMode(mode);
+  auto yT = graph->reduction(xT, reductionAttr);
+  yT->setName("result")
+      .setDim(yDims)
+      .setDynamicDims({0})
+      .setStride(
+          generateStrideFromDim(yDims, getContiguousStrideOrder(yDims.size())))
+      .setOutput(true);
+
+  FUSILLI_REQUIRE_OK(graph->validate());
+  FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+  int64_t xSize = 1;
+  for (auto dim : xDims)
+    xSize *= dim;
+
+  std::vector<T> xData(xSize);
+  for (int64_t i = 0; i < xSize; ++i)
+    xData[i] = static_cast<T>(i % 100 - 50);
+
+  FUSILLI_REQUIRE_ASSIGN(auto xBuf, allocateBufferOfType(handle, xT, xData));
+  FUSILLI_REQUIRE_ASSIGN(auto yBuf,
+                         allocateBufferOfType(handle, yT, dt, initValue));
+
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {{xT, xBuf}, {yT, yBuf}};
+
+  // XFAIL: MIN/MAX reductions currently reflect iree.abi.transients.size
+  // instead of iree.abi.transients.size.constant for dynamic batch. Fusilli
+  // rejects that dynamic workspace query until runtime size functions are
+  // supported.
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+  REQUIRE(workspaceSize.value_or(0) > 0);
+  FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                         allocateWorkspace(handle, workspaceSize));
+
+  FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+  std::vector<T> result;
+  FUSILLI_REQUIRE_OK(yBuf->read(handle, result));
+  REQUIRE(result.size() == static_cast<size_t>(yDims[0] * yDims[1]));
+
+  for (int64_t n = 0; n < xDims[0]; ++n) {
+    for (int64_t c = 0; c < xDims[1]; ++c) {
+      T expectedValue = initValue;
+      for (int64_t d2 = 0; d2 < xDims[2]; ++d2) {
+        for (int64_t d3 = 0; d3 < xDims[3]; ++d3) {
+          int64_t inIdx = ((n * xDims[1] + c) * xDims[2] + d2) * xDims[3] + d3;
+          if (mode == ReductionAttr::Mode::MIN)
+            expectedValue = std::min(expectedValue, xData[inIdx]);
+          else
+            expectedValue = std::max(expectedValue, xData[inIdx]);
+        }
+      }
+
+      int64_t outIdx = n * xDims[1] + c;
+      REQUIRE(result[outIdx] == expectedValue);
+    }
+  }
+}
+
+} // namespace
+
+// TODO(#400): Remove [!shouldfail] once Fusilli supports querying IREE dynamic
+// transient workspace size functions (iree.abi.transients.size) at runtime.
+TEST_CASE("Dynamic batch MIN/MAX reductions with dynamic workspace",
+          "[dynamic][reduction][graph][!shouldfail]") {
+  const auto mode =
+      GENERATE(ReductionAttr::Mode::MIN, ReductionAttr::Mode::MAX);
+
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+
+  executeDynamicReduction(handle, mode, DataType::Int32,
+                          mode == ReductionAttr::Mode::MIN
+                              ? std::numeric_limits<int>::max()
+                              : std::numeric_limits<int>::lowest());
+}

--- a/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
+++ b/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace fusilli;
+
+TEST_CASE("Dynamic sequence basic SDPA f16", "[dynamic][sdpa][graph]") {
+  const int64_t batch = 1;
+  const int64_t heads = 8;
+  const int64_t representativeSeqLen = 64;
+  const int64_t headDim = 64;
+  const std::vector<int64_t> runtimeSeqLens = {16, 32, representativeSeqLen};
+
+  auto graph = std::make_shared<Graph>();
+  graph->setName("dynamic_sdpa_basic_mha")
+      .setIODataType(DataType::Half)
+      .setIntermediateDataType(DataType::Half);
+
+  std::vector<int64_t> dims = {batch, heads, representativeSeqLen, headDim};
+  std::vector<int64_t> stride =
+      generateStrideFromDim(dims, getContiguousStrideOrder(dims.size()));
+
+  auto qT = graph->tensor(
+      TensorAttr().setName("q").setDim(dims).setDynamicDims({2}).setStride(
+          stride));
+  auto kT = graph->tensor(
+      TensorAttr().setName("k").setDim(dims).setDynamicDims({2}).setStride(
+          stride));
+  auto vT = graph->tensor(
+      TensorAttr().setName("v").setDim(dims).setDynamicDims({2}).setStride(
+          stride));
+
+  SdpaAttr sdpaAttr;
+  sdpaAttr.setName("sdpa")
+      .setDropout(0.0f)
+      .setIsCausal(false)
+      .setScale(std::nullopt)
+      .setEnableGqa(false);
+
+  auto oT = graph->sdpa(qT, kT, vT, /*mask=*/nullptr, sdpaAttr);
+  oT->setDynamicDims({2}).setOutput(true);
+
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  FUSILLI_REQUIRE_OK(graph->validate());
+  FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
+
+  for (int64_t runtimeSeqLen : runtimeSeqLens) {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Running runtimeSeqLen=" << runtimeSeqLen);
+
+    std::vector<int64_t> runtimeDims = {batch, heads, runtimeSeqLen, headDim};
+    size_t runtimeSize =
+        static_cast<size_t>(batch * heads * runtimeSeqLen * headDim);
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto qRawBuf,
+        Buffer::allocate(handle, castToSizeT(runtimeDims),
+                         std::vector<half>(runtimeSize, half(0.01f))));
+    auto qBuf = std::make_shared<Buffer>(std::move(qRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto kRawBuf,
+        Buffer::allocate(handle, castToSizeT(runtimeDims),
+                         std::vector<half>(runtimeSize, half(0.01f))));
+    auto kBuf = std::make_shared<Buffer>(std::move(kRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto vRawBuf,
+        Buffer::allocate(handle, castToSizeT(runtimeDims),
+                         std::vector<half>(runtimeSize, half(0.01f))));
+    auto vBuf = std::make_shared<Buffer>(std::move(vRawBuf));
+
+    FUSILLI_REQUIRE_ASSIGN(
+        auto oRawBuf,
+        Buffer::allocate(handle, castToSizeT(runtimeDims),
+                         std::vector<half>(runtimeSize, half(0.0f))));
+    auto oBuf = std::make_shared<Buffer>(std::move(oRawBuf));
+
+    const std::unordered_map<std::shared_ptr<TensorAttr>,
+                             std::shared_ptr<Buffer>>
+        variantPack = {{qT, qBuf}, {kT, kBuf}, {vT, vBuf}, {oT, oBuf}};
+
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    FUSILLI_REQUIRE_ASSIGN(auto workspace,
+                           allocateWorkspace(handle, workspaceSize));
+
+    FUSILLI_REQUIRE_OK(graph->execute(handle, variantPack, workspace));
+
+    std::vector<half> result;
+    FUSILLI_REQUIRE_OK(oBuf->read(handle, result));
+    REQUIRE(result.size() == runtimeSize);
+    for (auto val : result)
+      REQUIRE(std::abs(static_cast<float>(val) - 0.01f) < 1e-2f);
+  }
+}

--- a/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
+++ b/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
@@ -96,7 +96,8 @@ TEST_CASE("Dynamic sequence basic SDPA f16", "[dynamic][sdpa][graph]") {
                              std::shared_ptr<Buffer>>
         variantPack = {{qT, qBuf}, {kT, kBuf}, {vT, vBuf}, {oT, oBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
+                           graph->getWorkspaceSizeOrError());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,6 +215,7 @@ add_fusilli_lit_tests(
     lit/test_custom_op_asm_emitter_sdpa.cpp
     lit/test_custom_op_asm_emitter_static.cpp
     lit/test_custom_op_asm_emitter_dim_placeholder.cpp
+    lit/test_custom_op_asm_emitter_dynamic_type.cpp
     lit/test_sdpa_asm_emitter_basic_mha.cpp
     lit/test_sdpa_asm_emitter_causal.cpp
     lit/test_sdpa_asm_emitter_with_mask.cpp

--- a/tests/lit/test_asm_emitter.cpp
+++ b/tests/lit/test_asm_emitter.cpp
@@ -91,6 +91,35 @@ static void testGetTensorTypeAsm() {
   std::cout << scalar.getTensorTypeAsm(/*isValueTensor=*/true,
                                        /*useLogicalDims=*/true)
             << std::endl;
+
+  TensorAttr dynamic;
+  dynamic.setName("dynamic")
+      .setDataType(DataType::Float)
+      .setDim({2, 3, 4})
+      .setStride({12, 1, 3})
+      .setDynamicDims({1});
+
+  // Physical dims follow the stride-derived layout while dynamic annotations
+  // follow the original logical dimension through that permutation.
+  // CHECK:  !torch.vtensor<[2,4,?],f32>
+  std::cout << dynamic.getTensorTypeAsm(/*isValueTensor=*/true,
+                                        /*useLogicalDims=*/false)
+            << std::endl;
+
+  // CHECK:  !torch.tensor<[2,4,?],f32>
+  std::cout << dynamic.getTensorTypeAsm(/*isValueTensor=*/false,
+                                        /*useLogicalDims=*/false)
+            << std::endl;
+
+  // CHECK:  !torch.vtensor<[2,?,4],f32>
+  std::cout << dynamic.getTensorTypeAsm(/*isValueTensor=*/true,
+                                        /*useLogicalDims=*/true)
+            << std::endl;
+
+  // CHECK:  !torch.tensor<[2,?,4],f32>
+  std::cout << dynamic.getTensorTypeAsm(/*isValueTensor=*/false,
+                                        /*useLogicalDims=*/true)
+            << std::endl;
 }
 
 static void testGetValueNameAsm() {

--- a/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
@@ -11,14 +11,14 @@
 //
 // CHECK:       module @module {
 // CHECK:         func.func private @my_add(
-// CHECK-NEXT:      %arg0: !torch.vtensor<[4,8],f32>,
-// CHECK-NEXT:      %arg1: !torch.vtensor<[4,8],f32>)
-// CHECK-NEXT:      -> !torch.vtensor<[4,8],f32> {
+// CHECK-NEXT:      %arg0: !torch.vtensor<[?,8],f32>,
+// CHECK-NEXT:      %arg1: !torch.vtensor<[?,8],f32>)
+// CHECK-NEXT:      -> !torch.vtensor<[?,8],f32> {
 // CHECK:           %int1 = torch.constant.int 1
 // CHECK:           %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
-// CHECK:               !torch.vtensor<[4,8],f32>
-// CHECK:               -> !torch.vtensor<[4,8],f32>
-// CHECK:           return %0 : !torch.vtensor<[4,8],f32>
+// CHECK:               !torch.vtensor<[?,8],f32>
+// CHECK:               -> !torch.vtensor<[?,8],f32>
+// CHECK:           return %0 : !torch.vtensor<[?,8],f32>
 // CHECK:         }
 // CHECK:         func.func @main(
 // CHECK:           func.call @my_add
@@ -42,16 +42,22 @@ int main() {
   g.setName("custom_op_asm_emitter_dim_placeholder")
       .setIODataType(DataType::Float);
 
-  auto a = g.tensor(
-      TensorAttr().setName("a").setDim({4, 8}).setStride({8, 1}).setDataType(
-          DataType::Float));
-  auto b = g.tensor(
-      TensorAttr().setName("b").setDim({4, 8}).setStride({8, 1}).setDataType(
-          DataType::Float));
+  auto a = g.tensor(TensorAttr()
+                        .setName("a")
+                        .setDim({4, 8})
+                        .setStride({8, 1})
+                        .setDynamicDims({0})
+                        .setDataType(DataType::Float));
+  auto b = g.tensor(TensorAttr()
+                        .setName("b")
+                        .setDim({4, 8})
+                        .setStride({8, 1})
+                        .setDynamicDims({0})
+                        .setDataType(DataType::Float));
 
   // Composes tensor types from individual {IN0_DIM0}/{IN0_DIM1} placeholders
-  // instead of using {IN0_TYPE}.  Shows that users can build type strings
-  // from dimension values when they need custom type compositions.
+  // instead of using {IN0_TYPE}. Shows that dimension placeholders are
+  // dynamic-aware when users need custom type compositions.
   std::string addMlir = R"(
   func.func private @{FUNC_NAME}(
       %arg0: !torch.vtensor<[{IN0_DIM0},{IN0_DIM1}],{IN0_DTYPE}>,
@@ -73,6 +79,7 @@ int main() {
   outs[0]
       ->setDim({4, 8})
       .setStride({8, 1})
+      .setDynamicDims({0})
       .setDataType(DataType::Float)
       .setOutput(true);
 

--- a/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
+// RUN: %{TEST_EXE} | FileCheck %s
+
+// clang-format off
+//
+// CHECK:       module @module {
+// CHECK:         func.func private @my_dynamic_add(%arg0: !torch.vtensor<[?,8],f32>,
+// CHECK:                                            %arg1: !torch.vtensor<[?,8],f32>)
+// CHECK:                                            -> !torch.vtensor<[?,8],f32> {
+// CHECK:           %int1 = torch.constant.int 1
+// CHECK:           %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+// CHECK:               : !torch.vtensor<[?,8],f32>, !torch.vtensor<[?,8],f32>, !torch.int
+// CHECK:               -> !torch.vtensor<[?,8],f32>
+// CHECK:           return %0 : !torch.vtensor<[?,8],f32>
+// CHECK:         }
+// CHECK:         func.func @main(
+// CHECK-SAME:      %my_dynamic_add_OUT_0_: !torch.tensor<[?,8],f32>
+// CHECK-SAME:      %a: !torch.vtensor<[?,8],f32>
+// CHECK-SAME:      %b: !torch.vtensor<[?,8],f32>
+// CHECK:           %my_dynamic_add_OUT_0_my_dynamic_add_perm = func.call @my_dynamic_add(%a_my_dynamic_add_i0_perm, %b_my_dynamic_add_i1_perm) : (!torch.vtensor<[?,8],f32>, !torch.vtensor<[?,8],f32>) -> !torch.vtensor<[?,8],f32>
+// CHECK:           torch.overwrite.tensor.contents %my_dynamic_add_OUT_0 overwrites %my_dynamic_add_OUT_0_ : !torch.vtensor<[?,8],f32>, !torch.tensor<[?,8],f32>
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+//
+// clang-format on
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+using namespace fusilli;
+
+int main() {
+  Graph g;
+  g.setName("custom_op_asm_emitter_dynamic_type")
+      .setIODataType(DataType::Float);
+
+  auto a = g.tensor(TensorAttr()
+                        .setName("a")
+                        .setDim({4, 8})
+                        .setStride({8, 1})
+                        .setDynamicDims({0})
+                        .setDataType(DataType::Float));
+  auto b = g.tensor(TensorAttr()
+                        .setName("b")
+                        .setDim({4, 8})
+                        .setStride({8, 1})
+                        .setDynamicDims({0})
+                        .setDataType(DataType::Float));
+
+  std::string addMlir = R"(
+  func.func private @{FUNC_NAME}(%arg0: {IN0_TYPE},
+                                   %arg1: {IN1_TYPE})
+                                   -> {OUT0_TYPE} {
+    %int1 = torch.constant.int 1
+    %0 = torch.aten.add.Tensor %arg0, %arg1, %int1
+        : {IN0_TYPE}, {IN1_TYPE}, !torch.int
+        -> {OUT0_TYPE}
+    return %0 : {OUT0_TYPE}
+  }
+)";
+
+  CustomOpAttr addAttr;
+  addAttr.setName("my_dynamic_add").setMlir(addMlir).setNumOutputs(1);
+
+  auto outs = g.customOp({a, b}, addAttr);
+  outs[0]
+      ->setDim({4, 8})
+      .setStride({8, 1})
+      .setDynamicDims({0})
+      .setDataType(DataType::Float)
+      .setOutput(true);
+
+  auto status = g.validate();
+  if (isError(status)) {
+    std::cerr << "Validation failed: " << status << std::endl;
+    return 1;
+  }
+
+  auto asmOrErr = g.emitAsm();
+  if (isError(asmOrErr)) {
+    std::cerr << "ASM emission failed: " << asmOrErr << std::endl;
+    return 1;
+  }
+
+  auto indentErr = checkMlirIndentation(*asmOrErr);
+  if (isError(indentErr)) {
+    std::cerr << "Indentation check failed: " << indentErr << std::endl;
+    return 1;
+  }
+
+  std::cout << *asmOrErr << std::endl;
+  return 0;
+}

--- a/tests/test_tensor_attributes.cpp
+++ b/tests/test_tensor_attributes.cpp
@@ -76,6 +76,76 @@ TEST_CASE("TensorAttr setter templated overrides", "[TensorAttr]") {
   REQUIRE(t.getStride() == strideVec);
 }
 
+TEST_CASE("TensorAttr dynamic dimension metadata", "[TensorAttr]") {
+  SECTION("Dynamic dimension indices are canonicalized") {
+    TensorAttr t;
+    auto &result = t.setName("dynamic")
+                       .setDataType(DataType::Float)
+                       .setDim({2, 3, 4})
+                       .setStride({12, 4, 1})
+                       .setDynamicDims({2, 0, 2})
+                       .setDynamicDim(1);
+
+    REQUIRE(&result == &t);
+    REQUIRE(t.hasDynamicDims());
+    REQUIRE(t.getDynamicDims() == std::vector<size_t>{0, 1, 2});
+    REQUIRE(t.isDynamicDim(0));
+    REQUIRE(t.isDynamicDim(1));
+    REQUIRE(t.isDynamicDim(2));
+    REQUIRE_FALSE(t.isDynamicDim(3));
+    FUSILLI_REQUIRE_OK(t.validate());
+  }
+
+  SECTION("Dynamic dimensions can be set from an initializer list") {
+    TensorAttr t;
+    auto &result = t.setDynamicDims({2, 0, 2});
+
+    REQUIRE(&result == &t);
+    REQUIRE(t.hasDynamicDims());
+    REQUIRE(t.getDynamicDims() == std::vector<size_t>{0, 2});
+    REQUIRE(t.isDynamicDim(0));
+    REQUIRE_FALSE(t.isDynamicDim(1));
+    REQUIRE(t.isDynamicDim(2));
+  }
+
+  SECTION("Dynamic dimensions can be set from a span") {
+    TensorAttr t;
+    std::vector<size_t> dynamicDims = {3, 1, 3};
+    std::span<const size_t> dynamicSpan(dynamicDims.data(), dynamicDims.size());
+
+    t.setDynamicDims(dynamicSpan);
+
+    REQUIRE(t.hasDynamicDims());
+    REQUIRE(t.getDynamicDims() == std::vector<size_t>{1, 3});
+  }
+
+  SECTION("Dynamic dimensions can be cleared") {
+    TensorAttr t;
+    auto &result = t.setDynamicDims({0, 1}).clearDynamicDims();
+
+    REQUIRE(&result == &t);
+    REQUIRE_FALSE(t.hasDynamicDims());
+    REQUIRE(t.getDynamicDims().empty());
+    REQUIRE_FALSE(t.isDynamicDim(0));
+  }
+
+  SECTION("Out-of-range dynamic dimension fails validation") {
+    TensorAttr t;
+    t.setName("bad_dynamic")
+        .setDataType(DataType::Float)
+        .setDim({2, 3})
+        .setStride({3, 1})
+        .setDynamicDim(2);
+
+    auto status = t.validate();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "Tensor 'bad_dynamic' has dynamic dim index 2 out of range for "
+            "rank 2");
+  }
+}
+
 TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {
   SECTION("Unspecified dim fails validation") {
     TensorAttr t;
@@ -694,6 +764,51 @@ TEST_CASE("TensorAttr validate with broadcast strides", "[TensorAttr]") {
       .setDim({8, 2, 16, 128})
       .setStride({0, 0, 1, 16});
   FUSILLI_REQUIRE_OK(t.validate());
+
+  // Invalid: broadcast expansion is currently emitted with a static expand
+  // size list, so dynamic dims on broadcast-stride tensors are unsupported.
+  t.setName("dynamic_broadcast")
+      .setDataType(DataType::Float)
+      .setDim({4, 8})
+      .setStride({0, 1})
+      .setDynamicDims({0});
+
+  auto status = t.validate();
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+  REQUIRE(status.getMessage() ==
+          "Tensor 'dynamic_broadcast' has dynamic dim at index 0 with stride "
+          "0 (broadcast stride), which is not supported");
+
+  // Invalid: a representative unit dimension with stride 0 can become a
+  // runtime broadcast if that dimension is dynamic.
+  t.setName("dynamic_unit_zero_stride")
+      .setDataType(DataType::Float)
+      .setDim({1, 8})
+      .setStride({0, 1})
+      .setDynamicDims({0});
+
+  status = t.validate();
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+  REQUIRE(status.getMessage() ==
+          "Tensor 'dynamic_unit_zero_stride' has dynamic dim at index 0 with "
+          "stride 0 (broadcast stride), which is not supported");
+
+  // Invalid: even when the dynamic dimension is not the zero-stride axis,
+  // broadcast expansion still needs runtime expand sizes.
+  t.setName("dynamic_on_broadcast_stride_tensor")
+      .setDataType(DataType::Float)
+      .setDim({4, 8})
+      .setStride({0, 1})
+      .setDynamicDims({1});
+
+  status = t.validate();
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+  REQUIRE(status.getMessage() ==
+          "Tensor 'dynamic_on_broadcast_stride_tensor' has dynamic dimensions "
+          "on a tensor with broadcast strides, which is not supported");
 }
 
 TEST_CASE("Stride order utils", "[TensorAttr utils]") {

--- a/tests/test_tensor_attributes.cpp
+++ b/tests/test_tensor_attributes.cpp
@@ -144,6 +144,22 @@ TEST_CASE("TensorAttr dynamic dimension metadata", "[TensorAttr]") {
             "Tensor 'bad_dynamic' has dynamic dim index 2 out of range for "
             "rank 2");
   }
+
+  SECTION("Representative unit dynamic dimension fails validation") {
+    TensorAttr t;
+    t.setName("unit_dynamic")
+        .setDataType(DataType::Float)
+        .setDim({1, 8})
+        .setStride({8, 1})
+        .setDynamicDim(0);
+
+    auto status = t.validate();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "Tensor 'unit_dynamic' has dynamic dim at index 0 with "
+            "representative size 1, which is not supported");
+  }
 }
 
 TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {


### PR DESCRIPTION
This is the second dynamic-shapes slice. It enables Fusilli graphs to keep representative static extents in `TensorAttr` while emitting annotated dimensions as dynamic (`?`) in Torch MLIR types, which lets IREE compile and run zero-transient/single-dispatch dynamic-shape graphs.

This PR covers:
- per-dimension dynamic-dim metadata on `TensorAttr`
- Torch MLIR type emission for dynamic tensor and vtensor dims
- custom-op placeholder type emission with dynamic tensor dims
- end-to-end dynamic batch sample coverage for zero-workspace convolution
- an expected-failure MIN/MAX reduction sample documenting the current dynamic-workspace limitation

Scope and follow-up:
- Working path: single-dispatch / zero transient workspace cases. This has been tested with batch dynamism on convolution-style cases.
- Follow-up: dynamic transient workspace size support for multiple-dispatch cases. Those modules expose `iree.abi.transients.size` and require invoking the runtime size function before execution.

---

Co-authored-by: GPT 5.5 <codex@openai.com>

Generated with [Codex](https://openai.com/codex)
