### PR TITLE
[3/N Dynamic Shapes] Support inferring dynamic dims from inputs -> outputs in inferPropertiesNode

### DIFF
--- a/include/fusilli/attributes/tensor_attributes.h
+++ b/include/fusilli/attributes/tensor_attributes.h
@@ -371,6 +371,12 @@ computeBroadcastShape(const std::vector<std::vector<int64_t>> &shapes) {
   return ok(std::move(commonShape));
 }
 
+inline void canonicalizeDynamicDimIndices(std::vector<size_t> &dynamicDims) {
+  std::sort(dynamicDims.begin(), dynamicDims.end());
+  dynamicDims.erase(std::unique(dynamicDims.begin(), dynamicDims.end()),
+                    dynamicDims.end());
+}
+
 class TensorAttr {
 public:
   using scalar_t = std::variant<int64_t, int32_t, float, double>;
@@ -511,13 +517,13 @@ public:
 
   TensorAttr &setDynamicDim(size_t index) {
     dynamicDims_.push_back(index);
-    canonicalizeDynamicDims();
+    canonicalizeDynamicDimIndices(dynamicDims_);
     return *this;
   }
 
   TensorAttr &setDynamicDims(std::span<const size_t> indices) {
     dynamicDims_.assign(indices.begin(), indices.end());
-    canonicalizeDynamicDims();
+    canonicalizeDynamicDimIndices(dynamicDims_);
     return *this;
   }
 
@@ -800,13 +806,74 @@ private:
   // so they should not be in the variant pack.
   bool isScalar_ = false;
   std::optional<scalar_t> scalarValue_;
-
-  void canonicalizeDynamicDims() {
-    std::sort(dynamicDims_.begin(), dynamicDims_.end());
-    dynamicDims_.erase(std::unique(dynamicDims_.begin(), dynamicDims_.end()),
-                       dynamicDims_.end());
-  }
 };
+
+inline void setInferredDynamicDims(const std::shared_ptr<TensorAttr> &tensor,
+                                   std::vector<size_t> dynamicDims) {
+  if (!tensor || tensor->hasDynamicDims())
+    return;
+
+  std::erase_if(dynamicDims, [&](size_t dynamicDim) {
+    return dynamicDim >= tensor->getDim().size() ||
+           tensor->getDim()[dynamicDim] == 1;
+  });
+  canonicalizeDynamicDimIndices(dynamicDims);
+  if (!dynamicDims.empty())
+    tensor->setDynamicDims(dynamicDims);
+}
+
+inline void
+inferSameShapeDynamicDims(const std::shared_ptr<TensorAttr> &output,
+                          const std::shared_ptr<TensorAttr> &input) {
+  if (!output || !input || output->getDim().size() != input->getDim().size())
+    return;
+
+  std::vector<size_t> dynamicDims;
+  for (size_t dynamicDim : input->getDynamicDims()) {
+    if (dynamicDim < input->getDim().size() &&
+        input->getDim()[dynamicDim] == output->getDim()[dynamicDim])
+      dynamicDims.push_back(dynamicDim);
+  }
+  setInferredDynamicDims(output, std::move(dynamicDims));
+}
+
+inline void inferSameShapeDynamicDimsFromInputs(
+    const std::shared_ptr<TensorAttr> &output,
+    const std::vector<std::shared_ptr<TensorAttr>> &inputs) {
+  if (!output || output->hasDynamicDims())
+    return;
+
+  std::vector<size_t> dynamicDims;
+  for (const auto &input : inputs) {
+    if (!input || input->getDim() != output->getDim())
+      continue;
+    dynamicDims.insert(dynamicDims.end(), input->getDynamicDims().begin(),
+                       input->getDynamicDims().end());
+  }
+  setInferredDynamicDims(output, std::move(dynamicDims));
+}
+
+inline std::vector<size_t> inferBroadcastDynamicDims(
+    const std::vector<std::shared_ptr<TensorAttr>> &inputs,
+    const std::vector<int64_t> &outputDim) {
+  std::vector<size_t> dynamicDims;
+  for (const auto &input : inputs) {
+    if (!input || input->getDim().empty() ||
+        input->getDim().size() > outputDim.size())
+      continue;
+
+    const auto &inputDim = input->getDim();
+    for (size_t offset = 0; offset < inputDim.size(); ++offset) {
+      size_t inputIdx = inputDim.size() - 1 - offset;
+      size_t outputIdx = outputDim.size() - 1 - offset;
+      if (input->isDynamicDim(inputIdx) &&
+          inputDim[inputIdx] == outputDim[outputIdx])
+        dynamicDims.push_back(outputIdx);
+    }
+  }
+  canonicalizeDynamicDimIndices(dynamicDims);
+  return dynamicDims;
+}
 
 // Sorting function for deterministic lookups on TensorAttr containers
 // (`std::set`) ensuring iteration orders are deterministic. It sorts

