### PR TITLE
getWorkspaceSize API migration

### DIFF
--- a/benchmarks/driver.cpp
+++ b/benchmarks/driver.cpp
@@ -235,7 +235,7 @@ static ErrorObject benchmarkConvFprop(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -367,7 +367,7 @@ static ErrorObject benchmarkConvWGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -499,7 +499,7 @@ static ErrorObject benchmarkConvDGrad(const ConvOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -596,7 +596,7 @@ static ErrorObject benchmarkLayerNormFwd(const LayerNormOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -726,7 +726,7 @@ static ErrorObject benchmarkSdpaFwd(const SdpaOptions &opts,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 
@@ -856,7 +856,7 @@ static ErrorObject benchmarkMatmul(const MatmulOptions &opts, DataType aType,
   }
 
   // Allocate workspace buffer if needed.
-  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_ASSIGN_OR_RETURN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_ASSIGN_OR_RETURN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/include/fusilli/backend/runtime.h
+++ b/include/fusilli/backend/runtime.h
@@ -314,7 +314,7 @@ inline ErrorObject Graph::createVmContext(const Handle &handle) {
   return ok();
 }
 
-inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSizeOrError() {
+inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSize() {
   if (vmContext_ == nullptr)
     return ok(std::optional<size_t>());
 
@@ -326,12 +326,8 @@ inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSizeOrError() {
   return ok(workspaceSize_);
 }
 
-inline std::optional<size_t> Graph::getWorkspaceSize() {
-  auto sizeOrError = getWorkspaceSizeOrError();
-  ErrorObject err = sizeOrError;
-  if (!err.isOk())
-    return std::nullopt;
-  return *sizeOrError;
+inline ErrorOr<std::optional<size_t>> Graph::getWorkspaceSizeOrError() {
+  return getWorkspaceSize();
 }
 
 // Queries the required transient/workspace buffer size from the compiled
@@ -412,7 +408,7 @@ Graph::execute(const Handle &handle,
   bool executeAsync = kBackendExecuteAsync.at(handle.getBackend());
   FUSILLI_RETURN_ERROR_IF(
       !workspaceSize_.has_value(), ErrorCode::InvalidArgument,
-      "Graph::execute requires getWorkspaceSizeOrError() to be called before "
+      "Graph::execute requires getWorkspaceSize() to be called before "
       "workspace allocation and execution");
 
   iree_allocator_t allocator = iree_allocator_system();

--- a/include/fusilli/graph/graph.h
+++ b/include/fusilli/graph/graph.h
@@ -394,12 +394,10 @@ public:
   // artifact is loaded, 0 if no workspace is needed, or the maximum required
   // size in bytes seen for the currently loaded runtime state. Dynamic
   // workspace sizes are not supported yet and return an error.
-  std::optional<size_t> getWorkspaceSize();
+  ErrorOr<std::optional<size_t>> getWorkspaceSize();
 
-  // Same as above but returns an error if the query fails (e.g., dynamic
-  // workspace sizes not supported, or if the VM context isn't properly
-  // initialized). This is useful for internal calls where we want to propagate
-  // the error instead of treating it as "no workspace needed".
+  // Deprecated alias for getWorkspaceSize().
+  [[deprecated("Use Graph::getWorkspaceSize() instead.")]]
   ErrorOr<std::optional<size_t>> getWorkspaceSizeOrError();
 
   // ASM emitter driver method.

--- a/samples/aot/multi_backend.cpp
+++ b/samples/aot/multi_backend.cpp
@@ -82,7 +82,7 @@ void loadAndExecuteArtifact(Backend backend,
       };
 
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         runtimeGraph.graph->getWorkspaceSizeOrError());
+                         runtimeGraph.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 
   FUSILLI_REQUIRE_ASSIGN(auto workspace,

--- a/samples/aot/single_backend.cpp
+++ b/samples/aot/single_backend.cpp
@@ -94,7 +94,7 @@ TEST_CASE("AOT single-backend artifact compile/load/execute round trip",
       };
 
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         runtimeGraph.graph->getWorkspaceSizeOrError());
+                         runtimeGraph.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 
   FUSILLI_REQUIRE_ASSIGN(auto workspace,

--- a/samples/batchnorm/batchnorm_infer_nchw.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; no scale/bias",
           {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nchw_scale_bias.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Batch normalization; inference mode; NCHW layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_infer_nhwc_scale_bias.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Batch normalization; inference mode; NHWC layout; scale, bias",
           {meanT, meanBuf}, {varT, varBuf}, {yT, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_train_nchw.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; no scale/bias",
           {sivT, sivBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
+++ b/samples/batchnorm/batchnorm_train_nchw_scale_bias.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Batch normalization; training mode; NCHW layout; scale, bias",
           {yT, yBuf}, {smT, smBuf}, {sivT, sivBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_dgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -192,7 +192,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_dgrad_nhwc_krsc_grouped.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Convolution dgrad; DY/W (NHWC/KRSC), DX (NHWC); 1x1; no padding;"
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_grouped_with_relu_and_bias.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Convolution fprop; X (NCHW), W (KCRS); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
+++ b/samples/convolution/conv_fprop_nchw_kcrs_grouped.cpp
@@ -83,7 +83,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
+++ b/samples/convolution/conv_fprop_nhwc_krsc_with_pad.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 3x3 conv; same padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_with_bias.cpp
+++ b/samples/convolution/conv_fprop_with_bias.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_with_relu.cpp
+++ b/samples/convolution/conv_fprop_with_relu.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding; relu",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_fprop_with_relu_and_bias.cpp
+++ b/samples/convolution/conv_fprop_with_relu_and_bias.cpp
@@ -98,7 +98,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc.cpp
@@ -85,7 +85,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -193,7 +193,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped.cpp
@@ -84,7 +84,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; grouped",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
+++ b/samples/convolution/conv_wgrad_nhwc_krsc_grouped_strided.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Convolution wgrad; DY/X (NHWC), DW (KRSC); 1x1; no padding; "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/custom_op/custom_op_add.cpp
+++ b/samples/custom_op/custom_op_add.cpp
@@ -87,8 +87,7 @@ TEST_CASE("Custom op: compose built-in pointwise add with custom negate",
                              std::shared_ptr<Buffer>>
         variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/conv_fprop_dynamic_batch.cpp
@@ -81,8 +81,7 @@ TEST_CASE("Dynamic batch convolution fprop with zero workspace",
                              std::shared_ptr<Buffer>>
         variantPack = {{xT, xBuf}, {wT, wBuf}, {yT, yBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     REQUIRE(workspaceSize == 0);
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/custom_op_dynamic_batch.cpp
@@ -105,8 +105,7 @@ TEST_CASE("Dynamic batch custom add with zero workspace",
                              std::shared_ptr<Buffer>>
         variantPack = {{aT, aBuf}, {bT, bBuf}, {outs[0], outBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     REQUIRE(workspaceSize == 0);
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
+++ b/samples/dynamic_shapes/reduction_min_max_dynamic_batch.cpp
@@ -70,7 +70,7 @@ void executeDynamicReduction(Handle &handle, ReductionAttr::Mode mode,
   // instead of iree.abi.transients.size.constant for dynamic batch. Fusilli
   // rejects that dynamic workspace query until runtime size functions are
   // supported.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   REQUIRE(workspaceSize.value_or(0) > 0);
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));

--- a/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
+++ b/samples/dynamic_shapes/sdpa_basic_dynamic_sequence.cpp
@@ -96,8 +96,7 @@ TEST_CASE("Dynamic sequence basic SDPA f16", "[dynamic][sdpa][graph]") {
                              std::shared_ptr<Buffer>>
         variantPack = {{qT, qBuf}, {kT, kBuf}, {vT, vBuf}, {oT, oBuf}};
 
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nchw.cpp
+++ b/samples/layernorm/layernorm_infer_nchw.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nchw_scale_bias.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Layer normalization; inference mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_infer_nhwc_scale_bias.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Layer normalization; inference mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nchw.cpp
+++ b/samples/layernorm/layernorm_train_nchw.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; no bias/scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nchw_scale_bias.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Layer normalization; training mode; NCHW layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
+++ b/samples/layernorm/layernorm_train_nhwc_scale_bias.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Layer normalization; training mode; NHWC layout; scale, bias",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_basic.cpp
+++ b/samples/matmul/matmul_basic.cpp
@@ -75,7 +75,7 @@ TEST_CASE("Matrix multiplication; A (M, K), B (K, N); basic matmul",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -153,7 +153,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_basic_with_bias.cpp
+++ b/samples/matmul/matmul_basic_with_bias.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B (K, N), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -189,7 +189,7 @@ TEST_CASE("Matrix multiplication with bias; A (M, K), B^T (N, K), bias (1, N); "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_batched.cpp
+++ b/samples/matmul/matmul_batched.cpp
@@ -83,7 +83,7 @@ TEST_CASE(
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -166,7 +166,7 @@ TEST_CASE("Batched matrix multiplication with broadcast; A (B, M, K), B (1, K, "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_batched_with_bias.cpp
+++ b/samples/matmul/matmul_batched_with_bias.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Batched matrix multiplication with bias; A (B, M, K), B (B, K, N), "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -203,7 +203,7 @@ TEST_CASE("Batched matrix multiplication with broadcast and bias; A (B, M, K), "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/matmul/matmul_int4_fp16.cpp
+++ b/samples/matmul/matmul_int4_fp16.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Int4 x fp16 matmul", "[matmul][int4]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{aT, aBuf}, {bT, bBuf}, {cT, cBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_add_transposed.cpp
+++ b/samples/pointwise/pointwise_add_transposed.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Pointwise add with transposed operand", "[pointwise][graph]") {
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_binary_cmp_ops.cpp
+++ b/samples/pointwise/pointwise_binary_cmp_ops.cpp
@@ -107,8 +107,7 @@ TEST_CASE("Pointwise binary compare ops", "[pointwise][graph]") {
               };
 
           // Allocate workspace buffer if needed.
-          FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                                 graph->getWorkspaceSizeOrError());
+          FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
           FUSILLI_REQUIRE_ASSIGN(auto workspace,
                                  allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_binary_ops.cpp
+++ b/samples/pointwise/pointwise_binary_ops.cpp
@@ -108,8 +108,7 @@ TEST_CASE("Pointwise binary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_bwd.cpp
+++ b/samples/pointwise/pointwise_bwd.cpp
@@ -100,8 +100,7 @@ TEST_CASE("Pointwise backward ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_scalar_mul.cpp
+++ b/samples/pointwise/pointwise_scalar_mul.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Pointwise MUL with scalar operand", "[pointwise][scalar][graph]") {
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_ternary_ops.cpp
+++ b/samples/pointwise/pointwise_ternary_ops.cpp
@@ -112,8 +112,7 @@ TEST_CASE("Pointwise ternary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_unary_logical_ops.cpp
+++ b/samples/pointwise/pointwise_unary_logical_ops.cpp
@@ -78,8 +78,7 @@ TEST_CASE("Pointwise unary logical ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/pointwise/pointwise_unary_ops.cpp
+++ b/samples/pointwise/pointwise_unary_ops.cpp
@@ -158,8 +158,7 @@ TEST_CASE("Pointwise unary ops", "[pointwise][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/reduction/reduction_ops.cpp
+++ b/samples/reduction/reduction_ops.cpp
@@ -140,8 +140,7 @@ TEST_CASE("Reduction ops", "[reduction][graph]") {
         };
 
     // Allocate workspace buffer if needed.
-    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                           graph->getWorkspaceSizeOrError());
+    FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
     FUSILLI_REQUIRE_ASSIGN(auto workspace,
                            allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nchw.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw.cpp
@@ -78,7 +78,7 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; no scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nchw_scale.cpp
@@ -88,7 +88,7 @@ TEST_CASE("RMS normalization; inference mode; NCHW layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
+++ b/samples/rmsnorm/rmsnorm_infer_nhwc_scale.cpp
@@ -88,7 +88,7 @@ TEST_CASE("RMS normalization; inference mode; NHWC layout; with scale",
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/samples/sdpa_utils.cpp
+++ b/samples/sdpa_utils.cpp
@@ -210,8 +210,7 @@ void executeAndVerify(Handle &handle, const SdpaTestContext &ctx,
     variantPack[ctx.maskT] = maskBuf;
   }
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
+++ b/tests/hip_tests/samples/conv_fprop_nchw_kcrs.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Convolution fprop with hip stream; X (NCHW), W (KCRS); 1x1 conv; no "
       };
 
   // Allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 

--- a/tests/test_custom_op.cpp
+++ b/tests/test_custom_op.cpp
@@ -137,7 +137,7 @@ TEST_CASE("CustomOp compile + execute round-trip", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));
@@ -206,7 +206,7 @@ TEST_CASE("CustomOp composition: built-in op -> custom op", "[custom_op]") {
   const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
       variantPack = {{a, aBuf}, {b, bBuf}, {outs[0], outBuf}};
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
   FUSILLI_REQUIRE_OK(g.execute(handle, variantPack, workspace));

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -210,8 +210,7 @@ static void executeAndCheckGraph(Handle &handle, ExecutableGraph &ctx) {
           {ctx.y, yBuf},
       };
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -391,8 +390,7 @@ TEST_CASE("Graph `loadFromArtifact` after compileToArtifact enables execute",
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
 }
@@ -419,10 +417,9 @@ TEST_CASE("Graph `execute` requires prior workspace size query", "[graph]") {
   auto status = ctx.graph->execute(handle, variantPack, /*workspace=*/nullptr);
   REQUIRE(isError(status));
   REQUIRE(status.getCode() == ErrorCode::InvalidArgument);
-  REQUIRE(
-      status.getMessage() ==
-      "Graph::execute requires getWorkspaceSizeOrError() to be called before "
-      "workspace allocation and execution");
+  REQUIRE(status.getMessage() ==
+          "Graph::execute requires getWorkspaceSize() to be called before "
+          "workspace allocation and execution");
 }
 
 TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
@@ -444,8 +441,7 @@ TEST_CASE("Graph `compileToArtifact` preserves loaded runtime state",
       auto compileOnlyArtifactBytes,
       ctx.graph->compileToArtifact(compileOnlyBackend, /*remove=*/true));
 
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, ctx.graph->getWorkspaceSize());
   REQUIRE(!compileOnlyArtifactBytes.empty());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, ctx);
@@ -465,7 +461,7 @@ TEST_CASE("Graph `loadFromArtifact` accepts another Graph instance's artifact",
   }
 
   FUSILLI_REQUIRE_ASSIGN(auto workspaceSize,
-                         consumer.graph->getWorkspaceSizeOrError());
+                         consumer.graph->getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
   executeAndCheckGraph(handle, consumer);
 }
@@ -480,14 +476,14 @@ TEST_CASE("Graph failed `loadFromArtifact` clears loaded runtime state",
       ctx.graph->compileToArtifact(handle.getBackend(), /*remove=*/true));
   FUSILLI_REQUIRE_OK(ctx.graph->loadFromArtifact(handle, artifactBytes));
   FUSILLI_REQUIRE_ASSIGN(auto loadedWorkspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+                         ctx.graph->getWorkspaceSize());
   REQUIRE(loadedWorkspaceSize.has_value());
 
   const std::vector<uint8_t> invalidArtifactBytes = {0xde, 0xad, 0xbe, 0xef};
   auto status = ctx.graph->loadFromArtifact(handle, invalidArtifactBytes);
   REQUIRE(isError(status));
   FUSILLI_REQUIRE_ASSIGN(auto clearedWorkspaceSize,
-                         ctx.graph->getWorkspaceSizeOrError());
+                         ctx.graph->getWorkspaceSize());
   REQUIRE(!clearedWorkspaceSize.has_value());
 }
 
@@ -624,7 +620,7 @@ TEST_CASE("Graph `execute`", "[graph]") {
       };
 
   // Query and allocate workspace buffer if needed.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, graph->getWorkspaceSize());
   FUSILLI_REQUIRE_ASSIGN(auto workspace,
                          allocateWorkspace(handle, workspaceSize));
 
@@ -690,16 +686,16 @@ TEST_CASE("collectModuleScopeAsm gathers declarations from nested sub-nodes",
   REQUIRE(result.find("DECL_GRANDCHILD") < result.find("DECL_B"));
 }
 
-TEST_CASE("Graph `getWorkspaceSizeOrError` returns nullopt before compilation",
+TEST_CASE("Graph `getWorkspaceSize` returns nullopt before compilation",
           "[graph]") {
   Graph g = testGraph(/*validate=*/true);
 
   // Before compilation, workspace size should be nullopt.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   REQUIRE(!workspaceSize.has_value());
 }
 
-TEST_CASE("Graph `getWorkspaceSizeOrError` after compilation", "[graph]") {
+TEST_CASE("Graph `getWorkspaceSize` after compilation", "[graph]") {
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
   Graph g = testGraph(/*validate=*/true);
@@ -707,14 +703,14 @@ TEST_CASE("Graph `getWorkspaceSizeOrError` after compilation", "[graph]") {
   // Compile the graph.
   FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
 
-  // After compilation, getWorkspaceSizeOrError returns the queried transient
+  // After compilation, getWorkspaceSize returns the queried transient
   // size. It should have a value (not nullopt). The actual size is
   // implementation-dependent.
-  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto workspaceSize, g.getWorkspaceSize());
   REQUIRE(workspaceSize.has_value());
 }
 
-TEST_CASE("Graph `getWorkspaceSizeOrError` consistency across multiple queries",
+TEST_CASE("Graph `getWorkspaceSize` consistency across multiple queries",
           "[graph]") {
   FUSILLI_REQUIRE_ASSIGN(Handle handle, Handle::create(kDefaultBackend));
 
@@ -722,9 +718,9 @@ TEST_CASE("Graph `getWorkspaceSizeOrError` consistency across multiple queries",
   FUSILLI_REQUIRE_OK(g.compile(handle, /*remove=*/true));
 
   // Multiple queries should return the same value.
-  FUSILLI_REQUIRE_ASSIGN(auto size1, g.getWorkspaceSizeOrError());
-  FUSILLI_REQUIRE_ASSIGN(auto size2, g.getWorkspaceSizeOrError());
-  FUSILLI_REQUIRE_ASSIGN(auto size3, g.getWorkspaceSizeOrError());
+  FUSILLI_REQUIRE_ASSIGN(auto size1, g.getWorkspaceSize());
+  FUSILLI_REQUIRE_ASSIGN(auto size2, g.getWorkspaceSize());
+  FUSILLI_REQUIRE_ASSIGN(auto size3, g.getWorkspaceSize());
 
   REQUIRE(size1.has_value());
   REQUIRE(size1 == size2);


### PR DESCRIPTION
This PR performs the Fusilli side of the staged `getWorkspaceSize` API migration by making `getWorkspaceSize()` return `ErrorOr<std::optional<size_t>>`, while keeping `getWorkspaceSizeOrError()` as a deprecated forwarding alias. Fusilli-owned samples, tests, and benchmarks now use the new primary spelling.

Migration lifecycle:

1. [[Landed](https://github.com/iree-org/fusilli/pull/410)] Fusilli lands new `getWorkspaceSizeOrError` API while keeping old `getWorkspaceSize` same.
2. [[Landed](https://github.com/ROCm/TheRock/pull/5214)] TheRock bumps Fusilli to hash from 1.
3. [[In flight](https://github.com/ROCm/rocm-libraries/pull/7424)] Back bump of TheRock CI pin in rocm-libraries
4. [TODO] Hipdnn plugin switches to `getWorkspaceSizeOrError`.
5. [[This PR](https://github.com/iree-org/fusilli/pull/417)] Fusilli switches `getWorkspaceSize` over to new API, keeping `getWorkspaceSizeOrError` as an alias slated for deprecation. hipdnn plugin doesn't use this API so the breaking change is "silent".
6. [TODO] Rocm-libraries bump into TheRock.
7. [TODO] TheRock bumps Fusilli to hash from 5.
8. [TODO] Back bump of TheRock CI pin in rocm-libraries.
9. [TODO] Hipdnn plugin search/replace: `s/getWorkspaceSizeOrError/getWorkspaceSize` (NFC rename).
10. [TODO] Fusilli removes deprecated `getWorkspaceSizeOrError` API.

** Fusilli PRs (1, 5 and 10) can land independent of the hipdnn/rock PRs

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)
