### PR TITLE
[WIP] [fusilli] Emit flex_attention for SDPA

### DIFF
--- a/include/fusilli/attributes/sdpa_attributes.h
+++ b/include/fusilli/attributes/sdpa_attributes.h
@@ -28,7 +28,7 @@ class SdpaAttr : public AttributesCRTP<SdpaAttr> {
 public:
   // Names for Tensor Inputs and Outputs.
   enum class InputNames : uint8_t { Q, K, V, MASK };
-  enum class OutputNames : uint8_t { O };
+  enum class OutputNames : uint8_t { O, STATS };
 
   std::unordered_map<InputNames, std::shared_ptr<TensorAttr>> inputs;
   std::unordered_map<OutputNames, std::shared_ptr<TensorAttr>> outputs;
@@ -39,6 +39,7 @@ public:
   FUSILLI_GENERIC_INPUT_TENSOR_SETTER(SdpaAttr, InputNames, V)
   FUSILLI_GENERIC_INPUT_TENSOR_SETTER(SdpaAttr, InputNames, MASK)
   FUSILLI_GENERIC_OUTPUT_TENSOR_SETTER(SdpaAttr, OutputNames, O)
+  FUSILLI_GENERIC_OUTPUT_TENSOR_SETTER(SdpaAttr, OutputNames, STATS)
 
   // Tensor getters:
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, Q)
@@ -46,6 +47,7 @@ public:
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, V)
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, MASK)
   FUSILLI_GENERIC_OUTPUT_TENSOR_GETTER(OutputNames, O)
+  FUSILLI_GENERIC_OUTPUT_TENSOR_GETTER(OutputNames, STATS)
 
   // Scalar attribute setters:
   SdpaAttr &setDropout(float p) {
@@ -68,17 +70,24 @@ public:
     return *this;
   }
 
+  SdpaAttr &setGenerateStats(bool v) {
+    generateStats_ = v;
+    return *this;
+  }
+
   // Scalar attribute getters:
   float getDropout() const { return dropout_; }
   bool getIsCausal() const { return isCausal_; }
   std::optional<float> getScale() const { return scale_; }
   bool getEnableGqa() const { return enableGqa_; }
+  bool getGenerateStats() const { return generateStats_; }
 
 private:
   float dropout_ = 0.0f;
   bool isCausal_ = false;
   std::optional<float> scale_ = std::nullopt;
   bool enableGqa_ = false;
+  bool generateStats_ = false;
 };
 
 } // namespace fusilli

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -1049,10 +1049,17 @@ Graph::sdpa(const std::shared_ptr<TensorAttr> &q,
   // Set outputs.
   auto o = outputTensor(sdpaAttr.getName() + "_O");
   sdpaAttr.setO(o);
+  if (sdpaAttr.getGenerateStats() && !sdpaAttr.getSTATS()) {
+    auto stats = outputTensor(sdpaAttr.getName() + "_STATS");
+    stats->setDataType(DataType::Float);
+    sdpaAttr.setSTATS(stats);
+  }
 
-  // Create node and add to Graph's subNodes_.
+  // Keep sdpaAttr populated for callers: Graph::sdpa returns O, and the
+  // generate_stats STATS tensor is exposed through sdpaAttr.
+  SdpaAttr nodeAttr = sdpaAttr;
   subNodes_.emplace_back(
-      std::make_unique<SdpaNode>(std::move(sdpaAttr), context));
+      std::make_unique<SdpaNode>(std::move(nodeAttr), context));
 
   return o;
 }

--- a/include/fusilli/node/sdpa_node.h
+++ b/include/fusilli/node/sdpa_node.h
@@ -41,15 +41,23 @@ public:
       : NodeCRTP(ctx), sdpaAttr(std::move(attr)) {}
 
   // ASM emitter methods.
+  std::string emitModuleScopeAsm() const override final;
   std::string emitNodePreAsm() const override final;
   std::string getOperandNamesAsm() const;
   std::string getOperandTypesAsm() const;
+  std::string getFlexAttnOperandNamesAsm() const;
+  std::string getFlexAttnOperandTypesAsm() const;
   std::string getResultNamesAsm() const;
   std::string getResultTypesAsm() const;
+  std::string getFlexAttnResultNamesAsm() const;
+  std::string getFlexAttnResultTypesAsm() const;
   std::string getDropoutOpsAsm() const;
   std::string getIsCausalOpsAsm() const;
   std::string getScaleOpsAsm() const;
   std::string getEnableGqaOpsAsm() const;
+  std::string getReturnLseOpsAsm() const;
+  std::string getReturnMaxScoresOpsAsm() const;
+  std::string getCausalMaskFnNameAsm() const;
 
   const std::string &getName() const override final {
     return sdpaAttr.getName();
@@ -64,6 +72,7 @@ public:
     std::shared_ptr<TensorAttr> kT = sdpaAttr.getK();
     std::shared_ptr<TensorAttr> vT = sdpaAttr.getV();
     std::shared_ptr<TensorAttr> oT = sdpaAttr.getO();
+    std::shared_ptr<TensorAttr> statsT = sdpaAttr.getSTATS();
     std::shared_ptr<TensorAttr> maskT = sdpaAttr.getMASK();
 
     // Ensure mandatory input and output tensors are set.
@@ -75,6 +84,16 @@ public:
                             "SDPA input tensor V not set");
     FUSILLI_RETURN_ERROR_IF(!oT, ErrorCode::AttributeNotSet,
                             "SDPA output tensor O not set");
+    if (sdpaAttr.getGenerateStats()) {
+      FUSILLI_RETURN_ERROR_IF(
+          !statsT, ErrorCode::AttributeNotSet,
+          "SDPA output tensor STATS not set when generate_stats is enabled");
+    } else {
+      FUSILLI_RETURN_ERROR_IF(
+          statsT, ErrorCode::InvalidAttribute,
+          "SDPA output tensor STATS should not be set when generate_stats is "
+          "disabled");
+    }
 
     // Rank checks: all tensors must be rank 4.
     constexpr size_t kRequiredRank = 4;
@@ -192,6 +211,7 @@ public:
     std::shared_ptr<TensorAttr> qT = sdpaAttr.getQ();
     std::shared_ptr<TensorAttr> vT = sdpaAttr.getV();
     std::shared_ptr<TensorAttr> oT = sdpaAttr.getO();
+    std::shared_ptr<TensorAttr> statsT = sdpaAttr.getSTATS();
 
     const std::vector<int64_t> &qDim = qT->getDim();
     const std::vector<int64_t> &vDim = vT->getDim();
@@ -209,6 +229,18 @@ public:
           generateStrideFromDim(oDim, getContiguousStrideOrder(oDim.size())));
     }
 
+    if (statsT) {
+      std::vector<int64_t> statsDim = {qDim[0], qDim[1], qDim[2]};
+      if (statsT->getDim().empty())
+        statsT->setDim(statsDim);
+      if (statsT->getStride().empty()) {
+        statsT->setStride(generateStrideFromDim(
+            statsDim, getContiguousStrideOrder(statsDim.size())));
+      }
+      if (statsT->getDataType() == DataType::NotSet)
+        statsT->setDataType(DataType::Float);
+    }
+
     return ok();
   }
 
@@ -219,6 +251,7 @@ public:
     std::shared_ptr<TensorAttr> qT = sdpaAttr.getQ();
     std::shared_ptr<TensorAttr> vT = sdpaAttr.getV();
     std::shared_ptr<TensorAttr> oT = sdpaAttr.getO();
+    std::shared_ptr<TensorAttr> statsT = sdpaAttr.getSTATS();
 
     const std::vector<int64_t> &qDim = qT->getDim();
     const std::vector<int64_t> &vDim = vT->getDim();
@@ -230,6 +263,17 @@ public:
         oT->getDim() != expectedDim, ErrorCode::InvalidAttribute,
         "SDPA output tensor O dimensions do not match expected shape "
         "[batch, headsQ, seqQ, headDim]");
+
+    if (sdpaAttr.getGenerateStats()) {
+      std::vector<int64_t> expectedStatsDim = {qDim[0], qDim[1], qDim[2]};
+      FUSILLI_RETURN_ERROR_IF(
+          statsT->getDim() != expectedStatsDim, ErrorCode::InvalidAttribute,
+          "SDPA output tensor STATS dimensions do not match expected shape "
+          "[batch, headsQ, seqQ]");
+      FUSILLI_RETURN_ERROR_IF(
+          statsT->getDataType() != DataType::Float, ErrorCode::InvalidAttribute,
+          "SDPA output tensor STATS must have Float data type");
+    }
 
     return ok();
   }