--- a/include/fusilli/attributes/tensor_attributes.h
+++ b/include/fusilli/attributes/tensor_attributes.h
@@ -837,22 +837,6 @@ inferSameShapeDynamicDims(const std::shared_ptr<TensorAttr> &output,
   setInferredDynamicDims(output, std::move(dynamicDims));
 }
 
-inline void inferSameShapeDynamicDimsFromInputs(
-    const std::shared_ptr<TensorAttr> &output,
-    const std::vector<std::shared_ptr<TensorAttr>> &inputs) {
-  if (!output || output->hasDynamicDims())
-    return;
-
-  std::vector<size_t> dynamicDims;
-  for (const auto &input : inputs) {
-    if (!input || input->getDim() != output->getDim())
-      continue;
-    dynamicDims.insert(dynamicDims.end(), input->getDynamicDims().begin(),
-                       input->getDynamicDims().end());
-  }
-  setInferredDynamicDims(output, std::move(dynamicDims));
-}
-
 inline std::vector<size_t> inferBroadcastDynamicDims(
     const std::vector<std::shared_ptr<TensorAttr>> &inputs,
     const std::vector<int64_t> &outputDim) {

--- a/include/fusilli/node/batchnorm_node.h
+++ b/include/fusilli/node/batchnorm_node.h
@@ -154,6 +154,9 @@ public:
       if (t->getStride().empty())
         t->setStride(channel1DStride);
     };
+    std::vector<size_t> channelDynamicDims;
+    if (xT->isDynamicDim(1))
+      channelDynamicDims.push_back(0);
 
     // Infer 1D channel tensors.
     if (auto sT = batchnormAttr.getSCALE())
@@ -170,11 +173,15 @@ public:
       yT->setDim(xDim);
     if (yT->getStride().empty())
       yT->setStride(xT->getStride());
+    inferSameShapeDynamicDims(yT, xT);
 
     // Infer saved statistics shapes for training.
     if (isTrainingForwardPhase()) {
       infer1DTensor(batchnormAttr.getSAVED_MEAN());
+      setInferredDynamicDims(batchnormAttr.getSAVED_MEAN(), channelDynamicDims);
       infer1DTensor(batchnormAttr.getSAVED_INV_VARIANCE());
+      setInferredDynamicDims(batchnormAttr.getSAVED_INV_VARIANCE(),
+                             channelDynamicDims);
     }
 
     return ok();

--- a/include/fusilli/node/conv_node.h
+++ b/include/fusilli/node/conv_node.h
@@ -207,6 +207,17 @@ public:
       yT->setStride(yStride);
     }
 
+    std::vector<size_t> dynamicDims;
+    if (xT->isDynamicDim(0))
+      dynamicDims.push_back(0);
+    if (wT->isDynamicDim(0))
+      dynamicDims.push_back(1);
+    for (size_t i = 2; i < yDim.size(); ++i) {
+      if (xT->isDynamicDim(i) || wT->isDynamicDim(i))
+        dynamicDims.push_back(i);
+    }
+    setInferredDynamicDims(yT, std::move(dynamicDims));
+
     return ok();
   }
 
@@ -386,6 +397,13 @@ public:
       dwT->setStride(std::move(wStride));
     }
 
+    std::vector<size_t> dynamicDims;
+    if (dyT->isDynamicDim(1))
+      dynamicDims.push_back(0);
+    if (convWGradAttr.getX()->isDynamicDim(1))
+      dynamicDims.push_back(1);
+    setInferredDynamicDims(dwT, std::move(dynamicDims));
+
     return ok();
   }
 
