### PR TITLE
Disable IREE benchmarks in fusilli's captive IREE build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(IREE_COMPILER_LIB "" CACHE FILEPATH "Path to libIREECompiler.so")
 set(IREE_VISIBILITY_HIDDEN OFF)
 set(IREE_BUILD_COMPILER OFF)
 set(IREE_BUILD_TESTS OFF)
+set(IREE_BUILD_BENCHMARKS OFF)
 set(IREE_BUILD_SAMPLES OFF)
 # Disable missing submodules error because we are only building the runtime.
 set(IREE_ERROR_ON_MISSING_SUBMODULES OFF)


### PR DESCRIPTION
## Motivation

In ASan builds of TheRock, an issue in IREE's `third_party/benchmark` submodule breaks fusilli's CMake configure during IREE's sub-configure. A compiler invocation, inside a capability check, inside IREE's captive benchmark dependency, fails to find the ASan runtime library. This issue would likely only happen in TheRock when using the compiler hermetically created as part of the build. 

Given that fusilli-provider and fusilli don't use any code paths that require IREE's captive benchmark dependency the easiest path to fix the issue is simply to sidestep it by removing the dependency.

## Technical Details

PR https://github.com/iree-org/iree/pull/24167 added an `IREE_BUILD_BENCHMARKS` option. When `IREE_BUILD_BENCHMARKS` and `IREE_BUILD_TESTS` are both set to `OFF`, IREE doesn't require `third_party/benchmark`. A follow up PR will remove the dep from fusilli's docker [here](https://github.com/sjain-stanford/docker/blob/8193baabc876218a25218d0c1db427fa18938fcc/entrypoint.sh#L72).