--- a/include/fusilli/node/sdpa_node.h
+++ b/include/fusilli/node/sdpa_node.h
@@ -58,6 +58,7 @@ public:
   std::string getReturnLseOpsAsm() const;
   std::string getReturnMaxScoresOpsAsm() const;
   std::string getCausalMaskFnNameAsm() const;
+  bool useLegacySdpaAsm() const;
 
   const std::string &getName() const override final {
     return sdpaAttr.getName();

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2478,12 +2478,7 @@ inline bool SdpaNode::useLegacySdpaAsm() const {
   if (sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f)
     return true;
 
-  // The legacy SDPA op does not produce logsumexp, so keep generate_stats on
-  // flex_attention even when extra attributes are present.
-  if (sdpaAttr.getGenerateStats())
-    return false;
-
-  return sdpaAttr.getScale().has_value();
+  return false;
 }
 
 inline std::string SdpaNode::emitModuleScopeAsm() const {

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2466,11 +2466,30 @@ inline std::string SdpaNode::getCausalMaskFnNameAsm() const {
   return "sdpa_mask_" + suffix;
 }
 
+inline bool SdpaNode::useLegacySdpaAsm() const {
+  auto hasDynamicDims = [](const std::shared_ptr<TensorAttr> &tensor) {
+    return tensor && tensor->hasDynamicDims();
+  };
+  bool hasDynamicTensor =
+      hasDynamicDims(sdpaAttr.getQ()) || hasDynamicDims(sdpaAttr.getK()) ||
+      hasDynamicDims(sdpaAttr.getV()) || hasDynamicDims(sdpaAttr.getO());
+
+  if (hasDynamicTensor || sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f)
+    return true;
+
+  // The legacy SDPA op does not produce logsumexp, so keep generate_stats on
+  // flex_attention even when extra attributes are present.
+  if (sdpaAttr.getGenerateStats())
+    return false;
+
+  return (sdpaAttr.getIsCausal() && !sdpaAttr.getEnableGqa()) ||
+         sdpaAttr.getScale().has_value();
+}
+
 inline std::string SdpaNode::emitModuleScopeAsm() const {
-  // Keep legacy lowering for tensor masks or dropout until those are
-  // representable through hop_flex_attention in this emitter.
-  if (!sdpaAttr.getIsCausal() || sdpaAttr.getMASK() ||
-      sdpaAttr.getDropout() != 0.0f)
+  // Causal SDPA needs a mask callback only when this node is emitted through
+  // torch.hop_flex_attention.
+  if (!sdpaAttr.getIsCausal() || useLegacySdpaAsm())
     return "";
 
   // torch.hop_flex_attention has no is_causal operand, so causal SDPA is
@@ -2491,8 +2510,7 @@ inline std::string SdpaNode::emitModuleScopeAsm() const {
 
 inline std::string SdpaNode::emitNodePreAsm() const {
   std::string suffix = sdpaAttr.getName();
-  const bool useLegacySdpa =
-      sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f;
+  const bool useLegacySdpa = useLegacySdpaAsm();
 
   // Permute inputs.
   std::string permuteQ = getLayoutConversionOpsAsm(sdpaAttr.getQ(), "permute_Q",

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2104,6 +2104,30 @@ inline std::string SdpaNode::getOperandTypesAsm() const {
   return oss.str();
 }
 
+// Emits torch.hop_flex_attention operand names in MLIR assembly format.
+inline std::string SdpaNode::getFlexAttnOperandNamesAsm() const {
+  std::string suffix = sdpaAttr.getName();
+  std::ostringstream oss;
+  oss << sdpaAttr.getQ()->getValueNameAsm() << "_" << suffix << "_perm, "
+      << sdpaAttr.getK()->getValueNameAsm() << "_" << suffix << "_perm, "
+      << sdpaAttr.getV()->getValueNameAsm() << "_" << suffix << "_perm";
+  return oss.str();
+}
+
+// Emits torch.hop_flex_attention operand types in MLIR assembly format.
+inline std::string SdpaNode::getFlexAttnOperandTypesAsm() const {
+  std::ostringstream oss;
+  oss << sdpaAttr.getQ()->getTensorTypeAsm(/*isValueTensor=*/true,
+                                           /*useLogicalDims=*/true)
+      << ", "
+      << sdpaAttr.getK()->getTensorTypeAsm(/*isValueTensor=*/true,
+                                           /*useLogicalDims=*/true)
+      << ", "
+      << sdpaAttr.getV()->getTensorTypeAsm(/*isValueTensor=*/true,
+                                           /*useLogicalDims=*/true);
+  return oss.str();
+}
+
 // Emits SdpaNode's result names in MLIR assembly format.
 inline std::string SdpaNode::getResultNamesAsm() const {
   return sdpaAttr.getO()->getValueNameAsm() + "_" + sdpaAttr.getName() +
@@ -2114,6 +2138,24 @@ inline std::string SdpaNode::getResultNamesAsm() const {
 inline std::string SdpaNode::getResultTypesAsm() const {
   return sdpaAttr.getO()->getTensorTypeAsm(/*isValueTensor=*/true,
                                            /*useLogicalDims=*/true);
+}
+
+// Emits SdpaNode's result names for torch.hop_flex_attention.
+inline std::string SdpaNode::getFlexAttnResultNamesAsm() const {
+  std::string suffix = sdpaAttr.getName();
+  return std::format("{}, %sdpa_logsumexp_{}, %sdpa_max_scores_{}",
+                     getResultNamesAsm(), suffix, suffix);
+}
+
+// Emits SdpaNode's result types for torch.hop_flex_attention.
+inline std::string SdpaNode::getFlexAttnResultTypesAsm() const {
+  const std::vector<int64_t> &qDim = sdpaAttr.getQ()->getDim();
+  std::vector<int64_t> auxDims = {qDim[0], qDim[1], qDim[2]};
+  std::string logsumexpType = sdpaAttr.getGenerateStats()
+                                  ? buildTensorTypeStr(auxDims, DataType::Float)
+                                  : "!torch.none";
+  return std::format("{}, {}, {}", getResultTypesAsm(), logsumexpType,
+                     "!torch.none");
 }
 
 // Emits the dropout probability constant.
@@ -2140,8 +2182,51 @@ inline std::string SdpaNode::getEnableGqaOpsAsm() const {
                       sdpaAttr.getEnableGqa());
 }
 
+// Emits return_lse boolean constant for torch.hop_flex_attention.
+inline std::string SdpaNode::getReturnLseOpsAsm() const {
+  return torchBoolAsm("return_lse", sdpaAttr.getName(),
+                      sdpaAttr.getGenerateStats());
+}
+
+// Emits return_max_scores boolean constant for torch.hop_flex_attention.
+inline std::string SdpaNode::getReturnMaxScoresOpsAsm() const {
+  return torchBoolAsm("return_max_scores", sdpaAttr.getName(), /*value=*/false);
+}
+
+inline std::string SdpaNode::getCausalMaskFnNameAsm() const {
+  std::string suffix = sdpaAttr.getName();
+  if (suffix.empty())
+    suffix = "sdpa";
+  return "sdpa_mask_" + suffix;
+}
+
+inline std::string SdpaNode::emitModuleScopeAsm() const {
+  // Keep legacy lowering for tensor masks or dropout until those are
+  // representable through hop_flex_attention in this emitter.
+  if (!sdpaAttr.getIsCausal() || sdpaAttr.getMASK() ||
+      sdpaAttr.getDropout() != 0.0f)
+    return "";
+
+  // torch.hop_flex_attention has no is_causal operand, so causal SDPA is
+  // represented as the equivalent mask_mod callback.
+  constexpr std::string_view schema = R"(
+  func.func private @{0}(
+      %batch: !torch.vtensor<[],si32>,
+      %head: !torch.vtensor<[],si32>,
+      %token_q: !torch.vtensor<[],si32>,
+      %token_kv: !torch.vtensor<[],si32>)
+      -> !torch.vtensor<[],i1> {{
+    %mask = torch.aten.ge.Tensor %token_q, %token_kv : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+    return %mask : !torch.vtensor<[],i1>
+  }}
+)";
+  return std::format(schema, getCausalMaskFnNameAsm());
+}
+
 inline std::string SdpaNode::emitNodePreAsm() const {
   std::string suffix = sdpaAttr.getName();
+  const bool useLegacySdpa =
+      sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f;
 
   // Permute inputs.
   std::string permuteQ = getLayoutConversionOpsAsm(sdpaAttr.getQ(), "permute_Q",
@@ -2151,26 +2236,27 @@ inline std::string SdpaNode::emitNodePreAsm() const {
   std::string permuteV = getLayoutConversionOpsAsm(sdpaAttr.getV(), "permute_V",
                                                    suffix, /*isInput=*/true);
 
-  std::string mask;
-  if (sdpaAttr.getMASK())
-    mask = getLayoutConversionOpsAsm(sdpaAttr.getMASK(), "permute_mask", suffix,
-                                     /*isInput=*/true);
-  else
-    mask = torchNoneAsm("none_mask", suffix);
-
   // Permute output.
   std::string permuteO = getLayoutConversionOpsAsm(sdpaAttr.getO(), "permute_O",
                                                    suffix, /*isInput=*/false);
-
-  std::string operandNames = getOperandNamesAsm() + ", %dropout_" + suffix +
-                             ", %is_causal_" + suffix + ", %scale_" + suffix +
-                             ", %enable_gqa_" + suffix;
 
   // Scale type for the MLIR signature.
   std::string scaleType =
       sdpaAttr.getScale().has_value() ? "!torch.float" : "!torch.none";
 
-  constexpr std::string_view schema = R"(
+  if (useLegacySdpa) {
+    std::string legacyMask;
+    if (sdpaAttr.getMASK())
+      legacyMask = getLayoutConversionOpsAsm(sdpaAttr.getMASK(), "permute_mask",
+                                             suffix, /*isInput=*/true);
+    else
+      legacyMask = torchNoneAsm("none_mask", suffix);
+
+    std::string legacyOperandNames =
+        getOperandNamesAsm() + ", %dropout_" + suffix + ", %is_causal_" +
+        suffix + ", %scale_" + suffix + ", %enable_gqa_" + suffix;
+
+    constexpr std::string_view legacySchema = R"(
     {0}
     {1}
     {2}
@@ -2183,21 +2269,81 @@ inline std::string SdpaNode::emitNodePreAsm() const {
     {13}
   )";
 
-  return std::format(schema,
-                     permuteQ,             // {0}
-                     permuteK,             // {1}
-                     permuteV,             // {2}
-                     mask,                 // {3}
-                     getDropoutOpsAsm(),   // {4}
-                     getIsCausalOpsAsm(),  // {5}
-                     getScaleOpsAsm(),     // {6}
-                     getEnableGqaOpsAsm(), // {7}
-                     getResultNamesAsm(),  // {8}
-                     operandNames,         // {9}
-                     getOperandTypesAsm(), // {10}
-                     scaleType,            // {11}
-                     getResultTypesAsm(),  // {12}
-                     permuteO              // {13}
+    return std::format(legacySchema,
+                       permuteQ,             // {0}
+                       permuteK,             // {1}
+                       permuteV,             // {2}
+                       legacyMask,           // {3}
+                       getDropoutOpsAsm(),   // {4}
+                       getIsCausalOpsAsm(),  // {5}
+                       getScaleOpsAsm(),     // {6}
+                       getEnableGqaOpsAsm(), // {7}
+                       getResultNamesAsm(),  // {8}
+                       legacyOperandNames,   // {9}
+                       getOperandTypesAsm(), // {10}
+                       scaleType,            // {11}
+                       getResultTypesAsm(),  // {12}
+                       permuteO              // {13}
+    );
+  }
+
+  std::vector<std::string> flexAttnAttrs;
+  if (sdpaAttr.getIsCausal())
+    flexAttnAttrs.push_back(
+        std::format("mask_mod_fn = @{}", getCausalMaskFnNameAsm()));
+  if (sdpaAttr.getEnableGqa())
+    flexAttnAttrs.push_back("enable_gqa = true");
+
+  std::string opAttrs;
+  if (!flexAttnAttrs.empty()) {
+    std::ostringstream attrs;
+    attrs << " {";
+    interleave(
+        flexAttnAttrs.begin(), flexAttnAttrs.end(),
+        [&](const std::string &attr) { attrs << attr; },
+        [&] { attrs << ", "; });
+    attrs << "}";
+    opAttrs = attrs.str();
+  }
+
+  std::string flexAttnOperandNames = getFlexAttnOperandNamesAsm() +
+                                     ", %scale_" + suffix + ", %return_lse_" +
+                                     suffix + ", %return_max_scores_" + suffix;
+  std::string permuteStats;
+  if (sdpaAttr.getGenerateStats()) {
+    std::string logsumexpName = "%sdpa_logsumexp_" + suffix;
+    permuteStats =
+        getLayoutConversionOpsAsm(sdpaAttr.getSTATS(), "permute_STATS", suffix,
+                                  /*isInput=*/false, logsumexpName);
+  }
+
+  constexpr std::string_view flexAttnSchema = R"(
+    {0}
+    {1}
+    {2}
+    {3}
+    {4}
+    {5}
+    {6} = torch.hop_flex_attention {7}{8} : {9}, {10}, !torch.bool, !torch.bool -> {11}
+    {12}
+    {13}
+  )";
+
+  return std::format(flexAttnSchema,
+                     permuteQ,                     // {0}
+                     permuteK,                     // {1}
+                     permuteV,                     // {2}
+                     getScaleOpsAsm(),             // {3}
+                     getReturnLseOpsAsm(),         // {4}
+                     getReturnMaxScoresOpsAsm(),   // {5}
+                     getFlexAttnResultNamesAsm(),  // {6}
+                     flexAttnOperandNames,         // {7}
+                     opAttrs,                      // {8}
+                     getFlexAttnOperandTypesAsm(), // {9}
+                     scaleType,                    // {10}
+                     getFlexAttnResultTypesAsm(),  // {11}
+                     permuteO,                     // {12}
+                     permuteStats                  // {13}
   );
 }
 

--- a/include/fusilli/support/asm_emitter.h
+++ b/include/fusilli/support/asm_emitter.h
@@ -2474,7 +2474,8 @@ inline bool SdpaNode::useLegacySdpaAsm() const {
       hasDynamicDims(sdpaAttr.getQ()) || hasDynamicDims(sdpaAttr.getK()) ||
       hasDynamicDims(sdpaAttr.getV()) || hasDynamicDims(sdpaAttr.getO());
 
-  if (hasDynamicTensor || sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f)
+  (void)hasDynamicTensor;
+  if (sdpaAttr.getMASK() || sdpaAttr.getDropout() != 0.0f)
     return true;
 
   // The legacy SDPA op does not produce logsumexp, so keep generate_stats on
@@ -2482,8 +2483,7 @@ inline bool SdpaNode::useLegacySdpaAsm() const {
   if (sdpaAttr.getGenerateStats())
     return false;
 
-  return (sdpaAttr.getIsCausal() && !sdpaAttr.getEnableGqa()) ||
-         sdpaAttr.getScale().has_value();
+  return sdpaAttr.getScale().has_value();
 }
 
 inline std::string SdpaNode::emitModuleScopeAsm() const {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -159,6 +159,7 @@ add_fusilli_samples(
     sdpa/sdpa_fprop_gqa.cpp
     sdpa/sdpa_fprop_gqa_hk_ne_hv.cpp
     sdpa/sdpa_fprop_cross_attn.cpp
+    sdpa/sdpa_fprop_generate_stats.cpp
   DEPS
     libfusilli
     libutils

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -199,8 +199,7 @@ add_fusilli_samples(
     Catch2::Catch2WithMain
 )
 
-# XFAIL: TODO(#404): Remove once the compiler supports non-default SDPA scales.
+# XFAIL: TODO(#404): Remove once regular SDPA supports non-default scales.
 set_tests_properties(
-  fusilli_sdpa_custom_op_samples_sdpa_fprop_custom_scale
   fusilli_sdpa_samples_sdpa_fprop_custom_scale
   PROPERTIES WILL_FAIL TRUE)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -198,8 +198,3 @@ add_fusilli_samples(
     libsdpautils
     Catch2::Catch2WithMain
 )
-
-# XFAIL: TODO(#404): Remove once regular SDPA supports non-default scales.
-set_tests_properties(
-  fusilli_sdpa_samples_sdpa_fprop_custom_scale
-  PROPERTIES WILL_FAIL TRUE)

--- a/samples/sdpa/sdpa_fprop_generate_stats.cpp
+++ b/samples/sdpa/sdpa_fprop_generate_stats.cpp
@@ -1,0 +1,24 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "sdpa_utils.h"
+#include "utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <optional>
+
+TEST_CASE("SDPA forward: generate stats f16", "[sdpa][graph]") {
+  FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
+  executeSdpa(handle, DataType::Half,
+              /*batch=*/1, /*headsQ=*/8, /*headsK=*/8, /*headsV=*/8,
+              /*seqQ=*/64, /*seqKV=*/64, /*headDim=*/64,
+              /*isCausal=*/false, /*scale=*/std::nullopt,
+              /*enableGqa=*/false, /*hasAttnMask=*/false,
+              /*dropoutP=*/0.0f, /*generateStats=*/true);
+}

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -36,6 +36,13 @@ std::string buildSdpaMlir(bool hasAttnMask, float dropoutP, bool isCausal,
                         : "torch.constant.none";
   std::string scaleTypeStr = scale.has_value() ? "!torch.float" : "!torch.none";
   std::string enableGqaStr = enableGqa ? "true" : "false";
+  if (!hasAttnMask && dropoutP == 0.0f && !isCausal && scale.has_value()) {
+    std::string enableGqaAttr = enableGqa ? " {enable_gqa = true}" : "";
+    return std::vformat(kFlexSdpaNoMask,
+                        std::make_format_args(scaleConstStr,   // {0}
+                                              scaleTypeStr,    // {1}
+                                              enableGqaAttr)); // {2}
+  }
 
   return std::vformat(hasAttnMask ? kSdpaWithMask : kSdpaNoMask,
                       std::make_format_args(dropoutStr,    // {0} DROPOUT_P

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -101,6 +101,39 @@ std::vector<float> referenceSdpa(float qVal, float kVal, float vVal,
   return out;
 }
 
+std::vector<float> referenceSdpaLogsumexp(float qVal, float kVal, float maskVal,
+                                          int64_t batch, int64_t headsQ,
+                                          int64_t seqQ, int64_t seqKV,
+                                          int64_t headDim, bool isCausal,
+                                          std::optional<float> scale,
+                                          bool hasAttnMask) {
+  float s = scale.value_or(1.0f / std::sqrt(static_cast<float>(headDim)));
+  std::vector<float> out(batch * headsQ * seqQ);
+
+  for (int64_t b = 0; b < batch; ++b) {
+    for (int64_t hq = 0; hq < headsQ; ++hq) {
+      for (int64_t sq = 0; sq < seqQ; ++sq) {
+        std::vector<float> scores(seqKV);
+        for (int64_t sk = 0; sk < seqKV; ++sk) {
+          float dot = static_cast<float>(headDim) * qVal * kVal;
+          scores[sk] = dot * s;
+          if (hasAttnMask)
+            scores[sk] += maskVal;
+          if (isCausal && sk > sq)
+            scores[sk] = -std::numeric_limits<float>::infinity();
+        }
+
+        float maxScore = *std::max_element(scores.begin(), scores.end());
+        float sumExp = 0.0f;
+        for (float score : scores)
+          sumExp += std::exp(score - maxScore);
+        out[(b * headsQ + hq) * seqQ + sq] = std::log(sumExp) + maxScore;
+      }
+    }
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // Shared setup and verification helpers
 // ---------------------------------------------------------------------------
@@ -116,7 +149,7 @@ SdpaTestContext setupSdpaGraph(DataType dt, int64_t batch, int64_t headsQ,
                                int64_t headsK, int64_t headsV, int64_t seqQ,
                                int64_t seqKV, int64_t headDim, bool isCausal,
                                bool enableGqa, bool hasAttnMask, float dropoutP,
-                               std::optional<float> scale,
+                               bool generateStats, std::optional<float> scale,
                                std::string_view namePrefix) {
   REQUIRE(!(hasAttnMask && isCausal));
   if (enableGqa) {
@@ -137,13 +170,14 @@ SdpaTestContext setupSdpaGraph(DataType dt, int64_t batch, int64_t headsQ,
       scale.has_value() ? std::format("_scale{:g}", *scale) : "";
   std::string dropoutSuffix =
       dropoutP > 0.0f ? std::format("_dropout{:g}", dropoutP) : "";
+  std::string statsSuffix = generateStats ? "_stats" : "";
 
   auto graph = std::make_shared<Graph>();
   graph
-      ->setName(std::format("{}_b{}hq{}hk{}hv{}sq{}skv{}d{}{}{}{}{}{}",
+      ->setName(std::format("{}_b{}hq{}hk{}hv{}sq{}skv{}d{}{}{}{}{}{}{}",
                             namePrefix, batch, headsQ, headsK, headsV, seqQ,
                             seqKV, headDim, causalSuffix, maskSuffix, gqaSuffix,
-                            scaleSuffix, dropoutSuffix))
+                            scaleSuffix, dropoutSuffix, statsSuffix))
       .setIODataType(dt)
       .setIntermediateDataType(dt);
 
@@ -187,7 +221,8 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
                       int64_t headsV, int64_t seqQ, int64_t seqKV,
                       int64_t headDim, bool isCausal,
                       std::optional<float> scale, bool enableGqa,
-                      bool hasAttnMask, float dropoutP) {
+                      bool hasAttnMask, float dropoutP,
+                      const std::shared_ptr<TensorAttr> &statsT = nullptr) {
   FUSILLI_REQUIRE_OK(ctx.graph->validate());
   FUSILLI_REQUIRE_OK(ctx.graph->compile(handle, /*remove=*/true));
 
@@ -199,10 +234,17 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
                          allocateBufferOfType(handle, ctx.vT, dt, 0.01));
   FUSILLI_REQUIRE_ASSIGN(auto outBuf,
                          allocateBufferOfType(handle, oT, dt, 0.0));
+  std::shared_ptr<Buffer> statsBuf;
+  if (statsT) {
+    FUSILLI_REQUIRE_ASSIGN(
+        statsBuf, allocateBufferOfType(handle, statsT, DataType::Float, 0.0));
+  }
 
   std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {
           {ctx.qT, qBuf}, {ctx.kT, kBuf}, {ctx.vT, vBuf}, {oT, outBuf}};
+  if (statsT)
+    variantPack[statsT] = statsBuf;
 
   if (hasAttnMask) {
     FUSILLI_REQUIRE_ASSIGN(auto maskBuf,
@@ -243,6 +285,22 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
     INFO("index " << i << ": actual=" << actual << " expected=" << expected[i]);
     REQUIRE(std::abs(actual - expected[i]) < kTolerance);
   }
+
+  if (!statsT)
+    return;
+
+  std::vector<float> statsResult;
+  FUSILLI_REQUIRE_OK(statsBuf->read(handle, statsResult));
+  REQUIRE(statsResult.size() == static_cast<size_t>(batch * headsQ * seqQ));
+
+  auto expectedStats =
+      referenceSdpaLogsumexp(kInitQ, kInitK, kInitMask, batch, headsQ, seqQ,
+                             seqKV, headDim, isCausal, scale, hasAttnMask);
+  for (size_t i = 0; i < statsResult.size(); ++i) {
+    INFO("stats index " << i << ": actual=" << statsResult[i]
+                        << " expected=" << expectedStats[i]);
+    REQUIRE(std::abs(statsResult[i] - expectedStats[i]) < kTolerance);
+  }
 }
 
 } // namespace
@@ -254,24 +312,29 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
 void executeSdpa(Handle &handle, DataType dt, int64_t batch, int64_t headsQ,
                  int64_t headsK, int64_t headsV, int64_t seqQ, int64_t seqKV,
                  int64_t headDim, bool isCausal, std::optional<float> scale,
-                 bool enableGqa, bool hasAttnMask, float dropoutP) {
-  auto ctx =
-      setupSdpaGraph(dt, batch, headsQ, headsK, headsV, seqQ, seqKV, headDim,
-                     isCausal, enableGqa, hasAttnMask, dropoutP, scale, "sdpa");
+                 bool enableGqa, bool hasAttnMask, float dropoutP,
+                 bool generateStats) {
+  auto ctx = setupSdpaGraph(dt, batch, headsQ, headsK, headsV, seqQ, seqKV,
+                            headDim, isCausal, enableGqa, hasAttnMask, dropoutP,
+                            generateStats, scale, "sdpa");
 
   SdpaAttr sdpaAttr;
   sdpaAttr.setName("sdpa")
       .setDropout(dropoutP)
       .setIsCausal(isCausal)
       .setScale(scale)
-      .setEnableGqa(enableGqa);
+      .setEnableGqa(enableGqa)
+      .setGenerateStats(generateStats);
 
   auto oT = ctx.graph->sdpa(ctx.qT, ctx.kT, ctx.vT, ctx.maskT, sdpaAttr);
+  std::shared_ptr<TensorAttr> statsT = sdpaAttr.getSTATS();
   oT->setOutput(true);
+  if (generateStats)
+    statsT->setOutput(true);
 
   executeAndVerify(handle, ctx, oT, dt, batch, headsQ, headsK, headsV, seqQ,
                    seqKV, headDim, isCausal, scale, enableGqa, hasAttnMask,
-                   dropoutP);
+                   dropoutP, generateStats ? statsT : nullptr);
 }
 
 void executeSdpaCustomOp(Handle &handle, DataType dt, int64_t batch,
@@ -281,7 +344,7 @@ void executeSdpaCustomOp(Handle &handle, DataType dt, int64_t batch,
                          bool enableGqa, bool hasAttnMask, float dropoutP) {
   auto ctx = setupSdpaGraph(dt, batch, headsQ, headsK, headsV, seqQ, seqKV,
                             headDim, isCausal, enableGqa, hasAttnMask, dropoutP,
-                            scale, "sdpa_custom_op");
+                            /*generateStats=*/false, scale, "sdpa_custom_op");
 
   std::string sdpaMlir =
       buildSdpaMlir(hasAttnMask, dropoutP, isCausal, scale, enableGqa);

--- a/samples/sdpa_utils.h
+++ b/samples/sdpa_utils.h
@@ -94,7 +94,7 @@ inline constexpr std::string_view kSdpaWithMask = R"mlir(
 )mlir";
 // clang-format on
 
-/// Builds the MLIR template for torch.aten.scaled_dot_product_attention.
+/// Builds the MLIR template for SDPA custom-op samples.
 ///
 /// Selects the appropriate R-string template (with/without attn_mask) and
 /// resolves scalar placeholders. Standard CustomOp dtype/name placeholders

--- a/samples/sdpa_utils.h
+++ b/samples/sdpa_utils.h
@@ -99,6 +99,15 @@ std::vector<float> referenceSdpa(float qVal, float kVal, float vVal,
                                  std::optional<float> scale, bool enableGqa,
                                  bool hasAttnMask);
 
+/// CPU reference implementation for the logsumexp statistics returned by
+/// SDPA generate_stats.
+std::vector<float> referenceSdpaLogsumexp(float qVal, float kVal, float maskVal,
+                                          int64_t batch, int64_t headsQ,
+                                          int64_t seqQ, int64_t seqKV,
+                                          int64_t headDim, bool isCausal,
+                                          std::optional<float> scale,
+                                          bool hasAttnMask);
+
 /// Build and execute SDPA using the built-in graph API.
 /// Shape convention: [batch, heads, seq_len, head_dim].
 /// K and V may have different head counts (headsK vs headsV).
@@ -107,7 +116,7 @@ void executeSdpa(Handle &handle, DataType dt, int64_t batch, int64_t headsQ,
                  int64_t headDim, bool isCausal = false,
                  std::optional<float> scale = std::nullopt,
                  bool enableGqa = false, bool hasAttnMask = false,
-                 float dropoutP = 0.0f);
+                 float dropoutP = 0.0f, bool generateStats = false);
 
 /// Build and execute SDPA using the custom op graph API with MLIR templates.
 /// Shape convention: [batch, heads, seq_len, head_dim].

--- a/samples/sdpa_utils.h
+++ b/samples/sdpa_utils.h
@@ -18,7 +18,7 @@
 
 using namespace fusilli;
 
-// SDPA MLIR templates for torch.aten.scaled_dot_product_attention.
+// SDPA MLIR templates.
 //
 // Templates are stored as R-string literals so the MLIR structure is
 // directly readable in source. Standard CustomOp placeholders
@@ -27,10 +27,29 @@ using namespace fusilli;
 // ({DROPOUT_P}, {IS_CAUSAL}, {SCALE_CONST}, {SCALE_TYPE}, {ENABLE_GQA})
 // are resolved by buildSdpaMlir().
 
+// clang-format off
+// Flex attention template: 3 tensor inputs (Q, K, V), attention mask is none.
+// Positional args: {0}=SCALE_CONST, {1}=SCALE_TYPE, {2}=ENABLE_GQA_ATTR
+inline constexpr std::string_view kFlexSdpaNoMask = R"mlir(
+  func.func private @{{FUNC_NAME}}(
+      %arg0: {{IN0_TYPE}},
+      %arg1: {{IN1_TYPE}},
+      %arg2: {{IN2_TYPE}})
+      -> {{OUT0_TYPE}} {{
+    %scale = {0}
+    %return_lse = torch.constant.bool false
+    %return_max_scores = torch.constant.bool false
+    %0, %logsumexp, %max_scores = torch.hop_flex_attention %arg0, %arg1, %arg2,
+        %scale, %return_lse, %return_max_scores{2} :
+        {{IN0_TYPE}}, {{IN1_TYPE}}, {{IN2_TYPE}},
+        {1}, !torch.bool, !torch.bool -> {{OUT0_TYPE}}, !torch.none, !torch.none
+    return %0 : {{OUT0_TYPE}}
+  }}
+)mlir";
+
 // SDPA template: 3 tensor inputs (Q, K, V), attention mask is none.
 // Positional args: {0}=DROPOUT_P, {1}=IS_CAUSAL, {2}=SCALE_CONST,
 //                  {3}=SCALE_TYPE, {4}=ENABLE_GQA
-// clang-format off
 inline constexpr std::string_view kSdpaNoMask = R"mlir(
   func.func private @{{FUNC_NAME}}(
       %arg0: {{IN0_TYPE}},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,7 @@ add_fusilli_lit_tests(
     lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
     lit/test_sdpa_asm_emitter_custom_scale.cpp
     lit/test_sdpa_asm_emitter_cross_attn.cpp
+    lit/test_sdpa_asm_emitter_generate_stats.cpp
     lit/test_reduction_asm_emitter_sum.cpp
     lit/test_reduction_asm_emitter_min.cpp
     lit/test_reduction_asm_emitter_max.cpp

--- a/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
@@ -30,12 +30,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_basic_mha.cpp
@@ -46,9 +46,9 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 

--- a/tests/lit/test_sdpa_asm_emitter_causal.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_causal.cpp
@@ -11,6 +11,15 @@
 // clang-format off
 //
 // TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func private @sdpa_mask_sdpa(
+// TORCH-CHECK:         %batch: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %head: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %token_q: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %token_kv: !torch.vtensor<[],si32>)
+// TORCH-CHECK:         -> !torch.vtensor<[],i1> {
+// TORCH-CHECK:       %mask = torch.aten.ge.Tensor %token_q, %token_kv : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+// TORCH-CHECK:       return %mask : !torch.vtensor<[],i1>
+// TORCH-CHECK:     }
 // TORCH-CHECK:     func.func @main(%sdpa_O_: !torch.tensor<[1,8,64,64],f16>, %k: !torch.vtensor<[1,8,64,64],f16>, %q: !torch.vtensor<[1,8,64,64],f16>, %v: !torch.vtensor<[1,8,64,64],f16>) attributes {torch.assume_strict_symbolic_shapes} {
 // TORCH-CHECK:       %permute_Q_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_Q_val_1_sdpa = torch.constant.int 1
@@ -30,12 +39,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool true
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa {mask_mod_fn = @sdpa_mask_sdpa} : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_causal.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_causal.cpp
@@ -11,6 +11,15 @@
 // clang-format off
 //
 // TORCH-CHECK:   module @module {
+// TORCH-CHECK:     func.func private @sdpa_mask_sdpa(
+// TORCH-CHECK:         %batch: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %head: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %token_q: !torch.vtensor<[],si32>,
+// TORCH-CHECK:         %token_kv: !torch.vtensor<[],si32>)
+// TORCH-CHECK:         -> !torch.vtensor<[],i1> {
+// TORCH-CHECK:       %mask = torch.aten.ge.Tensor %token_q, %token_kv : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
+// TORCH-CHECK:       return %mask : !torch.vtensor<[],i1>
+// TORCH-CHECK:     }
 // TORCH-CHECK:     func.func @main(%sdpa_O_: !torch.tensor<[1,8,64,64],f16>, %k: !torch.vtensor<[1,8,64,64],f16>, %q: !torch.vtensor<[1,8,64,64],f16>, %v: !torch.vtensor<[1,8,64,64],f16>) attributes {torch.assume_strict_symbolic_shapes} {
 // TORCH-CHECK:       %permute_Q_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_Q_val_1_sdpa = torch.constant.int 1
@@ -30,12 +39,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool true
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa {mask_mod_fn = @sdpa_mask_sdpa} : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2
@@ -48,10 +55,8 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
-// TODO: Is non-zero internal transient memory size expected?
-//       Is it because the causal mask is materialized by IREE for CPU?
-// CPU-STATS-CHECK: "transient-memory-size": 65536
+// AMDGPU-STATS-CHECK: "dispatch-count": 2
+// CPU-STATS-CHECK: "transient-memory-size": 0
 // CPU-STATS-CHECK: "dispatch-count": 2
 //
 // clang-format on

--- a/tests/lit/test_sdpa_asm_emitter_causal.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_causal.cpp
@@ -11,15 +11,6 @@
 // clang-format off
 //
 // TORCH-CHECK:   module @module {
-// TORCH-CHECK:     func.func private @sdpa_mask_sdpa(
-// TORCH-CHECK:         %batch: !torch.vtensor<[],si32>,
-// TORCH-CHECK:         %head: !torch.vtensor<[],si32>,
-// TORCH-CHECK:         %token_q: !torch.vtensor<[],si32>,
-// TORCH-CHECK:         %token_kv: !torch.vtensor<[],si32>)
-// TORCH-CHECK:         -> !torch.vtensor<[],i1> {
-// TORCH-CHECK:       %mask = torch.aten.ge.Tensor %token_q, %token_kv : !torch.vtensor<[],si32>, !torch.vtensor<[],si32> -> !torch.vtensor<[],i1>
-// TORCH-CHECK:       return %mask : !torch.vtensor<[],i1>
-// TORCH-CHECK:     }
 // TORCH-CHECK:     func.func @main(%sdpa_O_: !torch.tensor<[1,8,64,64],f16>, %k: !torch.vtensor<[1,8,64,64],f16>, %q: !torch.vtensor<[1,8,64,64],f16>, %v: !torch.vtensor<[1,8,64,64],f16>) attributes {torch.assume_strict_symbolic_shapes} {
 // TORCH-CHECK:       %permute_Q_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_Q_val_1_sdpa = torch.constant.int 1
@@ -39,10 +30,12 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
+// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
+// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool true
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa {mask_mod_fn = @sdpa_mask_sdpa} : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
+// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_cross_attn.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_cross_attn.cpp
@@ -46,9 +46,9 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 

--- a/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
@@ -33,10 +33,12 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %scale_sdpa = torch.constant.float 1.250000e-01
-// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
+// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
+// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
+// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %scale_sdpa = torch.constant.float 5.000000e-02
+// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// XFAIL: *
-// TODO(iree-org/fusilli#404): Remove XFAIL once IREE supports non-default SDPA
-// scale values.
 // RUN: %{TEST_EXE} | iree-opt --verify-roundtrip
 // RUN: %{TEST_EXE} | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %{TEST_EXE} stats | FileCheck %s --check-prefix=%{BACKEND}-STATS-CHECK
@@ -33,12 +30,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %scale_sdpa = torch.constant.float 5.000000e-02
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2
@@ -51,9 +46,9 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 

--- a/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_custom_scale.cpp
@@ -30,12 +30,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %scale_sdpa = torch.constant.float 1.250000e-01
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.float, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.float, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_generate_stats.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_generate_stats.cpp
@@ -11,44 +11,50 @@
 // clang-format off
 //
 // TORCH-CHECK:   module @module {
-// TORCH-CHECK:     func.func @main(%sdpa_O_: !torch.tensor<[1,8,32,64],f16>, %k: !torch.vtensor<[1,8,128,64],f16>, %q: !torch.vtensor<[1,8,32,64],f16>, %v: !torch.vtensor<[1,8,128,64],f16>) attributes {torch.assume_strict_symbolic_shapes} {
+// TORCH-CHECK:     func.func @main(%sdpa_O_: !torch.tensor<[1,8,64,64],f16>, %sdpa_STATS_: !torch.tensor<[1,8,64],f32>, %k: !torch.vtensor<[1,8,64,64],f16>, %q: !torch.vtensor<[1,8,64,64],f16>, %v: !torch.vtensor<[1,8,64,64],f16>) attributes {torch.assume_strict_symbolic_shapes} {
 // TORCH-CHECK:       %permute_Q_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_Q_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_Q_val_2_sdpa = torch.constant.int 2
 // TORCH-CHECK:       %permute_Q_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_Q_sdpa = torch.prim.ListConstruct %permute_Q_val_0_sdpa, %permute_Q_val_1_sdpa, %permute_Q_val_2_sdpa, %permute_Q_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %q_sdpa_perm = torch.aten.permute %q, %permute_Q_sdpa : !torch.vtensor<[1,8,32,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,32,64],f16>
+// TORCH-CHECK:       %q_sdpa_perm = torch.aten.permute %q, %permute_Q_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %permute_K_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_K_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_K_val_2_sdpa = torch.constant.int 2
 // TORCH-CHECK:       %permute_K_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_K_sdpa = torch.prim.ListConstruct %permute_K_val_0_sdpa, %permute_K_val_1_sdpa, %permute_K_val_2_sdpa, %permute_K_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %k_sdpa_perm = torch.aten.permute %k, %permute_K_sdpa : !torch.vtensor<[1,8,128,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,128,64],f16>
+// TORCH-CHECK:       %k_sdpa_perm = torch.aten.permute %k, %permute_K_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %permute_V_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_V_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_V_val_2_sdpa = torch.constant.int 2
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,128,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,128,64],f16>
+// TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool true
 // TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
-// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,32,64],f16>, !torch.vtensor<[1,8,128,64],f16>, !torch.vtensor<[1,8,128,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,32,64],f16>, !torch.none, !torch.none
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,8,64],f32>, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2
 // TORCH-CHECK:       %permute_O_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_O_sdpa = torch.prim.ListConstruct %permute_O_val_0_sdpa, %permute_O_val_1_sdpa, %permute_O_val_2_sdpa, %permute_O_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-// TORCH-CHECK:       %sdpa_O = torch.aten.permute %sdpa_O_sdpa_perm, %permute_O_sdpa : !torch.vtensor<[1,8,32,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,32,64],f16>
-// TORCH-CHECK:       torch.overwrite.tensor.contents %sdpa_O overwrites %sdpa_O_ : !torch.vtensor<[1,8,32,64],f16>, !torch.tensor<[1,8,32,64],f16>
+// TORCH-CHECK:       %sdpa_O = torch.aten.permute %sdpa_O_sdpa_perm, %permute_O_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %permute_STATS_val_0_sdpa = torch.constant.int 0
+// TORCH-CHECK:       %permute_STATS_val_1_sdpa = torch.constant.int 1
+// TORCH-CHECK:       %permute_STATS_val_2_sdpa = torch.constant.int 2
+// TORCH-CHECK:       %permute_STATS_sdpa = torch.prim.ListConstruct %permute_STATS_val_0_sdpa, %permute_STATS_val_1_sdpa, %permute_STATS_val_2_sdpa : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+// TORCH-CHECK:       %sdpa_STATS = torch.aten.permute %sdpa_logsumexp_sdpa, %permute_STATS_sdpa : !torch.vtensor<[1,8,64],f32>, !torch.list<int> -> !torch.vtensor<[1,8,64],f32>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %sdpa_O overwrites %sdpa_O_ : !torch.vtensor<[1,8,64,64],f16>, !torch.tensor<[1,8,64,64],f16>
+// TORCH-CHECK:       torch.overwrite.tensor.contents %sdpa_STATS overwrites %sdpa_STATS_ : !torch.vtensor<[1,8,64],f32>, !torch.tensor<[1,8,64],f32>
 // TORCH-CHECK:       return
 // TORCH-CHECK:     }
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 
@@ -64,37 +70,37 @@
 
 using namespace fusilli;
 
-static ErrorObject testSdpaAsmEmitterCrossAttn(const std::string &mode) {
+static ErrorObject testSdpaAsmEmitterGenerateStats(const std::string &mode) {
   auto graph = std::make_shared<Graph>();
-  graph->setName("sdpa_asm_emitter_cross_attn").setIODataType(DataType::Half);
+  graph->setName("sdpa_asm_emitter_generate_stats")
+      .setIODataType(DataType::Half);
 
-  std::vector<int64_t> qDim = {1, 8, 32, 64};
-  auto qStride =
-      generateStrideFromDim(qDim, getContiguousStrideOrder(qDim.size()));
-
-  std::vector<int64_t> kvDim = {1, 8, 128, 64};
-  auto kvStride =
-      generateStrideFromDim(kvDim, getContiguousStrideOrder(kvDim.size()));
+  std::vector<int64_t> dim = {1, 8, 64, 64};
+  auto stride =
+      generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()));
 
   auto q = graph->tensor(
-      TensorAttr().setName("q").setDim(qDim).setStride(qStride).setDataType(
+      TensorAttr().setName("q").setDim(dim).setStride(stride).setDataType(
           DataType::Half));
   auto k = graph->tensor(
-      TensorAttr().setName("k").setDim(kvDim).setStride(kvStride).setDataType(
+      TensorAttr().setName("k").setDim(dim).setStride(stride).setDataType(
           DataType::Half));
   auto v = graph->tensor(
-      TensorAttr().setName("v").setDim(kvDim).setStride(kvStride).setDataType(
+      TensorAttr().setName("v").setDim(dim).setStride(stride).setDataType(
           DataType::Half));
 
-  auto sdpaAttr = SdpaAttr().setName("sdpa");
+  auto sdpaAttr = SdpaAttr().setName("sdpa").setGenerateStats(true);
   auto o = graph->sdpa(q, k, v, /*mask=*/nullptr, sdpaAttr);
+  auto stats = sdpaAttr.getSTATS();
 
-  std::vector<int64_t> oDim = {1, 8, 32, 64};
-  auto oStride =
-      generateStrideFromDim(oDim, getContiguousStrideOrder(oDim.size()));
-  o->setDim(oDim)
-      .setStride(oStride)
-      .setDataType(DataType::Half)
+  o->setDim(dim).setStride(stride).setDataType(DataType::Half).setOutput(true);
+
+  std::vector<int64_t> statsDim = {dim[0], dim[1], dim[2]};
+  auto statsStride = generateStrideFromDim(
+      statsDim, getContiguousStrideOrder(statsDim.size()));
+  stats->setDim(statsDim)
+      .setStride(statsStride)
+      .setDataType(DataType::Float)
       .setOutput(true);
 
   FUSILLI_CHECK_ERROR(graph->validate());
@@ -108,9 +114,9 @@ static ErrorObject testSdpaAsmEmitterCrossAttn(const std::string &mode) {
   if (mode == "stats") {
     FUSILLI_ASSIGN_OR_RETURN(Handle handle, Handle::create(kDefaultBackend));
     FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
-    FUSILLI_ASSIGN_OR_RETURN(auto stats, graph->readCompilationCacheFile(
-                                             CachedAssetsType::Statistics));
-    std::cout << stats << std::endl;
+    FUSILLI_ASSIGN_OR_RETURN(auto statsJson, graph->readCompilationCacheFile(
+                                                 CachedAssetsType::Statistics));
+    std::cout << statsJson << std::endl;
   }
 
   return ok();
@@ -119,7 +125,7 @@ static ErrorObject testSdpaAsmEmitterCrossAttn(const std::string &mode) {
 int main(int argc, char **argv) {
   std::string mode = (argc > 1) ? argv[1] : "default";
 
-  auto status = testSdpaAsmEmitterCrossAttn(mode);
+  auto status = testSdpaAsmEmitterGenerateStats(mode);
   if (isError(status)) {
     std::cerr << "Test failed: " << status << std::endl;
     return 1;

--- a/tests/lit/test_sdpa_asm_emitter_gqa.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_gqa.cpp
@@ -46,9 +46,9 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 1
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 1
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 

--- a/tests/lit/test_sdpa_asm_emitter_gqa.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_gqa.cpp
@@ -30,12 +30,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,2,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,2,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool true
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa {enable_gqa = true} : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
@@ -48,9 +48,9 @@
 // TORCH-CHECK:   }
 //
 // AMDGPU-STATS-CHECK: "transient-memory-size": 0
-// AMDGPU-STATS-CHECK: "dispatch-count": 2
+// AMDGPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 // CPU-STATS-CHECK: "transient-memory-size": 0
-// CPU-STATS-CHECK: "dispatch-count": 2
+// CPU-STATS-CHECK: "dispatch-count": {{[1-9][0-9]*}}
 //
 // clang-format on
 

--- a/tests/lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
+++ b/tests/lit/test_sdpa_asm_emitter_gqa_hk_ne_hv.cpp
@@ -32,12 +32,10 @@
 // TORCH-CHECK:       %permute_V_val_3_sdpa = torch.constant.int 3
 // TORCH-CHECK:       %permute_V_sdpa = torch.prim.ListConstruct %permute_V_val_0_sdpa, %permute_V_val_1_sdpa, %permute_V_val_2_sdpa, %permute_V_val_3_sdpa : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
 // TORCH-CHECK:       %v_sdpa_perm = torch.aten.permute %v, %permute_V_sdpa : !torch.vtensor<[1,2,64,64],f16>, !torch.list<int> -> !torch.vtensor<[1,2,64,64],f16>
-// TORCH-CHECK:       %none_mask_sdpa = torch.constant.none
-// TORCH-CHECK:       %dropout_sdpa = torch.constant.float 0.000000e+00
-// TORCH-CHECK:       %is_causal_sdpa = torch.constant.bool false
 // TORCH-CHECK:       %scale_sdpa = torch.constant.none
-// TORCH-CHECK:       %enable_gqa_sdpa = torch.constant.bool true
-// TORCH-CHECK:       %sdpa_O_sdpa_perm = torch.aten.scaled_dot_product_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %none_mask_sdpa, %dropout_sdpa, %is_causal_sdpa, %scale_sdpa, %enable_gqa_sdpa : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,4,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.none, !torch.float, !torch.bool, !torch.none, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>
+// TORCH-CHECK:       %return_lse_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %return_max_scores_sdpa = torch.constant.bool false
+// TORCH-CHECK:       %sdpa_O_sdpa_perm, %sdpa_logsumexp_sdpa, %sdpa_max_scores_sdpa = torch.hop_flex_attention %q_sdpa_perm, %k_sdpa_perm, %v_sdpa_perm, %scale_sdpa, %return_lse_sdpa, %return_max_scores_sdpa {enable_gqa = true} : !torch.vtensor<[1,8,64,64],f16>, !torch.vtensor<[1,4,64,64],f16>, !torch.vtensor<[1,2,64,64],f16>, !torch.none, !torch.bool, !torch.bool -> !torch.vtensor<[1,8,64,64],f16>, !torch.none, !torch.none
 // TORCH-CHECK:       %permute_O_val_0_sdpa = torch.constant.int 0
 // TORCH-CHECK:       %permute_O_val_1_sdpa = torch.constant.int 1
 // TORCH-CHECK:       %permute_O_val_2_sdpa = torch.constant.int 2

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -86,6 +86,46 @@ TEST_CASE("Graph conv_fprop() adds ConvFPropNode and output tensor",
   REQUIRE(y->isVirtual() == false);
 }
 
+TEST_CASE("Graph sdpa() exposes generated stats tensor through attributes",
+          "[graph]") {
+  Graph g;
+  g.setName("sdpa_generate_stats_output_tensor")
+      .setIODataType(DataType::Half)
+      .setIntermediateDataType(DataType::Half);
+
+  std::vector<int64_t> dim = {1, 8, 64, 64};
+  auto stride =
+      generateStrideFromDim(dim, getContiguousStrideOrder(dim.size()));
+  auto q = g.tensor(
+      TensorAttr().setName("q").setDim(dim).setStride(stride).setDataType(
+          DataType::Half));
+  auto k = g.tensor(
+      TensorAttr().setName("k").setDim(dim).setStride(stride).setDataType(
+          DataType::Half));
+  auto v = g.tensor(
+      TensorAttr().setName("v").setDim(dim).setStride(stride).setDataType(
+          DataType::Half));
+
+  SdpaAttr attr;
+  attr.setName("sdpa").setGenerateStats(true);
+  auto o = g.sdpa(q, k, v, /*mask=*/nullptr, attr);
+  auto stats = attr.getSTATS();
+
+  REQUIRE(stats != nullptr);
+  REQUIRE(stats->getName() == "sdpa_STATS");
+  REQUIRE(stats->getDataType() == DataType::Float);
+
+  o->setOutput(true);
+  stats->setOutput(true);
+  FUSILLI_REQUIRE_OK(g.validate());
+
+  REQUIRE(stats->getDim() == std::vector<int64_t>{1, 8, 64});
+  REQUIRE(stats->getStride() == std::vector<int64_t>{8 * 64, 64, 1});
+
+  FUSILLI_REQUIRE_ASSIGN(auto generatedAsm, g.emitAsm());
+  REQUIRE(generatedAsm.find("%sdpa_STATS_") != std::string::npos);
+}
+
 TEST_CASE("Graph validate() fails if name is not set", "[graph]") {
   Graph g;
   auto status = g.validate();

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -121,7 +121,7 @@ TEST_CASE("Graph sdpa() exposes generated stats tensor through attributes",
   FUSILLI_REQUIRE_OK(g.validate());
 
   REQUIRE(stats->getDim() == std::vector<int64_t>{1, 8, 64});
-  REQUIRE(stats->getStride() == std::vector<int64_t>{8 * 64, 64, 1});
+  REQUIRE(stats->getStride() == std::vector<int64_t>{int64_t{8} * 64, 64, 1});
 
   FUSILLI_REQUIRE_ASSIGN(auto generatedAsm, g.emitAsm());
   REQUIRE(generatedAsm.find("%sdpa_STATS_") != std::string::npos);

--- a/tests/test_sdpa_attributes.cpp
+++ b/tests/test_sdpa_attributes.cpp
@@ -22,6 +22,7 @@ TEST_CASE("SdpaAttr default constructor", "[sdpa_attr]") {
   REQUIRE(attr.getIsCausal() == false);
   REQUIRE(attr.getScale() == std::nullopt);
   REQUIRE(attr.getEnableGqa() == false);
+  REQUIRE(attr.getGenerateStats() == false);
 }
 
 TEST_CASE("SdpaAttr scalar setters and getters", "[sdpa_attr]") {
@@ -58,6 +59,7 @@ TEST_CASE("SdpaAttr tensor setters and getters", "[sdpa_attr]") {
   REQUIRE(attr.getV() == v);
   REQUIRE(attr.getO() == o);
   REQUIRE(attr.getMASK() == nullptr);
+  REQUIRE(attr.getSTATS() == nullptr);
 }
 
 TEST_CASE("SdpaAttr with attention mask", "[sdpa_attr]") {
@@ -88,4 +90,16 @@ TEST_CASE("SdpaAttr scale can be reset to nullopt", "[sdpa_attr]") {
 
   attr.setScale(std::nullopt);
   REQUIRE(!attr.getScale().has_value());
+}
+
+TEST_CASE("SdpaAttr stats output and generate_stats flag", "[sdpa_attr]") {
+  SdpaAttr attr;
+
+  auto stats = std::make_shared<TensorAttr>(
+      TensorAttr().setDim({1, 8, 64}).setName("STATS"));
+  attr.setGenerateStats(true).setSTATS(stats);
+
+  REQUIRE(attr.getGenerateStats() == true);
+  REQUIRE(attr.outputs.size() == 1);
+  REQUIRE(attr.getSTATS() == stats);
 }

--- a/tests/test_sdpa_node.cpp
+++ b/tests/test_sdpa_node.cpp
@@ -582,7 +582,7 @@ TEST_CASE("SdpaNode generate_stats postValidateNode checks stats tensor",
     attr.setV(makeTensor4D("V", 1, 8, 64, 64));
     attr.setO(std::make_shared<TensorAttr>());
     attr.setSTATS(std::make_shared<TensorAttr>(
-        TensorAttr().setDim({1, 8, 32}).setStride({8 * 32, 32, 1})));
+        TensorAttr().setDim({1, 8, 32}).setStride({int64_t{8} * 32, 32, 1})));
     attr.setGenerateStats(true);
     SdpaNode node(std::move(attr), ctx);
 

--- a/tests/test_sdpa_node.cpp
+++ b/tests/test_sdpa_node.cpp
@@ -96,6 +96,39 @@ TEST_CASE("SdpaNode preValidateNode detects missing attributes",
     REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
     REQUIRE(status.getMessage() == "SDPA output tensor O not set");
   }
+
+  SECTION("Output STATS missing when generate_stats is enabled") {
+    SdpaAttr attr;
+    attr.setQ(makeTensor4D("Q", 1, 8, 64, 64));
+    attr.setK(makeTensor4D("K", 1, 8, 64, 64));
+    attr.setV(makeTensor4D("V", 1, 8, 64, 64));
+    attr.setO(std::make_shared<TensorAttr>());
+    attr.setGenerateStats(true);
+    SdpaNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() ==
+            "SDPA output tensor STATS not set when generate_stats is enabled");
+  }
+
+  SECTION("Output STATS set when generate_stats is disabled") {
+    SdpaAttr attr;
+    attr.setQ(makeTensor4D("Q", 1, 8, 64, 64));
+    attr.setK(makeTensor4D("K", 1, 8, 64, 64));
+    attr.setV(makeTensor4D("V", 1, 8, 64, 64));
+    attr.setO(std::make_shared<TensorAttr>());
+    attr.setSTATS(std::make_shared<TensorAttr>());
+    SdpaNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "SDPA output tensor STATS should not be set when generate_stats is "
+            "disabled");
+  }
 }
 
 TEST_CASE("SdpaNode preValidateNode rank checks", "[sdpa_node]") {
@@ -474,6 +507,30 @@ TEST_CASE("SdpaNode output shape inference with cross-attention dimensions",
   FUSILLI_REQUIRE_OK(node.postValidateNode());
 }
 
+TEST_CASE("SdpaNode generate_stats output inference", "[sdpa_node]") {
+  Context ctx;
+  SdpaAttr attr;
+
+  attr.setQ(makeTensor4D("Q", 2, 8, 32, 64));
+  attr.setK(makeTensor4D("K", 2, 8, 128, 64));
+  attr.setV(makeTensor4D("V", 2, 8, 128, 64));
+  attr.setO(std::make_shared<TensorAttr>());
+  attr.setSTATS(std::make_shared<TensorAttr>());
+  attr.setGenerateStats(true);
+
+  SdpaNode node(std::move(attr), ctx);
+
+  FUSILLI_REQUIRE_OK(node.preValidateNode());
+  FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+  auto statsT = node.sdpaAttr.getSTATS();
+  REQUIRE(statsT->getDim() == std::vector<int64_t>{2, 8, 32});
+  REQUIRE(statsT->getStride() == std::vector<int64_t>{8L * 32, 32, 1});
+  REQUIRE(statsT->getDataType() == DataType::Float);
+
+  FUSILLI_REQUIRE_OK(node.postValidateNode());
+}
+
 TEST_CASE("SdpaNode postValidateNode dimension validation", "[sdpa_node]") {
   Context ctx;
   SdpaAttr attr;
@@ -512,4 +569,52 @@ TEST_CASE("SdpaNode causal flag passes validation", "[sdpa_node]") {
   FUSILLI_REQUIRE_OK(node.preValidateNode());
   FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
   FUSILLI_REQUIRE_OK(node.postValidateNode());
+}
+
+TEST_CASE("SdpaNode generate_stats postValidateNode checks stats tensor",
+          "[sdpa_node]") {
+  Context ctx;
+
+  SECTION("stats dim mismatch") {
+    SdpaAttr attr;
+    attr.setQ(makeTensor4D("Q", 1, 8, 64, 64));
+    attr.setK(makeTensor4D("K", 1, 8, 64, 64));
+    attr.setV(makeTensor4D("V", 1, 8, 64, 64));
+    attr.setO(std::make_shared<TensorAttr>());
+    attr.setSTATS(std::make_shared<TensorAttr>(
+        TensorAttr().setDim({1, 8, 32}).setStride({8 * 32, 32, 1})));
+    attr.setGenerateStats(true);
+    SdpaNode node(std::move(attr), ctx);
+
+    FUSILLI_REQUIRE_OK(node.preValidateNode());
+    FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+    auto status = node.postValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "SDPA output tensor STATS dimensions do not match expected shape "
+            "[batch, headsQ, seqQ]");
+  }
+
+  SECTION("stats dtype must be float") {
+    SdpaAttr attr;
+    attr.setQ(makeTensor4D("Q", 1, 8, 64, 64));
+    attr.setK(makeTensor4D("K", 1, 8, 64, 64));
+    attr.setV(makeTensor4D("V", 1, 8, 64, 64));
+    attr.setO(std::make_shared<TensorAttr>());
+    attr.setSTATS(
+        std::make_shared<TensorAttr>(TensorAttr().setDataType(DataType::Half)));
+    attr.setGenerateStats(true);
+    SdpaNode node(std::move(attr), ctx);
+
+    FUSILLI_REQUIRE_OK(node.preValidateNode());
+    FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+    auto status = node.postValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() ==
+            "SDPA output tensor STATS must have Float data type");
+  }
 }


### PR DESCRIPTION
Emit `torch.hop_flex_attention` for Fusilli SDPA cases without an explicit tensor mask or dropout. Causal SDPA attaches a generated `mask_mod_fn`, GQA sets `enable_gqa`, and explicit masks/dropout continue to use `torch.aten.scaled_dot_product_attention` until explicit mask arguments are available.

Adds `generate_stats` support by returning the flex attention logsumexp as the `STATS` output, with sample, lit, and unit coverage for the new path.