@@ -557,6 +575,18 @@ public:
               : generateStrideFromDim(
                     dxDim, getChannelsLastStrideOrder(dxDim.size())));
     }
+
+    std::shared_ptr<TensorAttr> wT = convDGradAttr.getW();
+    std::vector<size_t> dynamicDims;
+    if (dyT->isDynamicDim(0))
+      dynamicDims.push_back(0);
+    if (wT->isDynamicDim(1))
+      dynamicDims.push_back(1);
+    for (size_t i = 2; i < dxDim.size(); ++i) {
+      if (dyT->isDynamicDim(i) || wT->isDynamicDim(i))
+        dynamicDims.push_back(i);
+    }
+    setInferredDynamicDims(dxT, std::move(dynamicDims));
 
     return ok();
   }

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -102,9 +102,6 @@ public:
     for (auto &input : inputs)
       input->fillFromContext(context);
 
-    for (auto &output : outputs)
-      inferSameShapeDynamicDimsFromInputs(output, inputs);
-
     return ok();
   }
 };

--- a/include/fusilli/node/custom_op_node.h
+++ b/include/fusilli/node/custom_op_node.h
@@ -102,6 +102,9 @@ public:
     for (auto &input : inputs)
       input->fillFromContext(context);
 
+    for (auto &output : outputs)
+      inferSameShapeDynamicDimsFromInputs(output, inputs);
+
     return ok();
   }
 };

--- a/include/fusilli/node/layernorm_node.h
+++ b/include/fusilli/node/layernorm_node.h
@@ -182,6 +182,7 @@ public:
     // Infer shape and stride of output Y tensor.
     // When stride is unspecified, preserve the stride order of xT.
     norm_utils::inferDimAndStride(yT, xDim, xT->getStride());
+    inferSameShapeDynamicDims(yT, xT);
 
     if (isTrainingForwardPhase()) {
       const auto &[dim, stride] =
@@ -190,10 +191,12 @@ public:
       // Infer shape and stride of output MEAN tensor.
       std::shared_ptr<TensorAttr> mT = layernormAttr.getMEAN();
       norm_utils::inferDimAndStride(mT, dim, stride);
+      inferSameShapeDynamicDims(mT, xT);
 
       // Infer shape and stride of output INV_VARIANCE tensor.
       std::shared_ptr<TensorAttr> vT = layernormAttr.getINV_VARIANCE();
       norm_utils::inferDimAndStride(vT, dim, stride);
+      inferSameShapeDynamicDims(vT, xT);
     }
 
     return ok();

--- a/include/fusilli/node/matmul_node.h
+++ b/include/fusilli/node/matmul_node.h
@@ -192,18 +192,36 @@ public:
     const std::vector<int64_t> &aDim = aT->getDim();
     const std::vector<int64_t> &bDim = bT->getDim();
 
-    const std::vector<int64_t> &cDim = cT->getDim();
+    std::vector<int64_t> cDim = cT->getDim();
     const std::vector<int64_t> &cStride = cT->getStride();
 
     // Infer shape of output tensor.
-    if (cDim.empty())
-      cT->setDim(getMatmulInferredOutputShape(aDim, bDim));
+    if (cDim.empty()) {
+      cDim = getMatmulInferredOutputShape(aDim, bDim);
+      cT->setDim(cDim);
+    }
 
     // Output stride is contiguous (row-major) when unspecified.
     if (cStride.empty()) {
       cT->setStride(
           generateStrideFromDim(cDim, getContiguousStrideOrder(cDim.size())));
     }
+
+    std::vector<size_t> dynamicDims;
+    constexpr int64_t kNonBatchRank = 2;
+    size_t rank = aDim.size();
+    size_t batchDims = rank - kNonBatchRank;
+    for (size_t i = 0; i < batchDims; ++i) {
+      if (aT->isDynamicDim(i) && aDim[i] == cDim[i])
+        dynamicDims.push_back(i);
+      if (bT->isDynamicDim(i) && bDim[i] == cDim[i])
+        dynamicDims.push_back(i);
+    }
+    if (aT->isDynamicDim(rank - 2))
+      dynamicDims.push_back(rank - 2);
+    if (bT->isDynamicDim(rank - 1))
+      dynamicDims.push_back(rank - 1);
+    setInferredDynamicDims(cT, std::move(dynamicDims));
 
     return ok();
   }

