### PR TITLE
Mark SDPA custom scale sample XFAIL

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -176,3 +176,9 @@ add_fusilli_samples(
     libsdpautils
     Catch2::Catch2WithMain
 )
+
+# XFAIL: TODO(#404): Remove once the compiler supports non-default SDPA scales.
+set_tests_properties(
+  fusilli_sdpa_custom_op_samples_sdpa_fprop_custom_scale
+  fusilli_sdpa_samples_sdpa_fprop_custom_scale
+  PROPERTIES WILL_FAIL TRUE)

--- a/samples/custom_op/sdpa/sdpa_fprop_custom_scale.cpp
+++ b/samples/custom_op/sdpa/sdpa_fprop_custom_scale.cpp
@@ -16,5 +16,5 @@ TEST_CASE("SDPA forward: custom scale f16", "[sdpa][custom_op][graph]") {
   executeSdpaCustomOp(handle, DataType::Half,
                       /*batch=*/1, /*headsQ=*/8, /*headsK=*/8, /*headsV=*/8,
                       /*seqQ=*/64, /*seqKV=*/64, /*headDim=*/64,
-                      /*isCausal=*/false, /*scale=*/0.125f);
+                      /*isCausal=*/false, /*scale=*/0.05f);
 }

--- a/samples/sdpa/sdpa_fprop_custom_scale.cpp
+++ b/samples/sdpa/sdpa_fprop_custom_scale.cpp
@@ -16,5 +16,5 @@ TEST_CASE("SDPA forward: custom scale f16", "[sdpa][graph]") {
   executeSdpa(handle, DataType::Half,
               /*batch=*/1, /*headsQ=*/8, /*headsK=*/8, /*headsV=*/8,
               /*seqQ=*/64, /*seqKV=*/64, /*headDim=*/64,
-              /*isCausal=*/false, /*scale=*/0.125f);
+              /*isCausal=*/false, /*scale=*/0.05f);
 }

--- a/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// XFAIL: *
+// TODO(iree-org/fusilli#404): Remove XFAIL once IREE supports non-default SDPA
+// scale values.
 // RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
 // RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
@@ -33,7 +36,7 @@
 // TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
 // TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
 // TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %scale_sdpa = torch.constant.float 1.250000e-01
+// TORCH-CHECK:       %scale_sdpa = torch.constant.float 5.000000e-02
 // TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
@@ -84,7 +87,7 @@ static ErrorObject testSdpaAsmEmitterCustomScale(const std::string &mode) {
       TensorAttr().setName("v").setDim(dim).setStride(stride).setDataType(
           DataType::Half));
 
-  auto sdpaAttr = SdpaAttr().setName("sdpa").setScale(0.125f);
+  auto sdpaAttr = SdpaAttr().setName("sdpa").setScale(0.05f);
   auto o = graph->sdpa(q, k, v, /*mask=*/nullptr, sdpaAttr);
   o->setDim(dim).setStride(stride).setDataType(DataType::Half).setOutput(true);
 


### PR DESCRIPTION
Marks both SDPA custom-scale samples as expected failures while compiler support for non-default scales is still pending, keeping coverage present without breaking CI.

Updates the custom-scale lit test to use the same non-default scale and marks it XFAIL so the unsupported compiler path is recorded until IREE legalization support lands.


Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)