### PR TITLE
Enable BatchNorm training tests

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -87,9 +87,8 @@ add_fusilli_samples(
     batchnorm/batchnorm_infer_nchw.cpp
     batchnorm/batchnorm_infer_nchw_scale_bias.cpp
     batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
-    # TODO(iree-org/iree#24008): batchnorm training fails to distribute.
-    # batchnorm/batchnorm_train_nchw.cpp
-    # batchnorm/batchnorm_train_nchw_scale_bias.cpp
+    batchnorm/batchnorm_train_nchw.cpp
+    batchnorm/batchnorm_train_nchw_scale_bias.cpp
   DEPS
     libfusilli
     libutils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,8 +195,7 @@ add_fusilli_lit_tests(
     lit/test_conv_dgrad_asm_emitter_nhwc_kcrs.cpp
     lit/test_conv_dgrad_asm_emitter_nhwc_kcrs_grouped.cpp
     lit/test_batchnorm_infer_asm_emitter_nchw.cpp
-    # TODO(iree-org/iree#24008): batchnorm training fails to distribute.
-    # lit/test_batchnorm_train_asm_emitter_nchw.cpp
+    lit/test_batchnorm_train_asm_emitter_nchw.cpp
     lit/test_layernorm_infer_asm_emitter_nchw.cpp
     lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc.cpp
     lit/test_layernorm_infer_asm_emitter_scale_bias_nhwc_small_batch.cpp

--- a/tests/lit/test_batchnorm_train_asm_emitter_nchw.cpp
+++ b/tests/lit/test_batchnorm_train_asm_emitter_nchw.cpp
@@ -32,7 +32,7 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 6
+// AMDGPU-STATS-CHECK: "dispatch-count": 1
 // CPU-STATS-CHECK: "transient-memory-size": 0
 // CPU-STATS-CHECK: "dispatch-count": 4
 //


### PR DESCRIPTION
Re-enables BatchNorm training sample and lit coverage now that iree-org/iree#24008 is fixed.

Updates the BatchNorm training lit stats check to match the current AMDGPU compiler output, which now lowers this case to a single dispatch.