--- a/include/fusilli/node/pointwise_node.h
+++ b/include/fusilli/node/pointwise_node.h
@@ -164,6 +164,12 @@ public:
                               "Pointwise output strides could not be computed");
     }
 
+    setInferredDynamicDims(outTensor,
+                           inferBroadcastDynamicDims({pointwiseAttr.getIN_0(),
+                                                      pointwiseAttr.getIN_1(),
+                                                      pointwiseAttr.getIN_2()},
+                                                     outTensor->getDim()));
+
     return ok();
   }
 };

--- a/include/fusilli/node/reduction_node.h
+++ b/include/fusilli/node/reduction_node.h
@@ -104,6 +104,7 @@ public:
           yTensor->getDim(),
           getContiguousStrideOrder(yTensor->getDim().size())));
     }
+    inferSameShapeDynamicDims(yTensor, xTensor);
     return ok();
   }
 

--- a/include/fusilli/node/rmsnorm_node.h
+++ b/include/fusilli/node/rmsnorm_node.h
@@ -148,6 +148,7 @@ public:
     // Infer shape and stride of output Y tensor.
     // When stride is unspecified, preserve the stride order of xT.
     norm_utils::inferDimAndStride(yT, xDim, xT->getStride());
+    inferSameShapeDynamicDims(yT, xT);
 
     if (isTrainingForwardPhase()) {
       const auto &[dim, stride] =
@@ -156,6 +157,7 @@ public:
       // Infer shape and stride of output INV_RMS tensor.
       std::shared_ptr<TensorAttr> rT = rmsnormAttr.getINV_RMS();
       norm_utils::inferDimAndStride(rT, dim, stride);
+      inferSameShapeDynamicDims(rT, xT);
     }
 
     return ok();

--- a/include/fusilli/node/sdpa_node.h
+++ b/include/fusilli/node/sdpa_node.h
@@ -209,6 +209,17 @@ public:
           generateStrideFromDim(oDim, getContiguousStrideOrder(oDim.size())));
     }
 
+    std::vector<size_t> dynamicDims;
+    if (qT->isDynamicDim(0))
+      dynamicDims.push_back(0);
+    if (qT->isDynamicDim(1))
+      dynamicDims.push_back(1);
+    if (qT->isDynamicDim(2))
+      dynamicDims.push_back(2);
+    if (vT->isDynamicDim(3))
+      dynamicDims.push_back(3);
+    setInferredDynamicDims(oT, std::move(dynamicDims));
+
     return ok();
   }
 

--- a/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
@@ -48,9 +48,10 @@ TEST_CASE("Dynamic batch convolution fprop with zero workspace",
                         .setName("conv_fprop");
 
     auto yT = graph->convFProp(xT, wT, convAttr);
-    yT->setDynamicDims({0}).setOutput(true);
+    yT->setOutput(true);
 
     FUSILLI_REQUIRE_OK(graph->validate());
+    REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0});
     FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
 
     return std::make_tuple(graph, xT, wT, yT);

--- a/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
@@ -65,12 +65,12 @@ TEST_CASE("Dynamic batch custom add with zero workspace",
   auto outs = graph->customOp({aT, bT}, addAttr);
   outs[0]
       ->setDim({n, c})
-      .setDynamicDims({0})
       .setStride({c, 1})
       .setDataType(DataType::Float)
       .setOutput(true);
 
   FUSILLI_REQUIRE_OK(graph->validate());
+  REQUIRE(outs[0]->getDynamicDims() == std::vector<size_t>{0});
 
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));

--- a/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
@@ -65,12 +65,12 @@ TEST_CASE("Dynamic batch custom add with zero workspace",
   auto outs = graph->customOp({aT, bT}, addAttr);
   outs[0]
       ->setDim({n, c})
+      .setDynamicDims({0})
       .setStride({c, 1})
       .setDataType(DataType::Float)
       .setOutput(true);
 
   FUSILLI_REQUIRE_OK(graph->validate());
-  REQUIRE(outs[0]->getDynamicDims() == std::vector<size_t>{0});
 
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));

--- a/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
@@ -43,12 +43,12 @@ void executeDynamicReduction(Handle &handle, ReductionAttr::Mode mode,
   auto yT = graph->reduction(xT, reductionAttr);
   yT->setName("result")
       .setDim(yDims)
-      .setDynamicDims({0})
       .setStride(
           generateStrideFromDim(yDims, getContiguousStrideOrder(yDims.size())))
       .setOutput(true);
 
   FUSILLI_REQUIRE_OK(graph->validate());
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0});
   FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
 
   int64_t xSize = 1;

--- a/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
+++ b/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
@@ -55,10 +55,11 @@ TEST_CASE("Dynamic sequence basic SDPA f16", "[dynamic][sdpa][graph]") {
       .setEnableGqa(false);
 
   auto oT = graph->sdpa(qT, kT, vT, /*mask=*/nullptr, sdpaAttr);
-  oT->setDynamicDims({2}).setOutput(true);
+  oT->setOutput(true);
 
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
   FUSILLI_REQUIRE_OK(graph->validate());
+  REQUIRE(oT->getDynamicDims() == std::vector<size_t>{2});
   FUSILLI_REQUIRE_OK(graph->compile(handle, /*remove=*/true));
 
   for (int64_t runtimeSeqLen : runtimeSeqLens) {

--- a/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
@@ -78,6 +78,7 @@ int main() {
   auto outs = g.customOp({a, b}, addAttr);
   outs[0]
       ->setDim({4, 8})
+      .setDynamicDims({0})
       .setStride({8, 1})
       .setDataType(DataType::Float)
       .setOutput(true);

--- a/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dim_placeholder.cpp
@@ -79,7 +79,6 @@ int main() {
   outs[0]
       ->setDim({4, 8})
       .setStride({8, 1})
-      .setDynamicDims({0})
       .setDataType(DataType::Float)
       .setOutput(true);
 

--- a/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
@@ -76,6 +76,7 @@ int main() {
   auto outs = g.customOp({a, b}, addAttr);
   outs[0]
       ->setDim({4, 8})
+      .setDynamicDims({0})
       .setStride({8, 1})
       .setDataType(DataType::Float)
       .setOutput(true);

--- a/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
+++ b/tests/lit/test_custom_op_asm_emitter_dynamic_type.cpp
@@ -77,7 +77,6 @@ int main() {
   outs[0]
       ->setDim({4, 8})
       .setStride({8, 1})
-      .setDynamicDims({0})
       .setDataType(DataType::Float)
       .setOutput(true);
 

--- a/tests/test_batchnorm_node.cpp
+++ b/tests/test_batchnorm_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -219,6 +220,7 @@ TEST_CASE("BatchNormNode inferPropertiesNode infers Y shape from X",
       TensorAttr()
           .setName("x")
           .setDim({n, c, h, w})
+          .setDynamicDims({0})
           .setDataType(DataType::Float)
           .setStride({c * h * w, h * w, w, 1})); // NCHW
   auto meanT = std::make_shared<TensorAttr>(TensorAttr()
@@ -253,6 +255,7 @@ TEST_CASE("BatchNormNode inferPropertiesNode infers Y shape from X",
 
   REQUIRE(yT->getDim() == std::vector<int64_t>({n, c, h, w}));
   REQUIRE(yT->getStride() == xT->getStride());
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0});
 }
 
 TEST_CASE("BatchNormNode inferPropertiesNode infers SAVED outputs and 1D "
@@ -266,6 +269,7 @@ TEST_CASE("BatchNormNode inferPropertiesNode infers SAVED outputs and 1D "
       TensorAttr()
           .setName("x")
           .setDim({n, c, h, w})
+          .setDynamicDims({0, 1})
           .setDataType(DataType::Float)
           .setStride({c * h * w, h * w, w, 1})); // NCHW
   auto scaleT = std::make_shared<TensorAttr>(
@@ -301,12 +305,15 @@ TEST_CASE("BatchNormNode inferPropertiesNode infers SAVED outputs and 1D "
   // Y shape matches X.
   REQUIRE(yT->getDim() == std::vector<int64_t>({n, c, h, w}));
   REQUIRE(yT->getStride() == xT->getStride());
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0, 1});
 
   // SAVED outputs are inferred as 1D [c] with unit stride.
   REQUIRE(smT->getDim() == std::vector<int64_t>({c}));
   REQUIRE(smT->getStride() == std::vector<int64_t>({1}));
+  REQUIRE(smT->getDynamicDims() == std::vector<size_t>{0});
   REQUIRE(sivT->getDim() == std::vector<int64_t>({c}));
   REQUIRE(sivT->getStride() == std::vector<int64_t>({1}));
+  REQUIRE(sivT->getDynamicDims() == std::vector<size_t>{0});
 
   // Optional 1D tensors (scale, bias) are inferred as [c] with unit stride.
   REQUIRE(scaleT->getDim() == std::vector<int64_t>({c}));

--- a/tests/test_conv_node.cpp
+++ b/tests/test_conv_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -119,8 +120,11 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (4D) when Y is under specified",
 
   attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
 
-  auto xT = std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1}));
+  auto xT =
+      std::make_shared<TensorAttr>(TensorAttr()
+                                       .setDim({n, c, h, w})
+                                       .setDynamicDims({0, 2})
+                                       .setStride({c * h * w, h * w, w, 1}));
 
   auto wT = std::make_shared<TensorAttr>(
       TensorAttr().setDim({k, c, r, s}).setStride({c * r * s, r * s, s, 1}));
@@ -136,6 +140,69 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (4D) when Y is under specified",
   auto yT = node.convFPropAttr.getY();
   REQUIRE(yT->getDim() == std::vector<int64_t>({n, k, h, w}));
   REQUIRE(yT->getStride() == std::vector<int64_t>({k * h * w, h * w, w, 1}));
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0, 2});
+}
+
+TEST_CASE("ConvWGradNode infers dynamic dims for DW", "[conv_wgrad_node]") {
+  Context ctx;
+  ConvWGradAttr attr;
+
+  int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
+
+  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+
+  auto dyT =
+      std::make_shared<TensorAttr>(TensorAttr()
+                                       .setDim({n, k, h, w})
+                                       .setDynamicDims({1})
+                                       .setStride({k * h * w, h * w, w, 1}));
+
+  auto xT =
+      std::make_shared<TensorAttr>(TensorAttr()
+                                       .setDim({n, c, h, w})
+                                       .setDynamicDims({1})
+                                       .setStride({c * h * w, h * w, w, 1}));
+
+  auto dwT = std::make_shared<TensorAttr>(
+      TensorAttr().setDim({k, c, r, s}).setStride({c * r * s, r * s, s, 1}));
+
+  attr.setDY(dyT).setX(xT).setDW(dwT);
+
+  ConvWGradNode node(std::move(attr), ctx);
+  FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+  REQUIRE(dwT->getDynamicDims() == std::vector<size_t>{0, 1});
+}
+
+TEST_CASE("ConvDGradNode infers dynamic dims for DX", "[conv_dgrad_node]") {
+  Context ctx;
+  ConvDGradAttr attr;
+
+  int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
+
+  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+
+  auto dyT =
+      std::make_shared<TensorAttr>(TensorAttr()
+                                       .setDim({n, k, h, w})
+                                       .setDynamicDims({0, 2})
+                                       .setStride({k * h * w, h * w, w, 1}));
+
+  auto wT =
+      std::make_shared<TensorAttr>(TensorAttr()
+                                       .setDim({k, c, r, s})
+                                       .setDynamicDims({1})
+                                       .setStride({c * r * s, r * s, s, 1}));
+
+  auto dxT = std::make_shared<TensorAttr>(
+      TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1}));
+
+  attr.setDY(dyT).setW(wT).setDX(dxT);
+
+  ConvDGradNode node(std::move(attr), ctx);
+  FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+
+  REQUIRE(dxT->getDynamicDims() == std::vector<size_t>{0, 1, 2});
 }
 
 TEST_CASE("ConvFPropNode preValidate checks on input stride validity",

--- a/tests/test_layernorm_node.cpp
+++ b/tests/test_layernorm_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -231,7 +232,7 @@ TEST_CASE(
   int64_t n = 2, c = 5;
 
   attr.setX(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c}).setStride({c, 1})));
+      TensorAttr().setDim({n, c}).setDynamicDims({0}).setStride({c, 1})));
   attr.setY(std::make_shared<TensorAttr>(
       TensorAttr().setDim({n, c}).setStride({c, 1})));
   attr.setMEAN(std::make_shared<TensorAttr>(
@@ -247,10 +248,13 @@ TEST_CASE(
   auto vT = node.layernormAttr.getINV_VARIANCE();
   REQUIRE(yT->getDim() == std::vector<int64_t>{n, c});
   REQUIRE(yT->getStride() == std::vector<int64_t>{c, 1});
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0});
   REQUIRE(mT->getDim() == std::vector<int64_t>{n, 1});
   REQUIRE(mT->getStride() == std::vector<int64_t>{1, 1});
+  REQUIRE(mT->getDynamicDims() == std::vector<size_t>{0});
   REQUIRE(vT->getDim() == std::vector<int64_t>{n, 1});
   REQUIRE(vT->getStride() == std::vector<int64_t>{1, 1});
+  REQUIRE(vT->getDynamicDims() == std::vector<size_t>{0});
 }
 
 TEST_CASE(

--- a/tests/test_matmul_node.cpp
+++ b/tests/test_matmul_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -111,9 +112,9 @@ TEST_CASE("MatmulNode inferPropertiesNode when C is fully specified",
   int64_t m = 16, k = 32, n = 64;
 
   attr.setA(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({m, k}).setStride({k, 1})));
+      TensorAttr().setDim({m, k}).setDynamicDims({0}).setStride({k, 1})));
   attr.setB(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({k, n}).setStride({n, 1})));
+      TensorAttr().setDim({k, n}).setDynamicDims({1}).setStride({n, 1})));
   attr.setC(std::make_shared<TensorAttr>(
       TensorAttr().setDim({m, n}).setStride({n, 1})));
 
@@ -123,6 +124,7 @@ TEST_CASE("MatmulNode inferPropertiesNode when C is fully specified",
   auto cT = node.matmulAttr.getC();
   REQUIRE(cT->getDim() == std::vector<int64_t>{m, n});
   REQUIRE(cT->getStride() == std::vector<int64_t>{n, 1});
+  REQUIRE(cT->getDynamicDims() == std::vector<size_t>{0, 1});
 }
 
 TEST_CASE("MatmulNode inferPropertiesNode when C is under-specified",

--- a/tests/test_pointwise_node.cpp
+++ b/tests/test_pointwise_node.cpp
@@ -10,6 +10,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -171,6 +172,7 @@ TEST_CASE("PointwiseNode with ADD mode broadcast", "[pointwise_node]") {
 
   auto in0 = std::make_shared<TensorAttr>();
   in0->setDim({dim0, dim1, dim2, dim3})
+      .setDynamicDims({0})
       .setStride({dim1 * dim2 * dim3, dim2 * dim3, dim3, 1});
   auto in1 = std::make_shared<TensorAttr>();
   in1->setDim({1, dim1, 1, 1}).setStride({dim1, 1, 1, 1});
@@ -187,6 +189,7 @@ TEST_CASE("PointwiseNode with ADD mode broadcast", "[pointwise_node]") {
   REQUIRE(out->getDim() == in0->getDim());
   REQUIRE(out->getDataType() == DataType::Float);
   REQUIRE(out->getStride() == in0->getStride());
+  REQUIRE(out->getDynamicDims() == std::vector<size_t>{0});
 }
 
 TEST_CASE("PointwiseNode with ADD mode invalid broadcast", "[pointwise_node]") {

--- a/tests/test_reduction_node.cpp
+++ b/tests/test_reduction_node.cpp
@@ -10,6 +10,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -151,7 +152,9 @@ TEST_CASE("ReductionNode with SUM mode", "[reduction_node]") {
   int64_t d0 = 16, d1 = 256, d2 = 64, d3 = 32;
 
   auto x = std::make_shared<TensorAttr>();
-  x->setDim({d0, d1, d2, d3}).setStride({d1 * d2 * d3, d2 * d3, d3, 1});
+  x->setDim({d0, d1, d2, d3})
+      .setDynamicDims({0, 2})
+      .setStride({d1 * d2 * d3, d2 * d3, d3, 1});
 
   auto y = std::make_shared<TensorAttr>();
   y->setDim({d0, d1, 1, 1}).setStride({d1, 1, 1, 1});
@@ -161,6 +164,7 @@ TEST_CASE("ReductionNode with SUM mode", "[reduction_node]") {
   ReductionNode node(std::move(attr), ctx);
   FUSILLI_REQUIRE_OK(node.preValidateNode());
   FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
+  REQUIRE(y->getDynamicDims() == std::vector<size_t>{0});
 }
 
 TEST_CASE("ReductionNode rejects AVG on integral or boolean tensors",

--- a/tests/test_rmsnorm_node.cpp
+++ b/tests/test_rmsnorm_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -187,7 +188,7 @@ TEST_CASE(
   int64_t n = 2, c = 5;
 
   attr.setX(std::make_shared<TensorAttr>(
-      TensorAttr().setDim({n, c}).setStride({c, 1})));
+      TensorAttr().setDim({n, c}).setDynamicDims({0}).setStride({c, 1})));
   attr.setY(std::make_shared<TensorAttr>(
       TensorAttr().setDim({n, c}).setStride({c, 1})));
   attr.setINV_RMS(std::make_shared<TensorAttr>(
@@ -200,8 +201,10 @@ TEST_CASE(
   auto rT = node.rmsnormAttr.getINV_RMS();
   REQUIRE(yT->getDim() == std::vector<int64_t>{n, c});
   REQUIRE(yT->getStride() == std::vector<int64_t>{c, 1});
+  REQUIRE(yT->getDynamicDims() == std::vector<size_t>{0});
   REQUIRE(rT->getDim() == std::vector<int64_t>{n, 1});
   REQUIRE(rT->getStride() == std::vector<int64_t>{1, 1});
+  REQUIRE(rT->getDynamicDims() == std::vector<size_t>{0});
 }
 
 TEST_CASE(

--- a/tests/test_sdpa_node.cpp
+++ b/tests/test_sdpa_node.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -433,9 +434,14 @@ TEST_CASE("SdpaNode valid basic MHA configuration", "[sdpa_node]") {
   Context ctx;
   SdpaAttr attr;
 
-  attr.setQ(makeTensor4D("Q", 1, 8, 64, 64));
+  auto qT = makeTensor4D("Q", 1, 8, 64, 64);
+  qT->setDynamicDims({2});
+  auto vT = makeTensor4D("V", 1, 8, 64, 64);
+  vT->setDynamicDims({3});
+
+  attr.setQ(qT);
   attr.setK(makeTensor4D("K", 1, 8, 64, 64));
-  attr.setV(makeTensor4D("V", 1, 8, 64, 64));
+  attr.setV(vT);
   attr.setO(std::make_shared<TensorAttr>());
 
   SdpaNode node(std::move(attr), ctx);
@@ -447,6 +453,7 @@ TEST_CASE("SdpaNode valid basic MHA configuration", "[sdpa_node]") {
   REQUIRE(oT->getDim() == std::vector<int64_t>{1, 8, 64, 64});
   REQUIRE(oT->getStride() ==
           std::vector<int64_t>{8L * 64 * 64, 64L * 64, 64, 1});
+  REQUIRE(oT->getDynamicDims() == std::vector<size_t>{2, 3});
 
   FUSILLI_REQUIRE_OK(node.postValidateNode());
 }


### PR DESCRIPTION
Adds dynamic dimension inference for inferPropertiesNode so output tensors inherit compatible dynamic annotations from their inputs without requiring callers to restate them.

This also updates dynamic shape samples and focused node/lit coverage to assert inferred output dynamic dims across broadcast, same-shape, reduction, convolution, matmul, norm, SDPA, and custom-op flows.

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)